### PR TITLE
Store compilers in the CMake cache

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -1,8 +1,8 @@
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-set(CMAKE_C_COMPILER arm-none-eabi-gcc)
-set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc CACHE PATH "Path to C compiler")
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++ CACHE PATH "Path to C++ compiler")
 
 set(MCU_LINKER_SCRIPT STM32H750VBTx_FLASH.ld)
 set(MCU_ARCH cortex-m7)


### PR DESCRIPTION
Fixes this error when using VS Code with the CMake Tools extension:

> The path to the compiler for one or more source files was not found in the CMake cache. If you are using a toolchain file, this probably means that you need to specify the CACHE option when you set your C and/or C++ compiler path
