### PR TITLE
Include missing headers to fix compilation issues under OS X.

### DIFF
--- a/32blit/graphics/mode7.cpp
+++ b/32blit/graphics/mode7.cpp
@@ -4,6 +4,7 @@
     Functions to emulate the mode7 graphics effect from classic consoles.
 */
 #include "math.h"
+#include <cmath>
 #include <cfloat>
 
 #include "../math/interpolation.hpp"

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -1,6 +1,7 @@
 /*! \file surface.cpp
 */
 #include <algorithm>
+#include <string>
 
 #include "font.hpp"
 #include "sprite.hpp"


### PR DESCRIPTION
Due to some missing includes the engine code does not compile under OS X.

This PR fixes those issues.