### PR TITLE
Build DFU files automatically as part of the build

### DIFF
--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -95,9 +95,10 @@ function(blit_executable NAME SOURCES)
 	set_target_properties(${NAME}.elf PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT})
 	set_property(TARGET ${NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-Map=${NAME}.map,--cref")
   	add_custom_command(TARGET ${NAME}.elf POST_BUILD
+		COMMENT "Building ${NAME}.bin\nBuilding ${NAME}.dfu"
 		COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${NAME}.elf> ${NAME}.hex
 		COMMAND ${CMAKE_OBJCOPY} -O binary -S $<TARGET_FILE:${NAME}.elf> ${NAME}.bin
-		COMMAND arm-none-eabi-size $<TARGET_FILE:${NAME}.elf>
-		COMMENT "Building ${NAME}.hex \nBuilding ${NAME}.bin"
+		COMMAND ${CMAKE_DFU} build --force --out ${NAME}.dfu ${NAME}.bin
+		COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${NAME}.elf>
 	)
 endfunction()

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -3,6 +3,8 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 
 set(CMAKE_C_COMPILER arm-none-eabi-gcc CACHE PATH "Path to C compiler")
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++ CACHE PATH "Path to C++ compiler")
+set(CMAKE_SIZE arm-none-eabi-size CACHE PATH "Path to size tool")
+set(CMAKE_DFU "${CMAKE_CURRENT_LIST_DIR}/tools/dfu" CACHE PATH "Path to DFU builder")
 
 set(MCU_LINKER_SCRIPT STM32H750VBTx_FLASH.ld)
 set(MCU_ARCH cortex-m7)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(doom-fire)
-add_subdirectory(fire)
+add_subdirectory(rotozoom)
 add_subdirectory(fizzlefade)
 add_subdirectory(flight)
 add_subdirectory(geometry)


### PR DESCRIPTION
Also fixes the renamed fire directory in examples and adds a new
variable for the size tool instead of hard-coding it.