### PR TITLE
Remove alpha var from RGB getpixel

### DIFF
--- a/tools/asset-builder
+++ b/tools/asset-builder
@@ -278,7 +278,7 @@ if __name__ == '__main__':
                         r, g, b, a = source_image.getpixel((x, y))
                         c = color(r, g, b, a)
                     elif source_mode == 'RGB':
-                        r, g, b, a = source_image.getpixel((x, y))
+                        r, g, b = source_image.getpixel((x, y))
                         c = color(r, g, b)
 
                     try:

--- a/tools/sprite-builder
+++ b/tools/sprite-builder
@@ -348,7 +348,7 @@ if __name__ == '__main__':
                         r, g, b, a = source_image.getpixel((x, y))
                         c = color(r, g, b, a)
                     elif source_mode == 'RGB':
-                        r, g, b, a = source_image.getpixel((x, y))
+                        r, g, b = source_image.getpixel((x, y))
                         c = color(r, g, b)
 
                     try:


### PR DESCRIPTION
Asset building for an RGB sprite sheet was failing due to attempt to assign non-existent alpha var.