### PR TITLE
Run user code on a thread, Joypad support, more...

### DIFF
--- a/32blit-sdl/Input.cpp
+++ b/32blit-sdl/Input.cpp
@@ -1,0 +1,48 @@
+#include <SDL.h>
+
+#include "Input.hpp"
+#include "engine/input.hpp"
+
+std::map<int, int> Input::keys = {
+	// arrow keys
+	{SDLK_DOWN,   blit::button::DPAD_DOWN},
+	{SDLK_UP,     blit::button::DPAD_UP},
+	{SDLK_LEFT,   blit::button::DPAD_LEFT},
+	{SDLK_RIGHT,  blit::button::DPAD_RIGHT},
+
+	// wasd
+	{SDLK_w,       blit::button::DPAD_UP},
+	{SDLK_a,       blit::button::DPAD_LEFT},
+	{SDLK_s,       blit::button::DPAD_DOWN},
+	{SDLK_d,       blit::button::DPAD_RIGHT},
+
+	// action buttons
+	{SDLK_z,       blit::button::A},
+	{SDLK_x,       blit::button::B},
+	{SDLK_c,       blit::button::X},
+	{SDLK_y,       blit::button::Y},
+
+	// system buttons
+	{SDLK_1,       blit::button::HOME},
+	{SDLK_2,       blit::button::MENU},
+	{SDLK_3,       blit::button::JOYSTICK},
+};
+
+std::map<int, int> Input::buttons = {
+	// dpad
+	{SDL_CONTROLLER_BUTTON_DPAD_DOWN,   blit::button::DPAD_DOWN},
+	{SDL_CONTROLLER_BUTTON_DPAD_UP,     blit::button::DPAD_UP},
+	{SDL_CONTROLLER_BUTTON_DPAD_LEFT,   blit::button::DPAD_LEFT},
+	{SDL_CONTROLLER_BUTTON_DPAD_RIGHT,  blit::button::DPAD_RIGHT},
+
+	// action buttons
+	{SDL_CONTROLLER_BUTTON_A,           blit::button::A},
+	{SDL_CONTROLLER_BUTTON_B,           blit::button::B},
+	{SDL_CONTROLLER_BUTTON_X,           blit::button::X},
+	{SDL_CONTROLLER_BUTTON_Y,           blit::button::Y},
+
+	// system buttons
+	{SDL_CONTROLLER_BUTTON_BACK,        blit::button::HOME},
+	{SDL_CONTROLLER_BUTTON_START,       blit::button::MENU},
+	{SDL_CONTROLLER_BUTTON_LEFTSTICK,   blit::button::JOYSTICK},
+};

--- a/32blit-sdl/Input.cpp
+++ b/32blit-sdl/Input.cpp
@@ -2,6 +2,7 @@
 
 #include "Input.hpp"
 #include "engine/input.hpp"
+#include "System.hpp"
 
 std::map<int, int> Input::keys = {
 	// arrow keys
@@ -57,4 +58,91 @@ int Input::find_button(int button) {
 	auto iter = buttons.find(button);
 	if (iter == buttons.end()) return 0;
 	else return iter->second;
+}
+
+Input::Input(SDL_Window *window) {
+	int w, h;
+	SDL_GetWindowSize(window, &w, &h);
+	resize(w, h);
+}
+
+void Input::resize(int width, int height) {
+	win_width = width;
+	win_height = height;
+}
+
+bool Input::handle_mouse(System *sys, int button, bool state, int x, int y) {
+	if (button == SDL_BUTTON_LEFT) {
+		if (state) {
+			if(left_ctrl){
+				_virtual_tilt(sys, x, y);
+			} else {
+				x = x - (win_width / 2);
+				y = y - (win_height / 2);
+				_virtual_analog(sys, x, y);
+			}
+		} else {
+			_virtual_analog(sys, 0, 0);
+		}
+		return true;
+	}
+	return false;
+}
+
+bool Input::handle_keyboard(System *sys, int key, bool state) {
+	if (int blit_button = find_key(key)) {
+		sys->set_button(blit_button, state);
+		return true;
+	} else if (key == SDLK_LCTRL) {
+		left_ctrl = state;
+		return true;
+	}
+	return false;
+}
+
+bool Input::handle_controller_button(System *sys, int button, bool state) {
+	if (int blit_button = find_button(button)) {
+		sys->set_button(blit_button, state);
+		return true;
+	}
+	return false;
+}
+
+bool Input::handle_controller_motion(System *sys, int axis, int value) {
+	float fvalue = value / 32768.0;
+	switch(axis) {
+		case SDL_CONTROLLER_AXIS_LEFTX:
+			sys->set_joystick(0, fvalue);
+			return true;
+		case SDL_CONTROLLER_AXIS_LEFTY:
+			sys->set_joystick(1, fvalue);
+			return true;
+		case SDL_CONTROLLER_AXIS_RIGHTX:
+			sys->set_tilt(0, fvalue);
+			return true;
+		case SDL_CONTROLLER_AXIS_RIGHTY:
+			sys->set_tilt(1, fvalue);
+			return true;
+		default:
+			break;
+	}
+	return false;
+}
+
+void Input::_virtual_tilt(System *sys, int x, int y) {
+	int z = 80;
+	x = x - (win_width / 2);
+	y = y - (win_height / 2);
+	vec3 shadow_tilt = vec3(x, y, z);
+	shadow_tilt.normalize();
+	sys->set_tilt(0, shadow_tilt.x);
+	sys->set_tilt(1, shadow_tilt.y);
+	sys->set_tilt(2, shadow_tilt.z);
+}
+
+void Input::_virtual_analog(System *sys, int x, int y) {
+	float jx = (float)x / (win_width / 2);
+	float jy = (float)y / (win_height / 2);
+	sys->set_joystick(0, jx);
+	sys->set_joystick(1, jy);
 }

--- a/32blit-sdl/Input.cpp
+++ b/32blit-sdl/Input.cpp
@@ -60,7 +60,7 @@ int Input::find_button(int button) {
 	else return iter->second;
 }
 
-Input::Input(SDL_Window *window) {
+Input::Input(SDL_Window *window, System *target) : target(target) {
 	int w, h;
 	SDL_GetWindowSize(window, &w, &h);
 	resize(w, h);
@@ -71,27 +71,27 @@ void Input::resize(int width, int height) {
 	win_height = height;
 }
 
-bool Input::handle_mouse(System *sys, int button, bool state, int x, int y) {
+bool Input::handle_mouse(int button, bool state, int x, int y) {
 	if (button == SDL_BUTTON_LEFT) {
 		if (state) {
 			if(left_ctrl){
-				_virtual_tilt(sys, x, y);
+				_virtual_tilt(x, y);
 			} else {
 				x = x - (win_width / 2);
 				y = y - (win_height / 2);
-				_virtual_analog(sys, x, y);
+				_virtual_analog(x, y);
 			}
 		} else {
-			_virtual_analog(sys, 0, 0);
+			_virtual_analog(0, 0);
 		}
 		return true;
 	}
 	return false;
 }
 
-bool Input::handle_keyboard(System *sys, int key, bool state) {
+bool Input::handle_keyboard(int key, bool state) {
 	if (int blit_button = find_key(key)) {
-		sys->set_button(blit_button, state);
+		target->set_button(blit_button, state);
 		return true;
 	} else if (key == SDLK_LCTRL) {
 		left_ctrl = state;
@@ -100,28 +100,28 @@ bool Input::handle_keyboard(System *sys, int key, bool state) {
 	return false;
 }
 
-bool Input::handle_controller_button(System *sys, int button, bool state) {
+bool Input::handle_controller_button(int button, bool state) {
 	if (int blit_button = find_button(button)) {
-		sys->set_button(blit_button, state);
+		target->set_button(blit_button, state);
 		return true;
 	}
 	return false;
 }
 
-bool Input::handle_controller_motion(System *sys, int axis, int value) {
+bool Input::handle_controller_motion(int axis, int value) {
 	float fvalue = value / 32768.0;
 	switch(axis) {
 		case SDL_CONTROLLER_AXIS_LEFTX:
-			sys->set_joystick(0, fvalue);
+			target->set_joystick(0, fvalue);
 			return true;
 		case SDL_CONTROLLER_AXIS_LEFTY:
-			sys->set_joystick(1, fvalue);
+			target->set_joystick(1, fvalue);
 			return true;
 		case SDL_CONTROLLER_AXIS_RIGHTX:
-			sys->set_tilt(0, fvalue);
+			target->set_tilt(0, fvalue);
 			return true;
 		case SDL_CONTROLLER_AXIS_RIGHTY:
-			sys->set_tilt(1, fvalue);
+			target->set_tilt(1, fvalue);
 			return true;
 		default:
 			break;
@@ -129,20 +129,20 @@ bool Input::handle_controller_motion(System *sys, int axis, int value) {
 	return false;
 }
 
-void Input::_virtual_tilt(System *sys, int x, int y) {
+void Input::_virtual_tilt(int x, int y) {
 	int z = 80;
 	x = x - (win_width / 2);
 	y = y - (win_height / 2);
 	vec3 shadow_tilt = vec3(x, y, z);
 	shadow_tilt.normalize();
-	sys->set_tilt(0, shadow_tilt.x);
-	sys->set_tilt(1, shadow_tilt.y);
-	sys->set_tilt(2, shadow_tilt.z);
+	target->set_tilt(0, shadow_tilt.x);
+	target->set_tilt(1, shadow_tilt.y);
+	target->set_tilt(2, shadow_tilt.z);
 }
 
-void Input::_virtual_analog(System *sys, int x, int y) {
+void Input::_virtual_analog(int x, int y) {
 	float jx = (float)x / (win_width / 2);
 	float jy = (float)y / (win_height / 2);
-	sys->set_joystick(0, jx);
-	sys->set_joystick(1, jy);
+	target->set_joystick(0, jx);
+	target->set_joystick(1, jy);
 }

--- a/32blit-sdl/Input.cpp
+++ b/32blit-sdl/Input.cpp
@@ -46,3 +46,15 @@ std::map<int, int> Input::buttons = {
 	{SDL_CONTROLLER_BUTTON_START,       blit::button::MENU},
 	{SDL_CONTROLLER_BUTTON_LEFTSTICK,   blit::button::JOYSTICK},
 };
+
+int Input::find_key(int key) {
+	auto iter = keys.find(key);
+	if (iter == keys.end()) return 0;
+	else return iter->second;
+}
+
+int Input::find_button(int button) {
+	auto iter = buttons.find(button);
+	if (iter == buttons.end()) return 0;
+	else return iter->second;
+}

--- a/32blit-sdl/Input.hpp
+++ b/32blit-sdl/Input.hpp
@@ -1,4 +1,5 @@
 #include <map>
+class System;
 
 class Input {
 	public:
@@ -7,4 +8,21 @@ class Input {
 
 		static int find_key(int key);
 		static int find_button(int button);
+
+		Input(SDL_Window *window);
+
+		void resize(int width, int height);
+
+		// Input handlers return true if they handled the event
+		bool handle_mouse(System *sys, int button, bool state, int x, int y);
+		bool handle_keyboard(System *sys, int key, bool state);
+		bool handle_controller_button(System *sys, int button, bool state);
+		bool handle_controller_motion(System *sys, int axis, int value);
+
+	private:
+		void _virtual_analog(System *, int, int);
+		void _virtual_tilt(System *, int, int);
+
+		int win_width, win_height;
+		bool left_ctrl = false;
 };

--- a/32blit-sdl/Input.hpp
+++ b/32blit-sdl/Input.hpp
@@ -1,0 +1,7 @@
+#include <map>
+
+class Input {
+	public:
+		static std::map<int, int> keys;
+		static std::map<int, int> buttons;
+};

--- a/32blit-sdl/Input.hpp
+++ b/32blit-sdl/Input.hpp
@@ -9,19 +9,21 @@ class Input {
 		static int find_key(int key);
 		static int find_button(int button);
 
-		Input(SDL_Window *window);
+		Input(SDL_Window *window, System *system);
 
 		void resize(int width, int height);
 
 		// Input handlers return true if they handled the event
-		bool handle_mouse(System *sys, int button, bool state, int x, int y);
-		bool handle_keyboard(System *sys, int key, bool state);
-		bool handle_controller_button(System *sys, int button, bool state);
-		bool handle_controller_motion(System *sys, int axis, int value);
+		bool handle_mouse(int button, bool state, int x, int y);
+		bool handle_keyboard(int key, bool state);
+		bool handle_controller_button(int button, bool state);
+		bool handle_controller_motion(int axis, int value);
 
 	private:
-		void _virtual_analog(System *, int, int);
-		void _virtual_tilt(System *, int, int);
+		System *target;
+
+		void _virtual_analog(int, int);
+		void _virtual_tilt(int, int);
 
 		int win_width, win_height;
 		bool left_ctrl = false;

--- a/32blit-sdl/Input.hpp
+++ b/32blit-sdl/Input.hpp
@@ -4,4 +4,7 @@ class Input {
 	public:
 		static std::map<int, int> keys;
 		static std::map<int, int> buttons;
+
+		static int find_key(int key);
+		static int find_button(int button);
 };

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -44,6 +44,10 @@ std::map<int, int> keys = {
 	{SDLK_2,       button::MENU}
 };
 
+Uint32 shadow_buttons = 0;
+vec3 shadow_tilt = {0, 0, 0};
+vec2 shadow_joystick = {0, 0};
+
 SDL_Thread *t_system_timer;
 SDL_Thread *t_system_loop;
 SDL_sem *system_timer_stop = SDL_CreateSemaphore(0);
@@ -170,6 +174,9 @@ static int system_loop(void *ptr) {
 	while (true) {
 		SDL_SemWait(system_loop_update);
 		if(!running) break;
+		blit::buttons = shadow_buttons;
+		blit::tilt = shadow_tilt;
+		blit::joystick = shadow_joystick;
 		blit::tick(::now());
 		if(!running) break;
 		SDL_PushEvent(&event);
@@ -215,13 +222,13 @@ void virtual_tilt(int x, int y) {
 	x /= current_pixel_size;
 	y /= current_pixel_size;
 
-	blit::tilt = vec3(x, y, z);
-	blit::tilt.normalize();
+	shadow_tilt = vec3(x, y, z);
+	shadow_tilt.normalize();
 }
 
 void virtual_analog(int x, int y) {
 	if(x == 0 && y == 0){
-		blit::joystick = vec2(0, 0);
+		shadow_joystick = vec2(0, 0);
 		return;
 	}
 
@@ -232,7 +239,7 @@ void virtual_analog(int x, int y) {
 
 	//printf("Joystick X/Y %f %f\n", jx, jy);
 
-	blit::joystick = vec2(jx, jy);
+	shadow_joystick = vec2(jx, jy);
 }
 
 void resize_renderer(int sizeX, int sizeY) {
@@ -431,11 +438,11 @@ int main(int argc, char *argv[]) {
 					}
 
 					if (event.type == SDL_KEYDOWN) {
-						blit::buttons |= iter->second;
+						shadow_buttons |= iter->second;
 					}
 					else
 					{
-						blit::buttons &= ~iter->second;
+						shadow_buttons &= ~iter->second;
 					}
 				}
 				break;

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -352,8 +352,7 @@ int main(int argc, char *argv[]) {
 
 	//textureBuffer = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, SYSTEM_WIDTH, SYSTEM_HEIGHT);
 
-	__fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, SYSTEM_WIDTH, SYSTEM_HEIGHT);
-	__ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, SYSTEM_WIDTH * 2, SYSTEM_HEIGHT * 2);
+	resize_renderer(current_width, current_height);
 
 	start = std::chrono::steady_clock::now();
 

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -22,46 +22,46 @@
 
 std::map<int, int> keys = {
 	// arrow keys
-	{SDLK_DOWN,   button::DPAD_DOWN},
-	{SDLK_UP,     button::DPAD_UP},
-	{SDLK_LEFT,   button::DPAD_LEFT},
-	{SDLK_RIGHT,  button::DPAD_RIGHT},
+	{SDLK_DOWN,   blit::button::DPAD_DOWN},
+	{SDLK_UP,     blit::button::DPAD_UP},
+	{SDLK_LEFT,   blit::button::DPAD_LEFT},
+	{SDLK_RIGHT,  blit::button::DPAD_RIGHT},
 
 	// wasd
-	{SDLK_w,       button::DPAD_UP},
-	{SDLK_a,       button::DPAD_LEFT},
-	{SDLK_s,       button::DPAD_DOWN},
-	{SDLK_d,       button::DPAD_RIGHT},
+	{SDLK_w,       blit::button::DPAD_UP},
+	{SDLK_a,       blit::button::DPAD_LEFT},
+	{SDLK_s,       blit::button::DPAD_DOWN},
+	{SDLK_d,       blit::button::DPAD_RIGHT},
 
 	// action buttons
-	{SDLK_z,       button::A},
-	{SDLK_x,       button::B},
-	{SDLK_c,       button::X},
-	{SDLK_y,       button::Y},
+	{SDLK_z,       blit::button::A},
+	{SDLK_x,       blit::button::B},
+	{SDLK_c,       blit::button::X},
+	{SDLK_y,       blit::button::Y},
 
 	// system buttons
-	{SDLK_1,       button::HOME},
-	{SDLK_2,       button::MENU},
-	{SDLK_3,       button::JOYSTICK},
+	{SDLK_1,       blit::button::HOME},
+	{SDLK_2,       blit::button::MENU},
+	{SDLK_3,       blit::button::JOYSTICK},
 };
 
 std::map<int, int> gcbuttons = {
 	// dpad
-	{SDL_CONTROLLER_BUTTON_DPAD_DOWN,   button::DPAD_DOWN},
-	{SDL_CONTROLLER_BUTTON_DPAD_UP,     button::DPAD_UP},
-	{SDL_CONTROLLER_BUTTON_DPAD_LEFT,   button::DPAD_LEFT},
-	{SDL_CONTROLLER_BUTTON_DPAD_RIGHT,  button::DPAD_RIGHT},
+	{SDL_CONTROLLER_BUTTON_DPAD_DOWN,   blit::button::DPAD_DOWN},
+	{SDL_CONTROLLER_BUTTON_DPAD_UP,     blit::button::DPAD_UP},
+	{SDL_CONTROLLER_BUTTON_DPAD_LEFT,   blit::button::DPAD_LEFT},
+	{SDL_CONTROLLER_BUTTON_DPAD_RIGHT,  blit::button::DPAD_RIGHT},
 
 	// action buttons
-	{SDL_CONTROLLER_BUTTON_A,           button::A},
-	{SDL_CONTROLLER_BUTTON_B,           button::B},
-	{SDL_CONTROLLER_BUTTON_X,           button::X},
-	{SDL_CONTROLLER_BUTTON_Y,           button::Y},
+	{SDL_CONTROLLER_BUTTON_A,           blit::button::A},
+	{SDL_CONTROLLER_BUTTON_B,           blit::button::B},
+	{SDL_CONTROLLER_BUTTON_X,           blit::button::X},
+	{SDL_CONTROLLER_BUTTON_Y,           blit::button::Y},
 
 	// system buttons
-	{SDL_CONTROLLER_BUTTON_BACK,        button::HOME},
-	{SDL_CONTROLLER_BUTTON_START,       button::MENU},
-	{SDL_CONTROLLER_BUTTON_LEFTSTICK,   button::JOYSTICK},
+	{SDL_CONTROLLER_BUTTON_BACK,        blit::button::HOME},
+	{SDL_CONTROLLER_BUTTON_START,       blit::button::MENU},
+	{SDL_CONTROLLER_BUTTON_LEFTSTICK,   blit::button::JOYSTICK},
 };
 
 Uint32 shadow_buttons = 0;

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -85,7 +85,6 @@ uint32_t ticks_passed;
 uint32_t ticks_last_update;
 
 SDL_Window* window = NULL;
-SDL_Surface* screenSurface = NULL;
 SDL_Renderer* renderer;
 
 SDL_Texture* __fb_texture_RGB24;
@@ -203,8 +202,6 @@ void resize_renderer(int sizeX, int sizeY) {
 
 	std::cout << "Resized to: " << sizeX << "x" << sizeY << std::endl;
 
-	SDL_SetRenderTarget(renderer, NULL);
-
 	if (__fb_texture_RGB24) {
 		SDL_DestroyTexture(__fb_texture_RGB24);
 	}
@@ -257,8 +254,6 @@ int main(int argc, char *argv[]) {
 
 	SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
 	SDL_RenderClear(renderer);
-
-	//textureBuffer = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, SYSTEM_WIDTH, SYSTEM_HEIGHT);
 
 	resize_renderer(current_width, current_height);
 

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -1,9 +1,7 @@
 #if defined(_WIN32) && !defined(WIN32)
 #define WIN32
 #endif
-#ifndef NO_FFMPEG_CAPTURE
-#include "VideoCapture.hpp"
-#endif
+
 #include <SDL.h>
 #include <random>
 #include <cmath>
@@ -17,6 +15,10 @@
 #include "Input.hpp"
 #include "System.hpp"
 #include "Renderer.hpp"
+
+#ifndef NO_FFMPEG_CAPTURE
+#include "VideoCapture.hpp"
+#endif
 
 #define WINDOW_TITLE "TinyDebug SDL"
 

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	System *sys = new System();
-	Input *inp = new Input(window);
+	Input *inp = new Input(window, sys);
 	Renderer *ren = new Renderer(window, System::width, System::height);
 
 	sys->run();
@@ -106,18 +106,18 @@ int main(int argc, char *argv[]) {
 
 			case SDL_MOUSEBUTTONUP:
 			case SDL_MOUSEBUTTONDOWN:
-				inp->handle_mouse(sys, event.button.button, event.type == SDL_MOUSEBUTTONDOWN, event.button.x, event.button.y);
+				inp->handle_mouse(event.button.button, event.type == SDL_MOUSEBUTTONDOWN, event.button.x, event.button.y);
 				break;
 
 			case SDL_MOUSEMOTION:
 				if (event.motion.state & SDL_BUTTON_LMASK) {
-					inp->handle_mouse(sys, SDL_BUTTON_LEFT, event.motion.state & SDL_MOUSEBUTTONDOWN, event.motion.x, event.motion.y);
+					inp->handle_mouse(SDL_BUTTON_LEFT, event.motion.state & SDL_MOUSEBUTTONDOWN, event.motion.x, event.motion.y);
 				}
 				break;
 
 			case SDL_KEYDOWN: // fall-though
 			case SDL_KEYUP:
-				if (!inp->handle_keyboard(sys, event.key.keysym.sym, event.type == SDL_KEYDOWN)) {
+				if (!inp->handle_keyboard(event.key.keysym.sym, event.type == SDL_KEYDOWN)) {
 					switch (event.key.keysym.sym) {
 #ifndef NO_FFMPEG_CAPTURE
 					case SDLK_r:
@@ -149,11 +149,11 @@ int main(int argc, char *argv[]) {
 
 			case SDL_CONTROLLERBUTTONDOWN:
 			case SDL_CONTROLLERBUTTONUP:
-				inp->handle_controller_button(sys, event.cbutton.button, event.type == SDL_CONTROLLERBUTTONDOWN);
+				inp->handle_controller_button(event.cbutton.button, event.type == SDL_CONTROLLERBUTTONDOWN);
 				break;
 
 			case SDL_CONTROLLERAXISMOTION:
-				inp->handle_controller_motion(sys, event.caxis.axis, event.caxis.value);
+				inp->handle_controller_motion(event.caxis.axis, event.caxis.value);
 				break;
 
 			case SDL_RENDER_TARGETS_RESET:

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -128,7 +128,6 @@ int main(int argc, char *argv[]) {
 								filename << "-capture-";
 								filename << getTimeStamp().c_str();
 								filename << ".mpg";
-								ren->start_recording(record_buffer);
 								open_stream(filename.str().c_str(), System::width, System::height, record_buffer);
 								recording = true;
 								std::cout << "Starting capture to " << filename.str() << std::endl;
@@ -136,7 +135,6 @@ int main(int argc, char *argv[]) {
 							else
 							{
 								recording = false;
-								ren->stop_recording();
 								close_stream();
 								std::cout << "Finished capture." << std::endl;
 							}
@@ -170,7 +168,10 @@ int main(int argc, char *argv[]) {
 					sys->notify_redraw();
 					ren->present();
 #ifndef NO_FFMPEG_CAPTURE
-					if (recording) capture();
+					if (recording) {
+						ren->read_pixels(System::width, System::height, SDL_PIXELFORMAT_RGB24, record_buffer);
+						capture();
+					}
 #endif
 				} else if (event.type == System::timer_event) {
 					switch(event.user.code) {
@@ -196,7 +197,6 @@ int main(int argc, char *argv[]) {
 #ifndef NO_FFMPEG_CAPTURE
 	if (recording) {
 		recording = false;
-		ren->stop_recording();
 		close_stream();
 		std::cout << "Finished capture." << std::endl;
 	}

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -302,12 +302,6 @@ void resize_renderer(int sizeX, int sizeY) {
 
 	std::cout << "Textured destroyed" << std::endl;
 
-	current_width = sizeX;
-	current_height = sizeY;
-	SDL_SetWindowSize(window, sizeX, sizeY);
-
-	std::cout << "Window size set" << std::endl;
-
 	__fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, SYSTEM_WIDTH, SYSTEM_HEIGHT);
 	__ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, SYSTEM_WIDTH * 2, SYSTEM_HEIGHT * 2);
 

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -14,58 +14,15 @@
 #include <sstream>
 #include <map>
 
-#include "engine/input.hpp" // Only needed for button definitions
+#include "Input.hpp"
 #include "System.hpp"
+
+#include "engine/input.hpp"
 
 #define WINDOW_TITLE "TinyDebug SDL"
 
 #define SYSTEM_WIDTH 160
 #define SYSTEM_HEIGHT 120
-
-std::map<int, int> keys = {
-	// arrow keys
-	{SDLK_DOWN,   blit::button::DPAD_DOWN},
-	{SDLK_UP,     blit::button::DPAD_UP},
-	{SDLK_LEFT,   blit::button::DPAD_LEFT},
-	{SDLK_RIGHT,  blit::button::DPAD_RIGHT},
-
-	// wasd
-	{SDLK_w,       blit::button::DPAD_UP},
-	{SDLK_a,       blit::button::DPAD_LEFT},
-	{SDLK_s,       blit::button::DPAD_DOWN},
-	{SDLK_d,       blit::button::DPAD_RIGHT},
-
-	// action buttons
-	{SDLK_z,       blit::button::A},
-	{SDLK_x,       blit::button::B},
-	{SDLK_c,       blit::button::X},
-	{SDLK_y,       blit::button::Y},
-
-	// system buttons
-	{SDLK_1,       blit::button::HOME},
-	{SDLK_2,       blit::button::MENU},
-	{SDLK_3,       blit::button::JOYSTICK},
-};
-
-std::map<int, int> gcbuttons = {
-	// dpad
-	{SDL_CONTROLLER_BUTTON_DPAD_DOWN,   blit::button::DPAD_DOWN},
-	{SDL_CONTROLLER_BUTTON_DPAD_UP,     blit::button::DPAD_UP},
-	{SDL_CONTROLLER_BUTTON_DPAD_LEFT,   blit::button::DPAD_LEFT},
-	{SDL_CONTROLLER_BUTTON_DPAD_RIGHT,  blit::button::DPAD_RIGHT},
-
-	// action buttons
-	{SDL_CONTROLLER_BUTTON_A,           blit::button::A},
-	{SDL_CONTROLLER_BUTTON_B,           blit::button::B},
-	{SDL_CONTROLLER_BUTTON_X,           blit::button::X},
-	{SDL_CONTROLLER_BUTTON_Y,           blit::button::Y},
-
-	// system buttons
-	{SDL_CONTROLLER_BUTTON_BACK,        blit::button::HOME},
-	{SDL_CONTROLLER_BUTTON_START,       blit::button::MENU},
-	{SDL_CONTROLLER_BUTTON_LEFTSTICK,   blit::button::JOYSTICK},
-};
-
 
 static bool running = true;
 static bool recording = false;
@@ -322,8 +279,8 @@ int main(int argc, char *argv[]) {
 			case SDL_KEYDOWN: // fall-though
 			case SDL_KEYUP:
 				{
-					auto iter = keys.find(event.key.keysym.sym);
-					if (iter == keys.end()) {
+					auto iter = Input::keys.find(event.key.keysym.sym);
+					if (iter == Input::keys.end()) {
 						switch (event.key.keysym.sym) {
 						case SDLK_LCTRL:
 							left_ctrl = event.type == SDL_KEYDOWN;
@@ -361,8 +318,8 @@ int main(int argc, char *argv[]) {
 			case SDL_CONTROLLERBUTTONDOWN:
 			case SDL_CONTROLLERBUTTONUP:
 				{
-					auto iter = gcbuttons.find(event.cbutton.button);
-					if (iter == gcbuttons.end()) break;
+					auto iter = Input::buttons.find(event.cbutton.button);
+					if (iter == Input::buttons.end()) break;
 					sys->set_button(iter->second, event.type == SDL_CONTROLLERBUTTONDOWN);
 				}
 				break;

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -115,7 +115,6 @@ typedef struct vector2d {
 vector2d mouse;
 uint8_t mouse_button = 0;
 
-std::chrono::steady_clock::time_point start;
 
 void debug(std::string message) {
 	//OutputDebugStringA(message.c_str());
@@ -133,6 +132,7 @@ void set_screen_mode(blit::screen_mode new_mode) {
 	}
 }
 
+std::chrono::steady_clock::time_point start;
 uint32_t now() {
 	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
 	return (uint32_t)elapsed.count();

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -138,6 +138,8 @@ void system_redraw(System *sys) {
 		SDL_RenderCopy(renderer, __ltdc_texture_RGB565, NULL, &renderer_dest);
 	}
 
+	sys->notify_redraw();
+
 	SDL_RenderPresent(renderer);
 
 #ifndef NO_FFMPEG_CAPTURE
@@ -145,8 +147,6 @@ void system_redraw(System *sys) {
 		capture();
 	}
 #endif
-
-	sys->notify_redraw();
 }
 
 

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -41,7 +41,8 @@ std::map<int, int> keys = {
 
 	// system buttons
 	{SDLK_1,       button::HOME},
-	{SDLK_2,       button::MENU}
+	{SDLK_2,       button::MENU},
+	{SDLK_3,       button::JOYSTICK},
 };
 
 std::map<int, int> gcbuttons = {
@@ -59,7 +60,8 @@ std::map<int, int> gcbuttons = {
 
 	// system buttons
 	{SDL_CONTROLLER_BUTTON_BACK,        button::HOME},
-	{SDL_CONTROLLER_BUTTON_START,       button::MENU}
+	{SDL_CONTROLLER_BUTTON_START,       button::MENU},
+	{SDL_CONTROLLER_BUTTON_LEFTSTICK,   button::JOYSTICK},
 };
 
 Uint32 shadow_buttons = 0;

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -409,7 +409,7 @@ int main(int argc, char *argv[]) {
 						case SDLK_LCTRL:
 							left_ctrl = event.type == SDL_KEYDOWN;
 							break;
-	#ifndef NO_FFMPEG_CAPTURE
+#ifndef NO_FFMPEG_CAPTURE
 						case SDLK_r:
 							if (event.type == SDL_KEYDOWN && SDL_GetTicks() - last_record_startstop > 1000) {
 								if (!recording) {
@@ -439,7 +439,7 @@ int main(int argc, char *argv[]) {
 								}
 								last_record_startstop = SDL_GetTicks();
 							}
-	#endif
+#endif
 						}
 						break;
 					}

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -17,7 +17,7 @@
 #include "Renderer.hpp"
 
 #ifndef NO_FFMPEG_CAPTURE
-#include "VideoCapture.hpp"
+#include "VideoCaptureFfmpeg.hpp"
 #endif
 
 #define WINDOW_TITLE "TinyDebug SDL"
@@ -128,14 +128,14 @@ int main(int argc, char *argv[]) {
 								filename << "-capture-";
 								filename << getTimeStamp().c_str();
 								filename << ".mpg";
-								open_stream(filename.str().c_str(), System::width, System::height, record_buffer);
+								ffmpeg_open_stream(filename.str().c_str(), System::width, System::height, record_buffer);
 								recording = true;
 								std::cout << "Starting capture to " << filename.str() << std::endl;
 							}
 							else
 							{
 								recording = false;
-								close_stream();
+								ffmpeg_close_stream();
 								std::cout << "Finished capture." << std::endl;
 							}
 							last_record_startstop = SDL_GetTicks();
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
 #ifndef NO_FFMPEG_CAPTURE
 					if (recording) {
 						ren->read_pixels(System::width, System::height, SDL_PIXELFORMAT_RGB24, record_buffer);
-						capture();
+						ffmpeg_capture();
 					}
 #endif
 				} else if (event.type == System::timer_event) {
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
 #ifndef NO_FFMPEG_CAPTURE
 	if (recording) {
 		recording = false;
-		close_stream();
+		ffmpeg_close_stream();
 		std::cout << "Finished capture." << std::endl;
 	}
 #endif

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -3,14 +3,7 @@
 #endif
 
 #include <SDL.h>
-#include <random>
-#include <cmath>
 #include <iostream>
-#include <chrono>
-#include <ctime>
-#include <string>
-#include <sstream>
-#include <map>
 
 #include "Input.hpp"
 #include "System.hpp"

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -22,9 +22,6 @@
 
 #define WINDOW_TITLE "TinyDebug SDL"
 
-#define SYSTEM_WIDTH 160
-#define SYSTEM_HEIGHT 120
-
 
 inline std::tm localtime_xp(std::time_t timer)
 {
@@ -58,7 +55,7 @@ int main(int argc, char *argv[]) {
 #ifndef NO_FFMPEG_CAPTURE
 	static bool recording = false;
 	static unsigned int last_record_startstop = 0;
-	uint8_t record_buffer[SYSTEM_WIDTH*2 * SYSTEM_HEIGHT*2 * 3];
+	uint8_t record_buffer[System::width * System::height * 3];
 #endif
 
 	std::cout << "Hello World" << std::endl;
@@ -71,7 +68,7 @@ int main(int argc, char *argv[]) {
 	window = SDL_CreateWindow(
 		WINDOW_TITLE,
 		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-		SYSTEM_WIDTH*4, SYSTEM_HEIGHT*4,
+		System::width*2, System::height*2,
 		SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
 	);
 
@@ -79,7 +76,7 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "could not create window: %s\n", SDL_GetError());
 		return 1;
 	}
-	SDL_SetWindowMinimumSize(window, SYSTEM_WIDTH, SYSTEM_HEIGHT);
+	SDL_SetWindowMinimumSize(window, System::width, System::height);
 
 	// Open all joysticks as game controllers
 	for(int n=0; n<SDL_NumJoysticks(); n++) {
@@ -88,7 +85,7 @@ int main(int argc, char *argv[]) {
 
 	System *sys = new System();
 	Input *inp = new Input(window);
-	Renderer *ren = new Renderer(window, SYSTEM_WIDTH, SYSTEM_HEIGHT);
+	Renderer *ren = new Renderer(window, System::width, System::height);
 
 	sys->run();
 
@@ -132,7 +129,7 @@ int main(int argc, char *argv[]) {
 								filename << getTimeStamp().c_str();
 								filename << ".mpg";
 								ren->start_recording(record_buffer);
-								open_stream(filename.str().c_str(), SYSTEM_WIDTH*2, SYSTEM_HEIGHT*2, record_buffer);
+								open_stream(filename.str().c_str(), System::width, System::height, record_buffer);
 								recording = true;
 								std::cout << "Starting capture to " << filename.str() << std::endl;
 							}

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -278,49 +278,44 @@ int main(int argc, char *argv[]) {
 
 			case SDL_KEYDOWN: // fall-though
 			case SDL_KEYUP:
-				{
-					auto iter = Input::keys.find(event.key.keysym.sym);
-					if (iter == Input::keys.end()) {
-						switch (event.key.keysym.sym) {
-						case SDLK_LCTRL:
-							left_ctrl = event.type == SDL_KEYDOWN;
-							break;
+				if (int button = Input::find_key(event.key.keysym.sym)) {
+					sys->set_button(button, event.type == SDL_KEYDOWN);
+				} else {
+					switch (event.key.keysym.sym) {
+					case SDLK_LCTRL:
+						left_ctrl = event.type == SDL_KEYDOWN;
+						break;
 #ifndef NO_FFMPEG_CAPTURE
-						case SDLK_r:
-							if (event.type == SDL_KEYDOWN && SDL_GetTicks() - last_record_startstop > 1000) {
-								if (!recording) {
-									std::stringstream filename;
-									filename << argv[0];
-									filename << "-";
-									filename << "capture-";
-									filename << getTimeStamp().c_str();
-									filename << ".mkv";
-									open_stream(filename.str().c_str(), SYSTEM_WIDTH*2, SYSTEM_HEIGHT*2, AV_PIX_FMT_RGB24, recorder_buffer);
-									recording = true;
-									std::cout << "Starting capture to " << filename.str() << std::endl;
-								}
-								else
-								{
-									recording = false;
-									close_stream();
-									std::cout << "Finished capture." << std::endl;
-								}
-								last_record_startstop = SDL_GetTicks();
+					case SDLK_r:
+						if (event.type == SDL_KEYDOWN && SDL_GetTicks() - last_record_startstop > 1000) {
+							if (!recording) {
+								std::stringstream filename;
+								filename << argv[0];
+								filename << "-";
+								filename << "capture-";
+								filename << getTimeStamp().c_str();
+								filename << ".mkv";
+								open_stream(filename.str().c_str(), SYSTEM_WIDTH*2, SYSTEM_HEIGHT*2, AV_PIX_FMT_RGB24, recorder_buffer);
+								recording = true;
+								std::cout << "Starting capture to " << filename.str() << std::endl;
 							}
-#endif
+							else
+							{
+								recording = false;
+								close_stream();
+								std::cout << "Finished capture." << std::endl;
+							}
+							last_record_startstop = SDL_GetTicks();
 						}
-					} else {
-						sys->set_button(iter->second, event.type == SDL_KEYDOWN);
+#endif
 					}
 				}
 				break;
 
 			case SDL_CONTROLLERBUTTONDOWN:
 			case SDL_CONTROLLERBUTTONUP:
-				{
-					auto iter = Input::buttons.find(event.cbutton.button);
-					if (iter == Input::buttons.end()) break;
-					sys->set_button(iter->second, event.type == SDL_CONTROLLERBUTTONDOWN);
+				if (int button = Input::find_button(event.cbutton.button)) {
+					sys->set_button(button, event.type == SDL_CONTROLLERBUTTONDOWN);
 				}
 				break;
 
@@ -375,7 +370,6 @@ int main(int argc, char *argv[]) {
 
 	sys->stop();
 	delete sys;
-
 
 #ifndef NO_FFMPEG_CAPTURE
 	if (recording) {

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -179,8 +179,8 @@ static int system_loop(void *ptr) {
 		blit::buttons = shadow_buttons;
 		blit::tilt = shadow_tilt;
 		blit::joystick = shadow_joystick;
-		blit::tick(::now());
 		SDL_UnlockMutex(shadow_mutex);
+		blit::tick(::now());
 		if(!running) break;
 		SDL_PushEvent(&event);
 		SDL_SemWait(system_loop_redraw);

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -151,12 +151,11 @@ static int system_timer(void *ptr) {
 	SDL_Event event_frozen = {.type = USEREVENT_FROZEN};
 
 	while (SDL_SemWaitTimeout(system_timer_stop, 20)) {
-		int val = SDL_SemValue(system_loop_update);
-		if (val) {
+		if (SDL_SemValue(system_loop_update)) {
 			dropped++;
 			if(dropped > 100) {
-				SDL_PushEvent(&event_frozen);
 				dropped = 100;
+				SDL_PushEvent(&event_frozen);
 			} else {
 				SDL_PushEvent(&event_slow);
 			}

--- a/32blit-sdl/Makefile
+++ b/32blit-sdl/Makefile
@@ -128,7 +128,7 @@ $(PROJECT_BUILD_DIR)/$(OUTPUT_NAME): $(ALL_OBJ_FILES)
 $(PROJECT_BUILD_DIR)/%.o: $(PROJECT)/%.cpp $(PROJECT)/%.hpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -fPIC -c -o $@ $<
 
-$(TESTBED_BUILD_DIR)/%.o: $(TESTBED)/%.cpp
+$(TESTBED_BUILD_DIR)/%.o: $(TESTBED)/%.cpp $(TESTBED)/%.hpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -fPIC -c -o $@ $<
 
 $(BUILD_DIR):

--- a/32blit-sdl/Makefile
+++ b/32blit-sdl/Makefile
@@ -74,7 +74,7 @@ ifeq ($(ENABLE_FFMPEG), true)
 FFMPEG_LIBS = -Wl,-Bstatic -lavformat -lavcodec -lavdevice -lavfilter -lavutil -lswresample -lswscale -Wl,-Bdynamic -llzma -lz
 LDFLAGS +=  -L$(FFMPEG)/lib $(FFMPEG_LIBS)
 CPPFLAGS +=  -I$(FFMPEG)/include
-TESTBED_SRC_FILES += $(TESTBED)/VideoCapture.cpp
+TESTBED_SRC_FILES += $(TESTBED)/VideoCaptureFfmpeg.cpp
 else
 FFMPEG_LIBS = 
 CPPFLAGS += -DNO_FFMPEG_CAPTURE

--- a/32blit-sdl/Makefile
+++ b/32blit-sdl/Makefile
@@ -60,7 +60,7 @@ OUTPUT_NAME = $(shell basename $(PROJECT))
 SDL_LIBS = `sdl2-config --libs`
 
 # Glom all .cpp files from the testbed
-TESTBED_SRC_FILES := $(TESTBED)/Main.cpp
+TESTBED_SRC_FILES := $(TESTBED)/Main.cpp $(TESTBED)/System.cpp
 
 # Glom all .cpp files from our desired project
 PROJECT_SRC_FILES := $(wildcard $(PROJECT)/*.cpp)

--- a/32blit-sdl/Makefile
+++ b/32blit-sdl/Makefile
@@ -60,7 +60,7 @@ OUTPUT_NAME = $(shell basename $(PROJECT))
 SDL_LIBS = `sdl2-config --libs`
 
 # Glom all .cpp files from the testbed
-TESTBED_SRC_FILES := $(TESTBED)/Input.cpp $(TESTBED)/Main.cpp $(TESTBED)/System.cpp
+TESTBED_SRC_FILES := $(TESTBED)/Input.cpp $(TESTBED)/Main.cpp $(TESTBED)/Renderer.cpp $(TESTBED)/System.cpp
 
 # Glom all .cpp files from our desired project
 PROJECT_SRC_FILES := $(wildcard $(PROJECT)/*.cpp)

--- a/32blit-sdl/Makefile
+++ b/32blit-sdl/Makefile
@@ -60,7 +60,7 @@ OUTPUT_NAME = $(shell basename $(PROJECT))
 SDL_LIBS = `sdl2-config --libs`
 
 # Glom all .cpp files from the testbed
-TESTBED_SRC_FILES := $(TESTBED)/Main.cpp $(TESTBED)/System.cpp
+TESTBED_SRC_FILES := $(TESTBED)/Input.cpp $(TESTBED)/Main.cpp $(TESTBED)/System.cpp
 
 # Glom all .cpp files from our desired project
 PROJECT_SRC_FILES := $(wildcard $(PROJECT)/*.cpp)

--- a/32blit-sdl/Makefile
+++ b/32blit-sdl/Makefile
@@ -74,7 +74,7 @@ ifeq ($(ENABLE_FFMPEG), true)
 FFMPEG_LIBS = -Wl,-Bstatic -lavformat -lavcodec -lavdevice -lavfilter -lavutil -lswresample -lswscale -Wl,-Bdynamic -llzma -lz
 LDFLAGS +=  -L$(FFMPEG)/lib $(FFMPEG_LIBS)
 CPPFLAGS +=  -I$(FFMPEG)/include
-TESTBED_SRC_FILES += $(TESTBED)/VideoCaptureFfmpeg.cpp
+TESTBED_SRC_FILES += $(TESTBED)/VideoCapture.cpp $(TESTBED)/VideoCaptureFfmpeg.cpp
 else
 FFMPEG_LIBS = 
 CPPFLAGS += -DNO_FFMPEG_CAPTURE

--- a/32blit-sdl/Makefile
+++ b/32blit-sdl/Makefile
@@ -60,7 +60,7 @@ OUTPUT_NAME = $(shell basename $(PROJECT))
 SDL_LIBS = `sdl2-config --libs`
 
 # Glom all .cpp files from the testbed
-TESTBED_SRC_FILES := $(wildcard $(TESTBED)/*.cpp)
+TESTBED_SRC_FILES := $(TESTBED)/Main.cpp
 
 # Glom all .cpp files from our desired project
 PROJECT_SRC_FILES := $(wildcard $(PROJECT)/*.cpp)
@@ -74,10 +74,10 @@ ifeq ($(ENABLE_FFMPEG), true)
 FFMPEG_LIBS = -Wl,-Bstatic -lavformat -lavcodec -lavdevice -lavfilter -lavutil -lswresample -lswscale -Wl,-Bdynamic -llzma -lz
 LDFLAGS +=  -L$(FFMPEG)/lib $(FFMPEG_LIBS)
 CPPFLAGS +=  -I$(FFMPEG)/include
+TESTBED_SRC_FILES += $(TESTBED)/VideoCapture.cpp
 else
 FFMPEG_LIBS = 
 CPPFLAGS += -DNO_FFMPEG_CAPTURE
-TESTBED_SRC_FILES = $(TESTBED)/Main.cpp
 endif
 
 LDFLAGS += $(SDL_LIBS) -lpthread

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -37,7 +37,7 @@ void Renderer::set_mode(Mode new_mode) {
 	} else {
 		float current_pixel_size = std::min((float)win_width / sys_width, (float)win_height / sys_height);
 		if (mode == KeepPixels) current_pixel_size = (int)current_pixel_size;
-		if (mode == KeepPixelsx2) current_pixel_size = 2*(int)(current_pixel_size/2);
+		else if (mode == KeepPixelsLores) current_pixel_size = ((int)(2*current_pixel_size)) / 2.0;
 		dest.w = sys_width * current_pixel_size;
 		dest.h = sys_height * current_pixel_size;
 		dest.x = (win_width - dest.w) / 2;
@@ -60,9 +60,9 @@ void Renderer::resize(int width, int height) {
 		SDL_DestroyTexture(record_target);
 	}
 
-	fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width, sys_height);
-	ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, sys_width * 2, sys_height * 2);
-	record_target = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width * 2, sys_height * 2);
+	fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width/2, sys_height/2);
+	ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, sys_width, sys_height);
+	record_target = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width, sys_height);
 }
 
 void Renderer::update(System *sys) {

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -60,8 +60,8 @@ void Renderer::resize(int width, int height) {
 		SDL_DestroyTexture(record_target);
 	}
 
-	fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width/2, sys_height/2);
-	ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, sys_width, sys_height);
+	fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
+	ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
 	record_target = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width, sys_height);
 }
 

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -1,0 +1,83 @@
+#include <algorithm>
+#include <SDL.h>
+
+#include "Renderer.hpp"
+#include "System.hpp"
+
+Renderer::Renderer(SDL_Window *window, int width, int height) : sys_width(width), sys_height(height) {
+	//SDL_SetHint(SDL_HINT_RENDER_DRIVER, "openGL");
+	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+	if (renderer == NULL) {
+		fprintf(stderr, "could not create renderer: %s\n", SDL_GetError());
+	}
+
+	current = ltdc_texture_RGB565;
+
+	int w, h;
+	SDL_GetWindowSize(window, &w, &h);
+	resize(w, h);
+
+	// Clear the window.
+	SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+	SDL_RenderClear(renderer);
+	SDL_RenderPresent(renderer);
+}
+
+Renderer::~Renderer() {
+	SDL_DestroyTexture(fb_texture_RGB24);
+	SDL_DestroyTexture(ltdc_texture_RGB565);
+	SDL_DestroyRenderer(renderer);
+}
+
+void Renderer::set_mode(Mode new_mode) {
+	mode = new_mode;
+	if (mode == Stretch) {
+		dest.x = 0; dest.y = 0;
+		dest.w = win_width; dest.h = win_height;
+	} else {
+		float current_pixel_size = std::min((float)win_width / sys_width, (float)win_height / sys_height);
+		if (mode == KeepPixels) current_pixel_size = (int)current_pixel_size;
+		if (mode == KeepPixelsx2) current_pixel_size = 2*(int)(current_pixel_size/2);
+		dest.w = sys_width * current_pixel_size;
+		dest.h = sys_height * current_pixel_size;
+		dest.x = (win_width - dest.w) / 2;
+		dest.y = (win_height - dest.h) / 2;
+	}
+}
+
+void Renderer::resize(int width, int height) {
+	win_width = width;
+	win_height = height;
+	set_mode(mode);
+
+	if (fb_texture_RGB24) {
+		SDL_DestroyTexture(fb_texture_RGB24);
+	}
+	if (ltdc_texture_RGB565) {
+		SDL_DestroyTexture(ltdc_texture_RGB565);
+	}
+
+	fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width, sys_height);
+	ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, sys_width * 2, sys_height * 2);
+}
+
+void Renderer::update(System *sys) {
+	if (sys->mode() == SDL_PIXELFORMAT_RGB24) current = fb_texture_RGB24;
+	else current = ltdc_texture_RGB565;
+	sys->update_texture(current);
+}
+
+void Renderer::render(SDL_Texture *target) {
+	SDL_SetRenderTarget(renderer, target);
+	SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
+	SDL_RenderClear(renderer);
+	SDL_RenderCopy(renderer, current, NULL, &dest);
+}
+
+void Renderer::render() {
+	render(NULL);
+}
+
+void Renderer::present() {
+	SDL_RenderPresent(renderer);
+}

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -56,13 +56,9 @@ void Renderer::resize(int width, int height) {
 	if (ltdc_texture_RGB565) {
 		SDL_DestroyTexture(ltdc_texture_RGB565);
 	}
-	if (record_target) {
-		SDL_DestroyTexture(record_target);
-	}
 
 	fb_texture_RGB24 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
 	ltdc_texture_RGB565 = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
-	record_target = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_TARGET, sys_width, sys_height);
 }
 
 void Renderer::update(System *sys) {
@@ -81,17 +77,12 @@ void Renderer::_render(SDL_Texture *target, SDL_Rect *destination) {
 void Renderer::present() {
 	_render(NULL, &dest);
 	SDL_RenderPresent(renderer);
-	if (record_buffer) {
-		_render(record_target, NULL);
-		SDL_RenderReadPixels(renderer, NULL, SDL_PIXELFORMAT_RGB24, record_buffer, 320*3);
-	}
 }
 
-void Renderer::start_recording(Uint8 *buffer) {
-	record_buffer = buffer;
-}
-
-void Renderer::stop_recording() {
-	record_buffer = NULL;
+void Renderer::read_pixels(int width, int height, Uint32 format, Uint8 *buffer) {
+	SDL_Texture *record_target = SDL_CreateTexture(renderer, format, SDL_TEXTUREACCESS_TARGET, width, height);
+	_render(record_target, NULL);
+	SDL_RenderReadPixels(renderer, NULL, format, buffer, width*SDL_BYTESPERPIXEL(format));
+	SDL_DestroyTexture(record_target);
 }
 

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -11,8 +11,7 @@ class Renderer {
 		void update(System *sys);
 		void present();
 		void set_mode(Mode mode);
-		void start_recording(Uint8 *buffer);
-		void stop_recording();
+		void read_pixels(int width, int height, Uint32 format, Uint8 *buffer);
 
 	private:
 		void _render(SDL_Texture *target, SDL_Rect *destination);
@@ -27,7 +26,4 @@ class Renderer {
 		SDL_Texture *fb_texture_RGB24 = NULL;
 		SDL_Texture *ltdc_texture_RGB565 = NULL;
 		SDL_Texture *current = NULL;
-
-		Uint8 *record_buffer = NULL;
-		SDL_Texture *record_target = NULL;
 };

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -1,6 +1,3 @@
-struct SDL_Window;
-struct SDL_Texture;
-
 class System;
 
 class Renderer {
@@ -12,12 +9,14 @@ class Renderer {
 
 		void resize(int width, int height);
 		void update(System *sys);
-		void render(SDL_Texture *target);
-		void render();
 		void present();
 		void set_mode(Mode mode);
+		void start_recording(Uint8 *buffer);
+		void stop_recording();
 
 	private:
+		void _render(SDL_Texture *target, SDL_Rect *destination);
+
 		int sys_width, sys_height;
 		int win_width, win_height;
 
@@ -28,4 +27,7 @@ class Renderer {
 		SDL_Texture *fb_texture_RGB24 = NULL;
 		SDL_Texture *ltdc_texture_RGB565 = NULL;
 		SDL_Texture *current = NULL;
+
+		Uint8 *record_buffer = NULL;
+		SDL_Texture *record_target = NULL;
 };

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -5,7 +5,7 @@ class Renderer {
 		Renderer(SDL_Window *window, int width, int height);
 		~Renderer();
 
-		enum Mode {Stretch, KeepAspect, KeepPixels, KeepPixelsx2};
+		enum Mode {Stretch, KeepAspect, KeepPixels, KeepPixelsLores};
 
 		void resize(int width, int height);
 		void update(System *sys);

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -1,0 +1,31 @@
+struct SDL_Window;
+struct SDL_Texture;
+
+class System;
+
+class Renderer {
+	public:
+		Renderer(SDL_Window *window, int width, int height);
+		~Renderer();
+
+		enum Mode {Stretch, KeepAspect, KeepPixels, KeepPixelsx2};
+
+		void resize(int width, int height);
+		void update(System *sys);
+		void render(SDL_Texture *target);
+		void render();
+		void present();
+		void set_mode(Mode mode);
+
+	private:
+		int sys_width, sys_height;
+		int win_width, win_height;
+
+		Mode mode = KeepPixels;
+		SDL_Renderer *renderer = NULL;
+		SDL_Rect dest = {0, 0, 0, 0};
+
+		SDL_Texture *fb_texture_RGB24 = NULL;
+		SDL_Texture *ltdc_texture_RGB565 = NULL;
+		SDL_Texture *current = NULL;
+};

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -73,6 +73,8 @@ System::~System() {
 void System::run() {
 	running = true;
 
+	start = std::chrono::steady_clock::now();
+
 	blit::now = ::now;
 	blit::debug = ::debug;
 	blit::set_screen_mode = ::set_screen_mode;

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -157,17 +157,6 @@ void System::update_texture(SDL_Texture *texture) {
 	}
 }
 
-Uint8 *System::get_framebuffer() {
-	// For video recorder. Do not use for anything else.
-	if (_mode == blit::screen_mode::lores) {
-		return __fb.data;
-	}
-	else
-	{
-		return __ltdc.data;
-	}
-}
-
 void System::notify_redraw() {
 	SDL_SemPost(s_loop_redraw);
 }

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -1,0 +1,214 @@
+#include <chrono>
+#include <iostream>
+#include <SDL.h>
+
+#include "System.hpp"
+#include "32blit.hpp"
+#include "UserCode.hpp"
+
+
+// blit framebuffer memory
+rgb565 __ltdc_buffer[320 * 240 * 2];
+surface __ltdc((uint8_t *)__ltdc_buffer, pixel_format::RGB565, size(320, 240));
+surface __fb((uint8_t *)__ltdc_buffer + (320 * 240 * 2), pixel_format::RGB, size(160, 120));
+
+// blit debug callback
+void debug(std::string message) {
+	std::cout << message << std::endl;
+}
+
+// blit screenmode callback
+blit::screen_mode _mode = blit::screen_mode::lores;
+void set_screen_mode(blit::screen_mode new_mode) {
+	_mode = new_mode;
+	if (_mode == blit::screen_mode::hires) {
+		blit::fb = __ltdc;
+	}
+	else {
+		blit::fb = __fb;
+	}
+}
+
+// blit timer callback
+std::chrono::steady_clock::time_point start;
+uint32_t now() {
+	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+	return (uint32_t)elapsed.count();
+}
+
+// SDL events
+const Uint32 System::timer_event = SDL_RegisterEvents(2);
+const Uint32 System::loop_event = System::timer_event + 1;
+
+// Thread bouncers
+static int system_timer_thread(void *ptr) {
+	// Bounce back in to the class.
+	System *sys = (System *)ptr;
+	return sys->timer_thread();
+}
+
+static int system_loop_thread(void *ptr) {
+	// Bounce back in to the class.
+	System *sys = (System *)ptr;
+	return sys->update_thread();
+}
+
+
+System::System() {
+	m_input = SDL_CreateMutex();
+	s_timer_stop = SDL_CreateSemaphore(0);
+	s_loop_update = SDL_CreateSemaphore(0);
+	s_loop_redraw = SDL_CreateSemaphore(0);
+	s_loop_ended = SDL_CreateSemaphore(0);
+}
+
+System::~System() {
+	SDL_DestroyMutex(m_input);
+	SDL_DestroySemaphore(s_timer_stop);
+	SDL_DestroySemaphore(s_loop_update);
+	SDL_DestroySemaphore(s_loop_redraw);
+	SDL_DestroySemaphore(s_loop_ended);
+}
+
+void System::run() {
+	running = true;
+
+	blit::now = ::now;
+	blit::debug = ::debug;
+	blit::set_screen_mode = ::set_screen_mode;
+	blit::update = ::update;
+	blit::render = ::render;
+
+	::set_screen_mode(blit::lores);
+
+	t_system_loop = SDL_CreateThread(system_loop_thread, "Loop", (void *)this);
+	t_system_timer = SDL_CreateThread(system_timer_thread, "Timer", (void *)this);
+}
+
+int System::timer_thread() {
+	// Signal the system loop every 20 msec.
+	int dropped = 0;
+	SDL_Event event = {.type = timer_event};
+
+	while (SDL_SemWaitTimeout(s_timer_stop, 20)) {
+		if (SDL_SemValue(s_loop_update)) {
+			dropped++;
+			if(dropped > 100) {
+				dropped = 100;
+				event.user.code = 2;
+				SDL_PushEvent(&event);
+			} else {
+				event.user.code = 1;
+				SDL_PushEvent(&event);
+			}
+		} else {
+			SDL_SemPost(s_loop_update);
+			dropped = 0;
+			event.user.code = 0;
+			SDL_PushEvent(&event);
+		}
+	}
+	return 0;
+}
+
+int System::update_thread() {
+	// Run the blit user code once every time we are signalled.
+	SDL_Event event = {.type = loop_event};
+
+	::init(); // Run init here because the user can make it hang.
+
+	while (true) {
+		SDL_SemWait(s_loop_update);
+		if(!running) break;
+		SDL_LockMutex(m_input);
+		blit::buttons = shadow_buttons;
+		blit::tilt.x = shadow_tilt[0];
+		blit::tilt.y = shadow_tilt[1];
+		blit::tilt.z = shadow_tilt[2];
+		blit::joystick.x = shadow_joystick[0];
+		blit::joystick.y = shadow_joystick[1];
+		SDL_UnlockMutex(m_input);
+		blit::tick(::now());
+		if(!running) break;
+		SDL_PushEvent(&event);
+		SDL_SemWait(s_loop_redraw);
+	}
+	SDL_SemPost(s_loop_ended);
+	return 0;
+}
+
+int System::mode() {
+	if (_mode == blit::screen_mode::lores) {
+		return SDL_PIXELFORMAT_RGB24;
+	}
+	else
+	{
+		return SDL_PIXELFORMAT_RGB565;
+	}
+}
+
+void System::update_texture(SDL_Texture *texture) {
+	if (_mode == blit::screen_mode::lores) {
+		SDL_UpdateTexture(texture, NULL, (uint8_t *)__fb.data, 160 * 3);
+	}
+	else
+	{
+		SDL_UpdateTexture(texture, NULL, (uint8_t *)__ltdc.data, 320 * sizeof(uint16_t));
+	}
+}
+
+Uint8 *System::get_framebuffer() {
+	// For video recorder. Do not use for anything else.
+	if (_mode == blit::screen_mode::lores) {
+		return __fb.data;
+	}
+	else
+	{
+		return __ltdc.data;
+	}
+}
+
+void System::notify_redraw() {
+	SDL_SemPost(s_loop_redraw);
+}
+
+void System::set_joystick(int axis, float value) {
+	if (axis < 2) {
+		SDL_LockMutex(m_input);
+		shadow_joystick[axis] = value;
+		SDL_UnlockMutex(m_input);
+	}
+}
+
+void System::set_tilt(int axis, float value) {
+	if (axis < 3) {
+		SDL_LockMutex(m_input);
+		shadow_tilt[axis] = value;
+		SDL_UnlockMutex(m_input);
+	}
+}
+
+void System::set_button(int button, bool state) {
+	SDL_LockMutex(m_input);
+	if (state) {
+		shadow_buttons |= button;
+	} else {
+		shadow_buttons &= ~button;
+	}
+	SDL_UnlockMutex(m_input);
+}
+
+void System::stop() {
+	int returnValue;
+	running = false;
+
+	if(SDL_SemWaitTimeout(s_loop_ended, 500)) {
+		fprintf(stderr, "User code appears to have frozen. Detaching thread.\n");
+		SDL_DetachThread(t_system_loop);
+	} else {
+		SDL_WaitThread(t_system_loop, &returnValue);
+	}
+
+	SDL_SemPost(s_timer_stop);
+	SDL_WaitThread(t_system_timer, &returnValue);
+}

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -137,7 +137,7 @@ int System::update_thread() {
 	return 0;
 }
 
-int System::mode() {
+Uint32 System::mode() {
 	if (_mode == blit::screen_mode::lores) {
 		return SDL_PIXELFORMAT_RGB24;
 	}

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -20,9 +20,6 @@ class System {
 		void set_tilt(int axis, float value);
 		void set_button(int button, bool state);
 
-		// to make the video recorder work. don't use this for anything else
-		Uint8 *get_framebuffer();
-
 	private:
 
 		SDL_Thread *t_system_timer = NULL;

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -12,7 +12,7 @@ class System {
 		int update_thread();
 		int timer_thread();
 
-		int mode();
+		Uint32 mode();
 		void update_texture(SDL_Texture *);
 		void notify_redraw();
 

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -3,6 +3,9 @@ class System {
 		static const Uint32 timer_event;
 		static const Uint32 loop_event;
 
+		static const int width = 320;
+		static const int height = 240;
+
 		System();
 		~System();
 

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -1,0 +1,44 @@
+class System {
+	public:
+		static const Uint32 timer_event;
+		static const Uint32 loop_event;
+
+		System();
+		~System();
+
+		void run();
+		void stop();
+
+		int update_thread();
+		int timer_thread();
+
+		int mode();
+		void update_texture(SDL_Texture *);
+		void notify_redraw();
+
+		void set_joystick(int axis, float value);
+		void set_tilt(int axis, float value);
+		void set_button(int button, bool state);
+
+		// to make the video recorder work. don't use this for anything else
+		Uint8 *get_framebuffer();
+
+	private:
+
+		SDL_Thread *t_system_timer = NULL;
+		SDL_Thread *t_system_loop = NULL;
+
+		SDL_mutex *m_input = NULL;
+
+		SDL_sem *s_timer_stop = NULL;
+		SDL_sem *s_loop_update = NULL;
+		SDL_sem *s_loop_redraw = NULL;
+		SDL_sem *s_loop_ended = NULL;
+
+		bool running = false;
+
+		// shadow input
+		Uint32 shadow_buttons = 0;
+		float shadow_joystick[2] = {0, 0};
+		float shadow_tilt[3] = {0, 0, 0};
+};

--- a/32blit-sdl/VideoCapture.cpp
+++ b/32blit-sdl/VideoCapture.cpp
@@ -527,12 +527,13 @@ static void close_stream(AVFormatContext *oc, OutputStream *ost)
 /* media file output */
 
 //int main(int argc, char **argv)
-int open_stream(const char *filename, int width, int height, AVPixelFormat src_fmt, uint8_t *pic_src) {
+int open_stream(const char *filename, int width, int height, uint8_t *pic_src) {
 
 	AVOutputFormat *fmt;
 	AVCodec *audio_codec = NULL, *video_codec = NULL;
 	int ret;
 	AVDictionary *opt = NULL;
+	AVPixelFormat src_fmt = AV_PIX_FMT_RGB24;
 
 	source_format = src_fmt;
 	picture_source = pic_src;

--- a/32blit-sdl/VideoCapture.cpp
+++ b/32blit-sdl/VideoCapture.cpp
@@ -1,0 +1,67 @@
+#include <iomanip>
+#include <sstream>
+#include <SDL.h>
+
+#include "VideoCapture.hpp"
+
+#include "Renderer.hpp"
+#include "System.hpp"
+
+#include "VideoCaptureFfmpeg.hpp"
+
+inline std::tm localtime_xp(std::time_t timer)
+{
+	// Don't ignore unsafe warnings - https://stackoverflow.com/questions/38034033/c-localtime-this-function-or-variable-may-be-unsafe
+	std::tm bt{};
+#if defined(__unix__)
+	localtime_r(&timer, &bt);
+#elif defined(_MSC_VER)
+	localtime_s(&bt, &timer);
+#else
+	static std::mutex mtx;
+	std::lock_guard<std::mutex> lock(mtx);
+	bt = *std::localtime(&timer);
+#endif
+	return bt;
+}
+
+VideoCapture::VideoCapture(const char *name) : name(name) {
+	;
+}
+
+VideoCapture::~VideoCapture() {
+	if (buffer) {
+		fprintf(stderr, "Warning: recording was not stopped before exiting.\n");
+		stop();
+	}
+}
+
+void VideoCapture::start(const char *filename) {
+	buffer = (Uint8 *)malloc(System::width * System::height * SDL_BYTESPERPIXEL(SDL_PIXELFORMAT_RGB24));
+	ffmpeg_open_stream(filename, System::width, System::height, buffer);
+	fprintf(stderr, "Started with filename %s\n", filename);
+}
+
+void VideoCapture::start() {
+	auto bt = localtime_xp(std::time(0));
+	std::stringstream filename;
+	filename << name;
+	filename << std::put_time(&bt, "-capture-%Y-%m-%d-%H-%M-%S.mpg");
+	start(filename.str().c_str());
+}
+
+void VideoCapture::capture(Renderer *source) {
+	if (buffer) {
+		source->read_pixels(System::width, System::height, SDL_PIXELFORMAT_RGB24, buffer);
+		ffmpeg_capture();
+	} else {
+		fprintf(stderr, "Not recording.\n");
+	}
+}
+
+void VideoCapture::stop() {
+	ffmpeg_close_stream();
+	free(buffer);
+	buffer = NULL;
+	fprintf(stderr, "Stopped.\n");
+}

--- a/32blit-sdl/VideoCapture.hpp
+++ b/32blit-sdl/VideoCapture.hpp
@@ -1,3 +1,0 @@
-int open_stream(const char *filename, int width, int height, uint8_t *picture_source);
-int close_stream(void);
-int capture(void);

--- a/32blit-sdl/VideoCapture.hpp
+++ b/32blit-sdl/VideoCapture.hpp
@@ -1,0 +1,17 @@
+class Renderer;
+
+class VideoCapture {
+	public:
+		VideoCapture(const char *name);
+		~VideoCapture();
+
+		void start(const char *filename);
+		void start();
+		void capture(Renderer *source);
+		void stop();
+		bool recording() {return buffer;}
+
+	private:
+		const char *name;
+		Uint8 *buffer = NULL;
+};

--- a/32blit-sdl/VideoCapture.hpp
+++ b/32blit-sdl/VideoCapture.hpp
@@ -1,15 +1,3 @@
-#pragma once
-extern "C" {
-#include <libavutil/avassert.h>
-#include <libavutil/channel_layout.h>
-#include <libavutil/opt.h>
-#include <libavutil/mathematics.h>
-#include <libavutil/timestamp.h>
-#include <libavformat/avformat.h>
-#include <libswscale/swscale.h>
-#include <libswresample/swresample.h>
-}
-
-int open_stream(const char *filename, int width, int height, AVPixelFormat src_fmt, uint8_t *picture_source);
+int open_stream(const char *filename, int width, int height, uint8_t *picture_source);
 int close_stream(void);
 int capture(void);

--- a/32blit-sdl/VideoCaptureFfmpeg.cpp
+++ b/32blit-sdl/VideoCaptureFfmpeg.cpp
@@ -527,7 +527,7 @@ static void close_stream(AVFormatContext *oc, OutputStream *ost)
 /* media file output */
 
 //int main(int argc, char **argv)
-int open_stream(const char *filename, int width, int height, uint8_t *pic_src) {
+int ffmpeg_open_stream(const char *filename, int width, int height, uint8_t *pic_src) {
 
 	AVOutputFormat *fmt;
 	AVCodec *audio_codec = NULL, *video_codec = NULL;
@@ -590,7 +590,7 @@ int open_stream(const char *filename, int width, int height, uint8_t *pic_src) {
 	return 0;
 }
 
-int capture(void)
+int ffmpeg_capture(void)
 {
 	if (encode_video || encode_audio) {
 		/* select the stream to encode */
@@ -607,7 +607,7 @@ int capture(void)
 	return 0;
 }
 
-int close_stream(void) {
+int ffmpeg_close_stream(void) {
 	/* Write the trailer, if any. The trailer must be written before you
 	 * close the CodecContexts open when you wrote the header; otherwise
 	 * av_write_trailer() may try to use memory that was freed on

--- a/32blit-sdl/VideoCaptureFfmpeg.hpp
+++ b/32blit-sdl/VideoCaptureFfmpeg.hpp
@@ -1,0 +1,3 @@
+int ffmpeg_open_stream(const char *filename, int width, int height, uint8_t *picture_source);
+int ffmpeg_close_stream(void);
+int ffmpeg_capture(void);

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ DISPLAY=:0.0 ../build/project/<project_name>
 Then build your 32blit project with:
 
 ```
-make ../example/<project_name> ENABLE_FFMPG=true FFMPEG=../FFmpeg-n4.1.4/build
+make ../example/<project_name> ENABLE_FFMPEG=true FFMPEG=../FFmpeg-n4.1.4/build
 ```
 
 When running, you can now hit `r` to start and stop recording.


### PR DESCRIPTION
This allows us to monitor it and detect if it is too slow or hanging.
Inter-thread communication is done using semaphores and there is no
locking.

The timer thread waits with 20 msec timeout on a semaphore telling it
to exit. This is done instead of using bool running so that we can
tell it to exit after the system loop thread, and because it lets us
do the 20 msec delay at the same time. When the wait times out, it
posts to the update semaphore. If it detects this semaphore is not
being decremented, it posts slow/frozen events to the main loop.

The system loop thread blocking waits on the update semaphore and
does one update. Then it posts a redraw event to the main loop
and then blocking waits on the redraw semaphore.

When the main loop receives the redraw event it does the redraw
and then posts the redraw semaphore.

The system loop then continues and waits on the update semaphore
again.

When the main loop receives slow and frozen events it sets the window
title to show the message. This could be drawn in the window instead,
or handled as appropriate.

At shutdown, the system loop posts a semaphore and the main thread
waits with timeout for it. This is so we can detect frozen user
code and detach the thread, allowing clean exit.