### PR TITLE
Changed the window title to something more appropriate

### DIFF
--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -18,7 +18,7 @@
 #endif
 
 #ifndef WINDOW_TITLE
-#define WINDOW_TITLE "TinyDebug SDL"
+#define WINDOW_TITLE "32blit development (SDL)"
 #endif
 
 static bool running = true;


### PR DESCRIPTION
When using the SDL version to run locally, changed the window title to show more dedication to the 32blit :-)