### PR TITLE
Sdl main fix

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -50,5 +50,5 @@ endif()
 
 function(blit_executable NAME SOURCES)
 	add_executable(${NAME} ${SOURCES} ${ARGN})
-  	target_link_libraries(${NAME} BlitHalSDL)
+  	target_link_libraries(${NAME} -Wl,--whole-archive BlitHalSDL -Wl,--no-whole-archive)
 endfunction()

--- a/32blit-sdl/Main.hpp
+++ b/32blit-sdl/Main.hpp
@@ -1,4 +1,0 @@
-#pragma once
-#include "windows.h"
-int main();
-int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow);

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdio>
 #include <SDL.h>
 
 #include "Renderer.hpp"


### PR DESCRIPTION
libBlitHalSDL.a contains SDL_main, which is required by libSDL2.a.
But libBlitHalSDL.a also depends on libSDL2.a, so we have a circular
dependency. Which ever one is listed first will have some required
symbols stripped by the linker. In order to avoid this, just use
--whole-archive when linking libBlitHalSDL.a, because we almost
certainly need all of it anyway.

This whole situation happens because it is rather unusual to have
main() inside a static library, rather than the source of the final
executable. But due to what we're doing, we doing have much choice.

Fixes #26