### PR TITLE
Make mode static to avoid collisions

### DIFF
--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -34,7 +34,7 @@ FRESULT SD_FileOpenError = FR_INVALID_PARAMETER;
 uint32_t total_samples = 0;
 uint8_t dma_status = 0;
 
-blit::screen_mode mode = blit::screen_mode::lores;
+static blit::screen_mode mode = blit::screen_mode::lores;
 
 /* configure the screen surface to point at the reserved LTDC framebuffer */
 surface __ltdc((uint8_t *)&__ltdc_start, pixel_format::RGB565, size(320, 240));


### PR DESCRIPTION
The variable holding the current screen mode inside the STM32 HAL is not static - this means users cannot have any variable named mode otherwise a collision occurs. Fix the problem by making this variable static.