### PR TITLE
Wrong ranlib and ar being used.

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -4,6 +4,8 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_C_COMPILER arm-none-eabi-gcc CACHE PATH "Path to C compiler")
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++ CACHE PATH "Path to C++ compiler")
 set(CMAKE_SIZE arm-none-eabi-size CACHE PATH "Path to size tool")
+set(CMAKE_RANLIB arm-none-eabi-gcc-ranlib CACHE PATH "Path to ranlib")
+set(CMAKE_AR arm-none-eabi-gcc-ar CACHE PATH "Path to ar")
 set(CMAKE_DFU "${CMAKE_CURRENT_LIST_DIR}/tools/dfu" CACHE PATH "Path to DFU builder")
 
 set(MCU_LINKER_SCRIPT STM32H750VBTx_FLASH.ld)


### PR DESCRIPTION
CMAKE_RANLIB and CMAKE_AR were not being set.

This was defaulting to /usr/bin/ranlib and /usr/bin/ar.