### PR TITLE
Add CMakeLists.txt for Empty Visual Studio Game Solution.

### DIFF
--- a/vs/game/CMakeLists.txt
+++ b/vs/game/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+project (game)
+include (../../32blit.cmake)
+blit_executable (game game.cpp)


### PR DESCRIPTION
Noticed that the empty game solution for Visual Studio was missing a CMakeLists.txt so have added one.