### PR TITLE
Unshorten CMake instructions

### DIFF
--- a/docs/32blit.md
+++ b/docs/32blit.md
@@ -5,9 +5,12 @@ To build your project for 32blit using arm-none-eabi-gcc you should prepare the 
 From the root of your project:
 
 ```
-cmake . -B build.stm32 -DCMAKE_TOOLCHAIN_FILE=../../32blit.toolchain
-make -C build.stm32
+mkdir build.stm32
+cd build.stm32
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../../../32blit.toolchain
 ```
+
+And then `make` as normal.
 
 The result of your build will be a `.bin`, `.hex`, `.elf` and DfuSe-compatible `.dfu` file.
 

--- a/docs/Emscripten.md
+++ b/docs/Emscripten.md
@@ -17,8 +17,9 @@ You should now have commands like `emcc` in your path, and an `EMSDK` environmen
 In your project directory:
 
 ``` shell
-emcmake cmake . -B build.em -G "Unix Makefiles"
-make -C build.em
+mkdir build.em
+emcmake cmake .. -G "Unix Makefiles"
+make
 python3 -m http.server
 ```
 Finally, open the URL given by Python's HTTP server in your browser and open your project's .html file.

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -15,13 +15,15 @@ cd examples/palette-cycle
 prepare the Makefile with CMake:
 
 ```
-cmake . -B build
+mkdir build
+cd build
+cmake ..
 ```
 
 and compile the example:
 
 ```
-make -C build
+make
 ```
 
 To run the application on your computer, use the following command (from within the same directory):

--- a/docs/VideoCapture.md
+++ b/docs/VideoCapture.md
@@ -13,7 +13,9 @@
 Then configure your 32blit project with:
 
 ```
-cmake . -B build -DVIDEO_CAPTURE=true
+mkdir build
+cd build
+cmake .. -DVIDEO_CAPTURE=true
 ```
 
 When running your game, you can now hit `r` to start and stop recording.

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -46,13 +46,15 @@ cd examples/palette-cycle
 prepare the Makefile with CMake:
 
 ```
-cmake . -B build
+mkdir build
+cd build
+cmake ..
 ```
 
 and compile the example:
 
 ```
-make -C build
+make
 ```
 
 To run the application on your computer, use the following command (from within the same directory):
@@ -91,8 +93,10 @@ sudo make install
 Finally, from the root directory of your project:
 
 ```
-cmake . -B build.mingw -DCMAKE_TOOLCHAIN_FILE=../../mingw.toolchain -DSDL2_DIR=/usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2
-make -C build.mingw
+mkdir build.mingw
+cd build.mingw
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../../../mingw.toolchain -DSDL2_DIR=/usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2
+make
 cp /usr/local/cross-tools/x86_64-w64-mingw32/bin/SDL2.dll .
 ```
 

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -23,8 +23,10 @@ sudo make install
 Finally, from the root directory of this repository:
 
 ``` shell
-cmake . -B build -DCMAKE_TOOLCHAIN_FILE=./darwin.toolchain
-make -C build
+mkdir build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../darwin.toolchain
+make
 ```
 
 When the build completes you should find all the examples within the build directory.


### PR DESCRIPTION
-B isn't supported until CMake 3.13, which is newer than the version in Ubuntu 18.04 which is used in WSL. :cry: 