### PR TITLE
A few SDL audio fixes

### DIFF
--- a/32blit-sdl/Audio.cpp
+++ b/32blit-sdl/Audio.cpp
@@ -7,21 +7,16 @@
 #include "engine/audio.hpp"
 
 Audio::Audio() {
-    SDL_AudioSpec *desired;
+    SDL_AudioSpec desired = {}, audio_spec = {};
 
-    desired = new SDL_AudioSpec();
-    audio_spec = new SDL_AudioSpec();
+    desired.freq = _sample_rate;
+    desired.format = AUDIO_U16LSB;
+    desired.channels = 1;
 
-    desired->freq = _sample_rate;
-    desired->format = AUDIO_U16LSB;
-    desired->channels = 1;
+    desired.samples = 128;
+    desired.callback = _audio_callback;
 
-    desired->samples = 128;
-    desired->callback = _audio_callback;
-
-    audio_device = SDL_OpenAudioDevice(NULL, 0, desired, audio_spec, 0);
-
-    delete desired;
+    audio_device = SDL_OpenAudioDevice(NULL, 0, &desired, &audio_spec, 0);
 
     if(audio_device == 0){
         std::cout << "Audio Init Failed: " << SDL_GetError() << std::endl;

--- a/32blit-sdl/Audio.cpp
+++ b/32blit-sdl/Audio.cpp
@@ -10,7 +10,7 @@ Audio::Audio() {
     SDL_AudioSpec desired = {}, audio_spec = {};
 
     desired.freq = _sample_rate;
-    desired.format = AUDIO_U16LSB;
+    desired.format = AUDIO_S16LSB;
     desired.channels = 1;
 
     desired.samples = 256;
@@ -32,14 +32,14 @@ Audio::~Audio() {
     SDL_CloseAudioDevice(audio_device);
 }
 
-void _audio_bufferfill(unsigned short *buffer, int buffer_size){
+void _audio_bufferfill(short *buffer, int buffer_size){
     memset(buffer, 0, buffer_size);
 
     for(auto sample = 0; sample < buffer_size; sample++){
-        buffer[sample] = blit::audio::get_audio_frame();
+        buffer[sample] = (int)blit::audio::get_audio_frame() - 0x7fff;
     }
 }
 
 void _audio_callback(void *userdata, uint8_t *stream, int len){
-    _audio_bufferfill((unsigned short *)stream, len / 2);
+    _audio_bufferfill((short *)stream, len / 2);
 }

--- a/32blit-sdl/Audio.cpp
+++ b/32blit-sdl/Audio.cpp
@@ -13,7 +13,7 @@ Audio::Audio() {
     desired.format = AUDIO_U16LSB;
     desired.channels = 1;
 
-    desired.samples = 128;
+    desired.samples = 256;
     desired.callback = _audio_callback;
 
     audio_device = SDL_OpenAudioDevice(NULL, 0, &desired, &audio_spec, 0);

--- a/32blit-sdl/Audio.hpp
+++ b/32blit-sdl/Audio.hpp
@@ -6,7 +6,6 @@ class Audio {
 	private:
         const unsigned int _sample_rate = 22050;
 
-		SDL_AudioSpec *audio_spec = NULL;
         SDL_AudioDeviceID audio_device;
 };
 

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -169,9 +169,7 @@ int main(int argc, char *argv[]) {
 	blit_system = new System();
 	blit_input = new Input(window, blit_system);
 	blit_renderer = new Renderer(window, System::width, System::height);
-#ifndef __EMSCRIPTEN__
 	blit_audio = new Audio();
-#endif
 
 #ifdef VIDEO_CAPTURE
 	blit_capture = new VideoCapture(argv[0]);


### PR DESCRIPTION
Stuff I mentioned yesterday and a tiny cleanup. There's still no audio in Chrome without a workaround. (See https://github.com/emscripten-ports/SDL2/issues/57, which I should probably fix in SDL at some point.)