### PR TITLE
Copy SDL2.dll for Windows builds

### DIFF
--- a/mingw.toolchain
+++ b/mingw.toolchain
@@ -1,4 +1,13 @@
+if(NOT DEFINED SDL2_DIR)
+	set(SDL2_DIR /usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2)
+endif()
+list(APPEND CMAKE_MODULE_PATH ${SDL2_DIR})
+include(sdl2-config REQUIRED)
+
 set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
 set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
 set(CMAKE_CXX_FLAGS_INIT "-static-libstdc++ -static-libgcc -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic")
+set(SDL2_BINDIR ${SDL2_PREFIX}/bin)
+
+configure_file(${SDL2_BINDIR}/SDL2.dll ${CMAKE_CURRENT_BINARY_DIR}/SDL2.dll COPYONLY)


### PR DESCRIPTION
This rather long-winded approach includes a work-around for the fact that SDL2_PREFIX doesn't appear to normally be available to the .toolchain file.

It now checks SDL2_DIR, sets it to the README.md mentioned default if not set and imports sdl2-config.cmake to set these variables.

With SDL2_PREFIX it's now possible to copy SDL2.dll into the build output folder automagically.

Maybe there's a better way to do this?