### PR TITLE
External flash

### DIFF
--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -40,6 +40,7 @@ list(APPEND SOURCES
 	Middlewares/Third_Party/FatFs/src/ff.c
 	Middlewares/Third_Party/FatFs/src/ff_gen_drv.c
 	Middlewares/Third_Party/FatFs/src/option/syscall.c
+	Middlewares/Third_Party/FatFs/src/option/ccsbcs.c
 	Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c
 	Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c
 	Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c
@@ -72,6 +73,11 @@ list(APPEND SOURCES
 	Src/32blit.c
 	Src/CDCLogging.c
 	startup_stm32h750xx.s
+	Src/CDCDataStream.cpp 
+	Src/CDCCommandStream.cpp 
+	Src/CDCCommandHandler.cpp 
+	Src/CDCResetHandler.cpp
+	Src/CDCInfoHandler.cpp 
 )
 
 set_source_files_properties( ${SOURCES} PROPERTIES LANGUAGE CXX )
@@ -98,6 +104,10 @@ target_compile_definitions(BlitHalSTM32
 		-DUSE_HAL_DRIVER
 		-DUSE_USB_HS
 		-DSTM32H750xx
+		-DAPPLICATION_VTOR=${APPLICATION_VTOR}
+		-DEXTERNAL_LOAD_ADDRESS=${EXTERNAL_LOAD_ADDRESS}
+		-DINITIALISE_QSPI=${INITIALISE_QSPI}
+		-DCDC_FIFO_BUFFERS=${CDC_FIFO_BUFFERS}
 )
 
 set(MCU_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT}" PARENT_SCOPE)
@@ -114,5 +124,6 @@ function(blit_executable NAME SOURCES)
 		COMMAND ${CMAKE_OBJCOPY} -O binary -S $<TARGET_FILE:${NAME}.elf> ${NAME}.bin
 		COMMAND ${CMAKE_DFU} build --force --out ${NAME}.dfu ${NAME}.bin
 		COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${NAME}.elf>
+		COMMAND ${CMAKE_READELF} -S $<TARGET_FILE:${NAME}.elf>
 	)
 endfunction()

--- a/32blit-stm32/Inc/32blit.h
+++ b/32blit-stm32/Inc/32blit.h
@@ -37,6 +37,12 @@ extern void blit_process_input();
 extern void blit_enable_dac();
 extern uint32_t blit_update_dac(FIL *audio_file);
 
+// Switching execution
+extern void blit_switch_execution(void);
+
 void blit_menu_update(uint32_t time);
 void blit_menu_render(uint32_t time);
 void blit_menu();
+
+extern void blit_enable_ADC();
+extern void blit_disable_ADC();

--- a/32blit-stm32/Inc/ffconf.h
+++ b/32blit-stm32/Inc/ffconf.h
@@ -54,7 +54,7 @@
 /  1: Enable without LF-CRLF conversion.
 /  2: Enable with LF-CRLF conversion. */
 
-#define _USE_FIND            0
+#define _USE_FIND            1
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
@@ -110,7 +110,7 @@
 /   950 - Traditional Chinese (DBCS)
 */
 
-#define _USE_LFN     0    /* 0 to 3 */
+#define _USE_LFN     1    /* 0 to 3 */
 #define _MAX_LFN     255  /* Maximum LFN length to handle (12 to 255) */
 /* The _USE_LFN switches the support of long file name (LFN).
 /

--- a/32blit-stm32/Inc/quadspi.h
+++ b/32blit-stm32/Inc/quadspi.h
@@ -36,7 +36,7 @@ extern QSPI_HandleTypeDef hqspi;
 #define APPLICATION_ADDRESS                  QSPI_BASE
 
 // Flash example
-#define QSPI_FLASH_SIZE                      22
+#define QSPI_FLASH_SIZE                      POSITION_VAL(0x2000000)-1
 #define QSPI_PAGE_SIZE                       256
 
 /* Reset Operations */
@@ -161,6 +161,9 @@ HAL_StatusTypeDef qspi_sector_erase(uint32_t BlockAddress);
 HAL_StatusTypeDef qspi_write_buffer(size_t offset, const uint8_t* buffer, size_t length);
 HAL_StatusTypeDef qspi_read_buffer(size_t address, const uint8_t* buffer, size_t length);
 HAL_StatusTypeDef qspi_enable_memorymapped_mode(void);
+void QSPI_WriteEnable(QSPI_HandleTypeDef *hqspi);
+void qspi_chip_erase();
+
 /* USER CODE END Prototypes */
 
 #ifdef __cplusplus

--- a/32blit-stm32/Makefile
+++ b/32blit-stm32/Makefile
@@ -1,11 +1,18 @@
 
 # Single user cpp file containing game code to build into firmware
-PROJECT = Src/32blitgame.cpp
+PROJECT = Src/flash-loader.cpp
 # Set the output filename to match the user code filename
 TARGET = $(basename $(notdir $(PROJECT)))
 DEBUG = 1
-OPT = -O0
+OPT = -Og -g -DEXTERNAL_LOAD_ADDRESS=0x90000000 -DAPPLICATION_VTOR=0x08000000 -DINITIALISE_QSPI=1 -DCDC_FIFO_BUFFERS=64
 BUILD_DIR = build
+
+CPP_SOURCES = \
+Src/CDCDataStream.cpp \
+Src/CDCCommandStream.cpp \
+Src/CDCCommandHandler.cpp \
+Src/CDCResetHandler.cpp \
+Src/CDCInfoHandler.cpp
 
 # C sources
 C_SOURCES =  \
@@ -48,6 +55,7 @@ Src/system_stm32h7xx.c \
 Src/user_diskio.c \
 Src/fatfs.c \
 Src/fatfs_sd.c \
+Src/fatfs/option/ccsbcs.c \
 Middlewares/Third_Party/FatFs/src/diskio.c \
 Middlewares/Third_Party/FatFs/src/ff.c \
 Middlewares/Third_Party/FatFs/src/ff_gen_drv.c \
@@ -164,6 +172,9 @@ all: lib32blit-stm32 $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUI
 # list of objects
 OBJECTS = $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
+
+OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(CPP_SOURCES:.cpp=.o)))
+vpath %.cpp $(sort $(dir $(C_SOURCES)))
 
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(PROJECT:.cpp=.o)))
 vpath %.cpp $(sort $(dir $(PROJECT)))

--- a/32blit-stm32/STM32H750VBTxEXT_FLASH.ld
+++ b/32blit-stm32/STM32H750VBTxEXT_FLASH.ld
@@ -48,7 +48,7 @@ RAM_D2 (xrw)        : ORIGIN = 0x30000000, LENGTH = 288K
 RAM_D3 (xrw)        : ORIGIN = 0x38000000, LENGTH = 64K
 ITCMISR (xrw)       : ORIGIN = 0x00000000, LENGTH = 4K
 ITCMRAM (xrw)       : ORIGIN = 0x00001000, LENGTH = 60K
-FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 128K
+FLASH (rx)          : ORIGIN = 0x90000000, LENGTH = 32768K
 }
 
 /* Define output sections */

--- a/32blit-stm32/Src/CDCCommandHandler.cpp
+++ b/32blit-stm32/Src/CDCCommandHandler.cpp
@@ -1,0 +1,10 @@
+/*
+ * CDCCommandHandler.cpp
+ *
+ *  Created on: 17 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#include "CDCCommandHandler.h"
+
+constexpr char *CDCCommandHandler::StreamResultStrings[4];

--- a/32blit-stm32/Src/CDCCommandHandler.h
+++ b/32blit-stm32/Src/CDCCommandHandler.h
@@ -1,0 +1,46 @@
+/*
+ * CDCCommandHandler.h
+ *
+ *  Created on: 17 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#ifndef SRC_CDCCOMMANDHANDLER_H_
+#define SRC_CDCCOMMANDHANDLER_H_
+
+
+#include "CDCDataStream.h"
+
+class CDCCommandHandler
+{
+public:
+	template <int a, int b, int c, int d>
+	struct CDCFourCCMake
+	{
+	    static const unsigned int value = (((((d << 8) | c) << 8) | b) << 8) | a;
+	};
+
+	typedef uint32_t CDCFourCC;
+
+	typedef enum { srError, srContinue, srFinish, srNeedData } StreamResult;
+
+	static constexpr char *StreamResultStrings[4] = { (char *)"Error:", (char *)"Continue:", (char *)"Finish:", (char *)"NeedData:" };
+
+	static char *GetStreamResultString(StreamResult result)
+	{
+		return CDCCommandHandler::StreamResultStrings[result];
+	}
+
+	virtual StreamResult 	StreamData(CDCDataStream &dataStream) = 0;
+	virtual bool 	 				StreamInit(CDCFourCC uCommand) = 0;
+
+	uint32_t GetBytesHandled(void)
+	{
+		return m_uBytesHandled;
+	}
+
+protected:
+	uint32_t m_uBytesHandled = 0;
+};
+
+#endif /* SRC_CDCCOMMANDHANDLER_H_ */

--- a/32blit-stm32/Src/CDCCommandStream.cpp
+++ b/32blit-stm32/Src/CDCCommandStream.cpp
@@ -1,0 +1,218 @@
+/*
+ * CDCCommandStream.cpp
+ *
+ *  Created on: 17 Jan 2020
+ *      Author: andrewcapon
+ */
+#include "32blit.h"
+#include "usbd_cdc_if.h"
+extern USBD_HandleTypeDef hUsbDeviceHS;
+
+#include "CDCCommandStream.h"
+
+void CDCCommandStream::Init(void)
+{
+	m_state = stDetect;
+	m_uHeaderScanPos = 0;
+	m_bNeedsUSBResume = false;
+}
+
+void CDCCommandStream::AddCommandHandler(CDCCommandHandler::CDCFourCC uCommand, CDCCommandHandler *pCommandHandler)
+{
+	m_commandHandlers[uCommand] = pCommandHandler;
+}
+
+
+void CDCCommandStream::LogTimeTaken(CDCCommandHandler::StreamResult result, uint32_t uBytesHandled)
+{
+	// can be used to log time taken
+}
+
+
+void CDCCommandStream::Stream(void)
+{
+	while(CDCFifoElement *pElement = GetFifoReadElement())
+	{
+		if(pElement->m_uLen)
+			Stream(pElement->m_data, pElement->m_uLen);
+		ReleaseFifoReadElement();
+	}
+
+	// restart USB CDC if fifo was full
+	if(m_bNeedsUSBResume)
+	{
+		m_bNeedsUSBResume = false;
+	  USBD_CDC_SetRxBuffer(&hUsbDeviceHS, GetFifoWriteBuffer());
+		USBD_CDC_ReceivePacket(&hUsbDeviceHS);
+	}
+}
+
+uint8_t CDCCommandStream::Stream(uint8_t *data, uint32_t len)
+{
+	blit_disable_ADC();
+	uint8_t   *pScanPos  = data;
+
+	CDCCommandHandler::CDCFourCC uCommand   = 0;
+
+	if(m_state == stDetect)
+	{
+		bool bHeaderFound = false;
+		while ((!bHeaderFound) && (pScanPos < (data+len)))
+		{
+			if(*pScanPos == m_header[m_uHeaderScanPos])
+			{
+				if(m_uHeaderScanPos == 3)
+				{
+					// header found
+					bHeaderFound = true;
+					m_uHeaderScanPos = 0;
+					m_uCommandScanPos = 0;
+				}
+				else
+					m_uHeaderScanPos++;
+			}
+			else
+			{
+				m_uHeaderScanPos = 0;
+				m_uCommandScanPos = 0;
+			}
+			pScanPos++;
+		}
+
+		if(bHeaderFound)
+		{
+			// next command byte could be in next call
+			while((m_state == stDetect) && (m_uCommandScanPos < 4))
+			{
+				uint8_t  *pCommandByte = (uint8_t *)(&uCommand)+m_uCommandScanPos;
+				if(pScanPos > (data + len)) // rest in next packet
+					m_state = stDetectCommandWord;
+				else
+				{
+					*pCommandByte = *pScanPos++;
+					if(m_uCommandScanPos == 3)
+					{
+						m_state = stDispatch;
+					}
+					m_uCommandScanPos++;
+				}
+			}
+		}
+	}
+	else
+	{
+		if(m_state == stDetectCommandWord)
+		{
+			while(m_uCommandScanPos < 4)
+			{
+				uint8_t *pCommandByte = (uint8_t *)(&uCommand)+m_uCommandScanPos;
+				*pCommandByte = *pScanPos++;
+				m_uCommandScanPos++;
+			}
+			m_state = stDispatch;
+		}
+	}
+
+	if(m_state == stDispatch)
+	{
+		m_uRetryCount = 0;
+		m_uDispatchTime = HAL_GetTick();
+
+		m_pCurrentCommandHandler = m_commandHandlers[uCommand];
+		if(m_pCurrentCommandHandler)
+		{
+			if(m_pCurrentCommandHandler->StreamInit(uCommand))
+				m_state = stProcessing;
+			else
+			{
+				m_state = stDetect;
+				LogTimeTaken(CDCCommandHandler::srFinish, 0);
+			}
+		}
+		else
+			m_state = stDetect; // No handler go back to detect state
+	}
+
+	if(m_state == stProcessing)
+	{
+		m_dataStream.AddData(pScanPos, len - (pScanPos - data));
+		CDCCommandHandler::StreamResult result = m_pCurrentCommandHandler->StreamData(m_dataStream);
+
+		switch(result)
+		{
+			case CDCCommandHandler::srError:
+			case CDCCommandHandler::srFinish:
+			{
+				// handler has finished or failed go back to detect state
+				m_state = stDetect;
+				LogTimeTaken(result, m_pCurrentCommandHandler->GetBytesHandled());
+				blit_enable_ADC();
+			}
+			break;
+
+			case CDCCommandHandler::srNeedData:
+				m_uRetryCount++;
+				if(m_uRetryCount > 1)
+				{
+					m_state = stDetect;
+					LogTimeTaken(result, m_pCurrentCommandHandler->GetBytesHandled());
+					blit_enable_ADC();
+				}
+			break;
+
+			case CDCCommandHandler::srContinue:
+			break;
+		}
+	}
+
+
+	return m_state != stDetect;
+}
+
+uint32_t CDCCommandStream::GetTimeTaken(void)
+{
+	return HAL_GetTick() - m_uDispatchTime;
+}
+
+
+uint8_t	*CDCCommandStream::GetFifoWriteBuffer(void)
+{
+	uint8_t *pData = NULL;
+	if(m_uFifoUsedCount < CDC_FIFO_BUFFERS)
+	{
+		pData = m_fifoElements[m_uFifoWritePos].m_data;
+	}
+	else
+		m_bNeedsUSBResume = true;
+
+	if(!pData)
+		volatile int bp = 1;
+
+	return pData;
+}
+
+void	CDCCommandStream::ReleaseFifoWriteBuffer(uint8_t uLen)
+{
+	m_fifoElements[m_uFifoWritePos].m_uLen = uLen;
+	m_uFifoWritePos++;
+	if(m_uFifoWritePos == CDC_FIFO_BUFFERS)
+		m_uFifoWritePos = 0;
+	m_uFifoUsedCount++;
+}
+
+CDCFifoElement  *CDCCommandStream::GetFifoReadElement(void)
+{
+	CDCFifoElement *pElement = NULL;
+	if(m_uFifoUsedCount)
+		pElement = &m_fifoElements[m_uFifoReadPos];
+	return pElement;
+}
+
+void CDCCommandStream::ReleaseFifoReadElement(void)
+{
+	m_uFifoReadPos++;
+	if(m_uFifoReadPos == CDC_FIFO_BUFFERS)
+		m_uFifoReadPos = 0;
+	m_uFifoUsedCount--;
+}
+

--- a/32blit-stm32/Src/CDCCommandStream.h
+++ b/32blit-stm32/Src/CDCCommandStream.h
@@ -1,0 +1,85 @@
+/*
+ * CDCCommandStream.h
+ *
+ *  Created on: 17 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#ifndef SRC_CDCCOMMANDSTREAM_H_
+#define SRC_CDCCOMMANDSTREAM_H_
+
+#include <map>
+
+#include "CDCCommandHandler.h"
+
+// for receiving at fullspeed CDC we need as many fifo elements as the time taken in ms in the main loop
+// Also for code that does not require fast streaming this could be set to 1
+// So this will need tuning and define should come from cmake.
+
+struct CDCFifoElement
+{
+	uint8_t  m_data[64];
+	uint8_t  m_uLen = 0;
+};
+
+
+class CDCCommandStream
+{
+public:
+	CDCCommandStream() : m_uFifoReadPos(0), m_uFifoWritePos(0), m_uFifoUsedCount(0)
+	{
+		Init();
+	}
+
+	void Init(void);
+	void AddCommandHandler(CDCCommandHandler::CDCFourCC uCommand, CDCCommandHandler *pCommandHandler);
+
+
+	uint32_t GetTimeTaken(void);
+	void     Stream(void);
+	uint8_t  Stream(uint8_t *data, uint32_t len);
+
+	// USB Packet fifo
+	uint8_t					*GetFifoWriteBuffer(void);
+	void						ReleaseFifoWriteBuffer(uint8_t uLen);
+	CDCFifoElement  *GetFifoReadElement(void);
+	void 						ReleaseFifoReadElement(void);
+	bool						IsFifoFull(void)
+	{
+		return m_uFifoUsedCount==CDC_FIFO_BUFFERS;
+	}
+
+
+private:
+	typedef enum { stDetect, stDetectCommandWord, stDispatch, stProcessing, stError } StreamState;
+
+	StreamState m_state;
+
+	uint8_t			m_header[4] = { '3', '2', 'B', 'L' };
+	uint8_t			m_uHeaderScanPos = 0;
+	uint8_t			m_uCommandScanPos = 0;
+
+
+	CDCCommandHandler														*m_pCurrentCommandHandler;
+	std::map<uint32_t, CDCCommandHandler*> 	m_commandHandlers;
+
+	uint32_t m_uDispatchTime;
+
+	CDCDataStream	m_dataStream;
+
+	uint8_t m_uRetryCount = 0;
+
+
+	CDCFifoElement m_fifoElements[CDC_FIFO_BUFFERS];
+	uint8_t				 m_uFifoReadPos;
+	uint8_t				 m_uFifoWritePos;
+	uint8_t				 m_uFifoUsedCount;
+
+	bool					m_bNeedsUSBResume;
+
+
+	void 			LogTimeTaken(CDCCommandHandler::StreamResult result, uint32_t uBytesHandled);
+
+};
+
+#endif /* SRC_CDCCOMMANDSTREAM_H_ */

--- a/32blit-stm32/Src/CDCDataStream.cpp
+++ b/32blit-stm32/Src/CDCDataStream.cpp
@@ -1,0 +1,9 @@
+/*
+ * CDCDataStream.cpp
+ *
+ *  Created on: 17 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#include "CDCDataStream.h"
+

--- a/32blit-stm32/Src/CDCDataStream.h
+++ b/32blit-stm32/Src/CDCDataStream.h
@@ -1,0 +1,140 @@
+/*
+ * CDCDataStream.h
+ *
+ *  Created on: 17 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#ifndef SRC_CDCDATASTREAM_H_
+#define SRC_CDCDATASTREAM_H_
+
+#include "stm32h7xx_hal.h"
+#include <cstring>
+#include <streambuf>
+#include <istream>
+
+class CDCMemBuffer : public std::basic_streambuf<char>
+{
+public:
+	CDCMemBuffer(const uint8_t *pData, size_t uLen)
+	{
+    setg((char*)pData, (char*)pData, (char*)pData + uLen);
+  }
+
+	void SetData(const uint8_t *pData, size_t uLen)
+	{
+    setg((char*)pData, (char*)pData, (char*)pData + uLen);
+  }
+};
+
+class CDCMemoryStream : public std::istream
+{
+public:
+	CDCMemoryStream(const uint8_t *pData = NULL , size_t uLen = 0) : std::istream(&m_buffer), m_buffer(pData, uLen)
+	{
+    rdbuf(&m_buffer);
+  }
+
+	void SetData(const uint8_t *pData, size_t uLen)
+	{
+		clear();
+		m_buffer.SetData(pData, uLen);
+    rdbuf(&m_buffer);
+	}
+private:
+	CDCMemBuffer m_buffer;
+};
+
+
+class CDCDataStream
+{
+public:
+	CDCDataStream() : m_pData(NULL), m_uLen(0)
+	{
+
+	}
+
+	bool AddData(uint8_t *pData, uint32_t uLen)
+	{
+		m_pData = pData;
+		m_uLen  = uLen;
+
+		return true;
+
+	}
+
+	uint32_t GetStreamLength(void)
+	{
+		return m_uLen;
+	}
+
+
+	bool GetMemoryStream(CDCMemoryStream &ms)
+	{
+		bool bResult = false;
+
+		uint8_t *pData;
+		uint32_t uLen;
+		if(uLen)
+		{
+			ms.SetData(pData, uLen);
+			bResult = true;
+		}
+
+		return bResult;
+	}
+
+
+	bool GetStreamData(uint8_t **ppData, uint32_t *puLen)
+	{
+		bool bResult = true;
+
+		if(m_uLen)
+		{
+			*ppData = m_pData;
+			*puLen = m_uLen;
+			m_uLen = 0;
+		}
+		else
+		{
+			bResult = false;
+		}
+
+		return bResult;
+	}
+
+	bool GetDataOfLength(void *pData, uint8_t uLen)
+	{
+		bool bResult = false;
+		uint8_t *pByteData = (uint8_t *)pData;
+
+		if(m_uLen >= uLen)
+		{
+			while(uLen--)
+			{
+				bResult = true;
+				*pByteData++ = *m_pData++;
+				m_uLen--;
+			}
+		}
+
+		return bResult;
+	}
+
+	bool Get(uint32_t &uValue)
+	{
+		return GetDataOfLength(&uValue, 4);
+	}
+
+	bool Get(uint8_t &uValue)
+	{
+		return GetDataOfLength(&uValue, 1);
+	}
+
+private:
+	uint8_t		*m_pData;
+	uint32_t 	m_uLen;
+};
+
+
+#endif /* SRC_CDCDATASTREAM_H_ */

--- a/32blit-stm32/Src/CDCInfoHandler.cpp
+++ b/32blit-stm32/Src/CDCInfoHandler.cpp
@@ -1,0 +1,29 @@
+/*
+ * CDCInfoHandler.cpp
+ *
+ *  Created on: 18 Jan 2020
+ *      Author: andrewcapon
+ */
+#include "usbd_def.h"
+#include "usbd_cdc_if.h"
+
+#include "CDCInfoHandler.h"
+
+bool CDCInfoHandler::StreamInit(CDCFourCC uCommand)
+{
+	if(APPLICATION_VTOR >= 0x90000000)
+		while(USBD_BUSY == CDC_Transmit_HS((uint8_t *)"32BL_EXT", 8))
+				;
+	else
+		while(USBD_BUSY == CDC_Transmit_HS((uint8_t *)"32BL_INT", 8))
+				;
+
+	HAL_Delay(250);
+	return false;
+}
+
+
+CDCCommandHandler::StreamResult CDCInfoHandler::StreamData(CDCDataStream &dataStream)
+{
+	return srFinish;
+}

--- a/32blit-stm32/Src/CDCInfoHandler.h
+++ b/32blit-stm32/Src/CDCInfoHandler.h
@@ -1,0 +1,20 @@
+/*
+ * CDCInfoHandler.h
+ *
+ *  Created on: 18 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#ifndef SRC_CDCINFOHANDLER_H_
+#define SRC_CDCINFOHANDLER_H_
+
+#include "CDCCommandHandler.h"
+
+class CDCInfoHandler : public CDCCommandHandler
+{
+public:
+	virtual StreamResult StreamData(CDCDataStream &dataStream);
+	virtual bool StreamInit(CDCFourCC uCommand);
+};
+
+#endif /* SRC_CDCRESETHANDLER_H_ */

--- a/32blit-stm32/Src/CDCResetHandler.cpp
+++ b/32blit-stm32/Src/CDCResetHandler.cpp
@@ -1,0 +1,21 @@
+/*
+ * CDCResetHandler.cpp
+ *
+ *  Created on: 18 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#include "CDCResetHandler.h"
+
+bool CDCResetHandler::StreamInit(CDCFourCC uCommand)
+{
+	NVIC_SystemReset();
+
+	return false;
+}
+
+
+CDCCommandHandler::StreamResult CDCResetHandler::StreamData(CDCDataStream &dataStream)
+{
+	return srFinish;
+}

--- a/32blit-stm32/Src/CDCResetHandler.h
+++ b/32blit-stm32/Src/CDCResetHandler.h
@@ -1,0 +1,20 @@
+/*
+ * CDCResetHandler.h
+ *
+ *  Created on: 18 Jan 2020
+ *      Author: andrewcapon
+ */
+
+#ifndef SRC_CDCRESETHANDLER_H_
+#define SRC_CDCRESETHANDLER_H_
+
+#include "CDCCommandHandler.h"
+
+class CDCResetHandler : public CDCCommandHandler
+{
+public:
+	virtual StreamResult StreamData(CDCDataStream &dataStream);
+	virtual bool StreamInit(CDCFourCC uCommand);
+};
+
+#endif /* SRC_CDCRESETHANDLER_H_ */

--- a/32blit-stm32/Src/flash-loader.cpp
+++ b/32blit-stm32/Src/flash-loader.cpp
@@ -1,0 +1,510 @@
+#include "flash-loader.hpp"
+#include "graphics/color.hpp"
+#include <cmath>
+#include "quadspi.h"
+#include "CDCCommandStream.h"
+#include <cstring>
+#include <stdio.h>
+#include <stdlib.h>
+using namespace blit;
+
+extern QSPI_HandleTypeDef hqspi;
+extern CDCCommandStream g_commandStream;
+
+FlashLoader flashLoader;
+
+
+// c calls to c++ object
+void init()
+{
+	flashLoader.Init();
+}
+
+void render(uint32_t time)
+{
+	flashLoader.Render(time);
+}
+
+void update(uint32_t time)
+{
+	flashLoader.Update(time);
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Init() Register command handlers
+void FlashLoader::Init()
+{
+	set_screen_mode(screen_mode::hires);
+
+	// register PROG
+	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'P', 'R', 'O', 'G'>::value, this);
+
+	// register SAVE
+	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'S', 'A', 'V', 'E'>::value, this);
+
+	// register LS
+	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'_', '_', 'L', 'S'>::value, this);
+}
+
+
+// FSInit() Read a page worth of *.BIN filenames from the SDCard
+void FlashLoader::FSInit(void)
+{
+	// needed as init is called before sdcard is mounted currently.
+	m_uFileCount = 0;
+
+	volatile FRESULT fr;     /* Return value */
+	DIR dj;         /* Directory search object */
+	FILINFO fno;    /* File information */
+
+	fr = f_findfirst(&dj, &fno, "", "*.BIN");
+
+	while (fr == FR_OK && fno.fname[0] && m_uFileCount < MAX_FILENAMES)
+	{
+		if(fno.fname[0]!='.')
+		{
+			//printf("%s %lu\n\r", fno.fname, fno.fsize);
+			strncpy(m_filenames[m_uFileCount], fno.fname, MAX_FILENAME_LENGTH);
+			m_uFileCount++;
+		}
+		fr = f_findnext(&dj, &fno);
+	}
+
+	f_closedir(&dj);
+
+	m_bFsInit = true;
+}
+
+
+// Flash(): Flash a file from the SDCard to external flash
+bool FlashLoader::Flash(const char *pszFilename)
+{
+	bool bResult = false;
+
+	FIL file;
+	FRESULT res = f_open(&file, pszFilename, FA_READ);
+	if(!res)
+	{
+		// get file length
+		FSIZE_t uSize = f_size(&file);
+		FSIZE_t uTotalBytesRead = 0;
+		size_t uOffset = 0;
+
+		if(uSize)
+		{
+			// quick and dirty erase
+			QSPI_WriteEnable(&hqspi);
+			qspi_chip_erase();
+
+			bool bFinished = false;
+
+			while(!bFinished)
+			{
+				// limited ram so a bit at a time
+				UINT uBytesRead = 0;
+				res = f_read(&file, (void *)m_buffer, BUFFER_SIZE, &uBytesRead);
+
+				if(!res)
+				{
+					if(uBytesRead)
+					{
+						if(QSPI_OK == qspi_write_buffer(uOffset, m_buffer, uBytesRead))
+						{
+							if(QSPI_OK == qspi_read_buffer(uOffset, m_verifyBuffer, uBytesRead))
+							{
+								// compare buffers
+								bool bVerified = true;
+								for(uint32_t uB = 0; bVerified && uB < uBytesRead; uB++)
+									bVerified = m_buffer[uB] == m_verifyBuffer[uB];
+
+								if(bVerified)
+								{
+									uOffset += uBytesRead;
+									uTotalBytesRead += uBytesRead;
+								}
+								else
+									bFinished = true;
+							}
+							else
+								bFinished = true;
+						}
+						else
+							bFinished = true;
+					}
+
+					if(uBytesRead < BUFFER_SIZE)
+					{
+						bFinished = true;
+						bResult = uTotalBytesRead == uSize;
+					}
+				}
+				else
+					bFinished = true;
+			}
+		}
+
+		f_close(&file);
+	}
+
+	return bResult;
+}
+
+
+// Render() Call relevant render based on state
+void FlashLoader::Render(uint32_t time)
+{
+	switch(m_state)
+	{
+		case stFlashFile:
+		case stLS:
+			RenderFlashFile(time);
+			break;
+
+		case stSaveFile:
+			RenderSaveFile(time);
+			break;
+
+		case stFlashCDC:
+			RenderFlashCDC(time);
+			break;
+
+		case stSwitch:
+			blit::switch_execution();
+		break;
+	}
+}
+
+// RenderSaveFile() Render file save progress %
+void FlashLoader::RenderSaveFile(uint32_t time)
+{
+	fb.pen(rgba(0,0,0));
+  fb.rectangle(rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT));
+	fb.pen(rgba(255, 255, 255));
+	char buffer[128];
+	sprintf(buffer, "Saving %.2u%%", (uint16_t)m_fPercent);
+	fb.text(buffer, &minimal_font[0][0], ROW(0));
+}
+
+
+// RenderFlashCDC() Render flashing progress %
+void FlashLoader::RenderFlashCDC(uint32_t time)
+{
+	fb.pen(rgba(0,0,0));
+  fb.rectangle(rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT));
+	fb.pen(rgba(255, 255, 255));
+
+	char buffer[128];
+	sprintf(buffer, "Flashing %.2u%%", (uint16_t)m_fPercent);
+	fb.text(buffer, &minimal_font[0][0], ROW(0));
+}
+
+
+// RenderFlashFile() Render main ui for selecting files to flash
+void FlashLoader::RenderFlashFile(uint32_t time)
+{
+
+	static uint32_t lastButtons = 0;
+
+	if(!m_bFsInit)
+		FSInit();
+
+	uint32_t changedButtons = blit::buttons ^ lastButtons;
+
+	bool button_a = blit::buttons & changedButtons & blit::button::A;
+	bool button_up = blit::buttons & changedButtons & blit::button::DPAD_UP;
+	bool button_down = blit::buttons & changedButtons & blit::button::DPAD_DOWN;
+
+	lastButtons = blit::buttons;
+
+	fb.pen(rgba(0,0,0));
+  fb.rectangle(rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT));
+	fb.pen(rgba(255, 255, 255));
+
+	// just display
+	if(m_uFileCount)
+	{
+    fb.pen(rgba(50, 50, 70));
+    fb.rectangle(rect(0, ROW_SPACE*m_uCurrentFile, SCREEN_WIDTH, ROW_SPACE));
+    fb.pen(rgba(255, 255, 255));
+
+		for(uint8_t uF = 0; uF < m_uFileCount; uF++)
+			fb.text(m_filenames[uF], &minimal_font[0][0], ROW(uF));
+	}
+	else
+	{
+		fb.text("No Files Found.", &minimal_font[0][0], ROW(0));
+
+	}
+
+	if(button_up)
+	{
+		if(m_uCurrentFile)
+			m_uCurrentFile--;
+	}
+
+	if(button_down)
+	{
+		if(m_uCurrentFile < m_uFileCount)
+			m_uCurrentFile++;
+	}
+
+	if(button_a)
+	{
+		if(Flash(m_filenames[m_uCurrentFile]))
+			blit::switch_execution();
+	}
+}
+
+
+void FlashLoader::Update(uint32_t time)
+{
+	if(m_state == stLS)
+	{
+		FSInit();
+		m_state = stFlashFile;
+	}
+}
+
+
+
+
+//////////////////////////////////////////////////////////////////////
+// Streaming Code
+//  The streaming code works with a simple state machine,
+//  current state is in m_parseState, the states parse index is
+//  in m_uParseState
+//////////////////////////////////////////////////////////////////////
+
+// StreamInit() Initialise state machine
+bool FlashLoader::StreamInit(CDCFourCC uCommand)
+{
+	//printf("streamInit()\n\r");
+	m_fPercent = 0.0f;
+	bool bNeedStream = true;
+	switch(uCommand)
+	{
+		case CDCCommandHandler::CDCFourCCMake<'P', 'R', 'O', 'G'>::value:
+			m_state = stFlashCDC;
+			m_parseState = stFilename;
+			m_uParseIndex = 0;
+		break;
+
+		case CDCCommandHandler::CDCFourCCMake<'S', 'A', 'V', 'E'>::value:
+			m_state = stSaveFile;
+			m_parseState = stFilename;
+			m_uParseIndex = 0;
+		break;
+
+		case CDCCommandHandler::CDCFourCCMake<'_', '_', 'L', 'S'>::value:
+			m_state = stLS;
+			bNeedStream = false;
+		break;
+
+	}
+	return bNeedStream;
+}
+
+
+// FlashData() Flash data to the QSPI flash
+// Note: currently qspi_write_buffer only works for sizes of 256 max
+bool FlashLoader::FlashData(uint32_t uOffset, uint8_t *pBuffer, uint32_t uLen)
+{
+	bool bResult = false;
+	if(QSPI_OK == qspi_write_buffer(uOffset, pBuffer, uLen))
+	{
+		if(QSPI_OK == qspi_read_buffer(uOffset, m_verifyBuffer, uLen))
+		{
+			// compare buffers
+			bResult = true;
+
+			for(uint32_t uB = 0; bResult && uB < uLen; uB++)
+				bResult = pBuffer[uB] == m_verifyBuffer[uB];
+		}
+	}
+	return bResult;
+}
+
+
+// SaveData() Saves date to file on SDCard
+bool FlashLoader::SaveData(uint8_t *pBuffer, uint32_t uLen)
+{
+	UINT uWritten;
+	FRESULT res = f_write(&m_file, pBuffer, uLen, &uWritten);
+
+	return !res && (uWritten == uLen);
+
+}
+
+
+// StreamData() Handle streamed data
+// State machine has three states:
+// stFilename : Parse filename
+// stLength   : Parse length, this is sent as an ascii string
+// stData     : The binary data (.bin file)
+CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStream)
+{
+	CDCCommandHandler::StreamResult result = srContinue;
+	uint8_t byte;
+	while(dataStream.GetStreamLength() && result == srContinue)
+	{
+		switch (m_parseState)
+		{
+			case stFilename:
+				if(m_uParseIndex < MAX_FILENAME)
+				{
+					while(result == srContinue && m_parseState == stFilename && dataStream.Get(byte))
+					{
+						m_sFilename[m_uParseIndex++] = byte;
+						if (byte == 0)
+						{
+							m_parseState = stLength;
+							m_uParseIndex = 0;
+						}
+					}
+				}
+				else
+				{
+					printf("Failed to read filename\n\r");
+					result =srError;
+				}
+			break;
+
+
+			case stLength:
+				if(m_uParseIndex < MAX_FILELEN)
+				{
+					while(result == srContinue && m_parseState == stLength && dataStream.Get(byte))
+					{
+						m_sFilelen[m_uParseIndex++] = byte;
+						if (byte == 0)
+						{
+							m_parseState = stData;
+							m_uParseIndex = 0;
+							char *pEndPtr;
+							m_uFilelen = strtoul(m_sFilelen, &pEndPtr, 10);
+							if(m_uFilelen)
+							{
+								// init file or flash
+								switch(m_state)
+								{
+									case stSaveFile:
+									{
+										FRESULT res = f_open(&m_file, m_sFilename, FA_CREATE_ALWAYS | FA_WRITE);
+										if(res)
+										{
+											printf("Failed to create file (%s)\n\r", m_sFilename);
+											result = srError;
+										}
+									}
+									break;
+
+									case stFlashCDC:
+										QSPI_WriteEnable(&hqspi);
+										qspi_chip_erase();
+									break;
+
+									default:
+									break;
+								}
+							}
+							else
+							{
+								printf("Failed to parse filelen\n\r");
+								result =srError;
+							}
+						}
+					}
+				}
+				else
+				{
+					printf("Failed to read filelen\n\r");
+					result =srError;
+				}
+			break;
+
+			case stData:
+					while((result == srContinue) && (m_parseState == stData) && (m_uParseIndex <= m_uFilelen) && dataStream.Get(byte))
+					{
+						uint32_t uByteOffset = m_uParseIndex % PAGE_SIZE;
+						m_buffer[uByteOffset] = byte;
+
+						// check buffer needs writing
+						volatile uint32_t uWriteLen = 0;
+						bool bEOS = false;
+						if (m_uParseIndex == m_uFilelen-1)
+						{
+							uWriteLen = uByteOffset+1;
+							bEOS = true;
+						}
+						else
+							if(uByteOffset == PAGE_SIZE-1)
+								uWriteLen = PAGE_SIZE;
+
+						if(uWriteLen)
+						{
+							switch(m_state)
+							{
+								case stSaveFile:
+									// save data
+									if(!SaveData(m_buffer, uWriteLen))
+									{
+										printf("Failed to save to SDCard\n\r");
+										result = srError;
+									}
+
+									// end of stream close up
+									if(bEOS)
+									{
+										f_close(&m_file);
+										m_bFsInit = false;
+										m_state = stFlashFile;
+										if(result != srError)
+											result = srFinish;
+									}
+								break;
+
+								case stFlashCDC:
+								{
+									// save data
+									volatile uint32_t uPage = (m_uParseIndex / PAGE_SIZE);
+									if(!FlashData(uPage*PAGE_SIZE, m_buffer, uWriteLen))
+									{
+										printf("Failed to write to flash\n\r");
+										result = srError;
+									}
+
+									// end of stream close up
+									if(bEOS)
+									{
+										if(result != srError)
+										{
+											result = srFinish;
+											m_state = stSwitch;
+										}
+										else
+											m_state = stFlashFile;
+									}
+								}
+								break;
+
+								default:
+								break;
+							}
+						}
+
+						m_uParseIndex++;
+						m_uBytesHandled = m_uParseIndex;
+						m_fPercent = ((float)m_uParseIndex/(float)m_uFilelen)* 100.0f;
+					}
+			break;
+		}
+	}
+
+	if(result==srError)
+		m_state = stFlashFile;
+
+	return result;
+}
+

--- a/32blit-stm32/Src/flash-loader.hpp
+++ b/32blit-stm32/Src/flash-loader.hpp
@@ -1,0 +1,63 @@
+#include "32blit.hpp"
+#include "CDCCommandHandler.h"
+#include "fatfs.h"
+
+#define SCREEN_WIDTH 320
+#define SCREEN_HEIGHT 240
+#define BUFFER_SIZE (256)
+#define MAX_FILENAMES 30
+#define MAX_FILENAME_LENGTH 32
+#define ROW_SPACE 10
+#define ROW(x) point(0,x * ROW_SPACE)
+#define MAX_FILENAME 256+1
+#define MAX_FILELEN 5+1
+#define PAGE_SIZE 256
+
+class FlashLoader : public CDCCommandHandler
+{
+public:
+	virtual StreamResult StreamData(CDCDataStream &dataStream);
+	virtual bool StreamInit(CDCFourCC uCommand);
+
+
+	void Init(void);
+	void Render(uint32_t time);
+	void Update(uint32_t time);
+
+private:
+	typedef enum {stFlashFile, stSaveFile, stFlashCDC, stLS, stSwitch} State;
+	typedef enum {stFilename, stLength, stData} ParseState;
+
+	bool Flash(const char *pszFilename);
+	void FSInit(void);
+
+	void RenderSaveFile(uint32_t time);
+	void RenderFlashCDC(uint32_t time);
+	void RenderFlashFile(uint32_t time);
+
+	bool FlashData(uint32_t uOffset, uint8_t *pBuffer, uint32_t uLen);
+	bool SaveData(uint8_t *pBuffer, uint32_t uLen);
+
+	char 		m_filenames[MAX_FILENAMES][MAX_FILENAME_LENGTH+1] = {0};
+
+	uint8_t m_buffer[PAGE_SIZE];
+	uint8_t m_verifyBuffer[PAGE_SIZE];
+
+	uint8_t m_uFileCount = 0;
+	uint8_t m_uCurrentFile = 0;
+	bool		m_bFsInit = false;
+	State		m_state = stFlashFile;
+
+	ParseState m_parseState = stFilename;
+
+	char m_sFilename[MAX_FILENAME];
+	char m_sFilelen[MAX_FILELEN];
+
+	uint32_t m_uParseIndex = 0;
+	uint32_t m_uFilelen = 0;
+
+	FIL m_file;
+
+	float m_fPercent;
+
+};

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -39,6 +39,10 @@
 #include "32blit.h"
 #include "32blit.hpp"
 #include "graphics/color.hpp"
+#include "CDCResetHandler.h"
+#include "CDCInfoHandler.h"
+#include "CDCCommandStream.h"
+
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -58,6 +62,9 @@
 /* Private variables ---------------------------------------------------------*/
 
 /* USER CODE BEGIN PV */
+extern CDCCommandStream g_commandStream;
+CDCResetHandler g_resetHandler;
+CDCInfoHandler g_infoHandler;
 
 /* USER CODE END PV */
 
@@ -69,7 +76,6 @@ void SystemClock_Config(void);
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
-
 /* USER CODE END 0 */
 
 /**
@@ -113,7 +119,9 @@ int main(void)
   MX_HRTIM_Init();
   MX_I2C4_Init();
   MX_LTDC_Init();
+#if (INITIALISE_QSPI==1)
   MX_QUADSPI_Init();
+#endif
   MX_ADC1_Init();
   MX_ADC3_Init();
   //MX_USB_OTG_HS_USB_Init();
@@ -126,9 +134,16 @@ int main(void)
   MX_RNG_Init();
   MX_USB_DEVICE_Init();
   /* USER CODE BEGIN 2 */
-  blit_clear_framebuffer();
-  blit_init();
 
+#if (INITIALISE_QSPI==1)
+  qspi_init();
+#endif
+
+  blit_init();
+  blit_clear_framebuffer();
+
+
+  // card needs to be mounted in init
   char sd_card_label[12];
   uint32_t freespace = 0;
   uint32_t totalspace = 0;
@@ -141,6 +156,13 @@ int main(void)
       blit_enable_dac();
     }
   }
+
+  // add CDC handler to reset device on receiving "_RST"
+	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'_', 'R', 'S', 'T'>::value, &g_resetHandler);
+
+  // add CDC handler to log info device on receiving "INFO"
+	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'I', 'N', 'F', 'O'>::value, &g_infoHandler);
+
   /* USER CODE END 2 */
 
   /* Infinite loop */
@@ -156,6 +178,9 @@ int main(void)
     }
 
     blit_tick();
+
+    // handle CDC input
+    g_commandStream.Stream();
 
     uint32_t t_elapsed = blit::now() - t_start;
     /* USER CODE END WHILE */

--- a/32blit-stm32/Src/quadspi.c
+++ b/32blit-stm32/Src/quadspi.c
@@ -21,7 +21,6 @@
 #include "quadspi.h"
 
 /* USER CODE BEGIN 0 */
-
 /* USER CODE END 0 */
 
 QSPI_HandleTypeDef hqspi;
@@ -31,7 +30,7 @@ void MX_QUADSPI_Init(void)
 {
 
   hqspi.Instance = QUADSPI;
-  hqspi.Init.ClockPrescaler = 128;
+  hqspi.Init.ClockPrescaler = 5;
   hqspi.Init.FifoThreshold = 1;
   hqspi.Init.SampleShifting = QSPI_SAMPLE_SHIFTING_NONE;
   hqspi.Init.FlashSize = QSPI_FLASH_SIZE;
@@ -136,7 +135,7 @@ void HAL_QSPI_MspDeInit(QSPI_HandleTypeDef* qspiHandle)
   * @param  hqspi: QSPI handle
   * @retval None
   */
-static void QSPI_WriteEnable(QSPI_HandleTypeDef *hqspi)
+void QSPI_WriteEnable(QSPI_HandleTypeDef *hqspi)
 {
     QSPI_CommandTypeDef     sCommand;
     QSPI_AutoPollingTypeDef sConfig;
@@ -175,7 +174,7 @@ static void QSPI_WriteEnable(QSPI_HandleTypeDef *hqspi)
     }
 }
 
-static uint8_t QSPI_AutoPollingMemReady(QSPI_HandleTypeDef *hqspi, uint32_t Timeout)
+static HAL_StatusTypeDef QSPI_AutoPollingMemReady(QSPI_HandleTypeDef *hqspi, uint32_t Timeout)
 {
     QSPI_CommandTypeDef     s_command;
     QSPI_AutoPollingTypeDef s_config;
@@ -198,12 +197,9 @@ static uint8_t QSPI_AutoPollingMemReady(QSPI_HandleTypeDef *hqspi, uint32_t Time
     s_config.Mask            = 0x01;
     s_config.StatusBytesSize = 1;
 
-    if (HAL_QSPI_AutoPolling(hqspi, &s_command, &s_config, Timeout) != HAL_OK)
-    {
-        Error_Handler();
-    }
+    HAL_StatusTypeDef status = HAL_QSPI_AutoPolling(hqspi, &s_command, &s_config, Timeout);
 
-    return QSPI_OK;
+    return status;
 }
 
 /**
@@ -369,17 +365,13 @@ HAL_StatusTypeDef qspi_write_buffer(size_t offset, const uint8_t* buffer, size_t
     s_command.Address     = offset;
     s_command.NbData      = length;
 
-    if ((status = HAL_QSPI_Command(&hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)) != HAL_OK)
+    if ((status = HAL_QSPI_Command(&hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)) == HAL_OK)
     {
-        Error_Handler();
+    	if ((status = HAL_QSPI_Transmit(&hqspi, (uint8_t *)buffer, HAL_QPSI_TIMEOUT_DEFAULT_VALUE )) == HAL_OK)
+    	{
+        status = QSPI_AutoPollingMemReady(&hqspi, HAL_QPSI_TIMEOUT_DEFAULT_VALUE);
+    	}
     }
-
-    if ((status = HAL_QSPI_Transmit(&hqspi, buffer, HAL_QPSI_TIMEOUT_DEFAULT_VALUE )) != HAL_OK)
-    {
-        Error_Handler();
-    }
-
-    status = QSPI_AutoPollingMemReady(&hqspi, HAL_QPSI_TIMEOUT_DEFAULT_VALUE);
 
     return status;
 }
@@ -404,15 +396,12 @@ HAL_StatusTypeDef qspi_read_buffer(size_t address, const uint8_t* buffer, size_t
     s_command.Address     = address;
     s_command.NbData      = length;
 
-    if ((status = HAL_QSPI_Command(&hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)) != HAL_OK) {
-        Error_Handler();
+    if ((status = HAL_QSPI_Command(&hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)) == HAL_OK)
+    {
+    	status = HAL_QSPI_Receive(&hqspi, (uint8_t *)buffer, HAL_QPSI_TIMEOUT_DEFAULT_VALUE);
     }
 
-    if ((status = HAL_QSPI_Receive(&hqspi, buffer, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)) != HAL_OK) {
-        Error_Handler();
-    }
-
-    return QSPI_OK;
+    return status;
 }
 
 static HAL_StatusTypeDef qspi_enable_quad(QSPI_HandleTypeDef *hqspi)
@@ -471,10 +460,17 @@ HAL_StatusTypeDef qspi_enable_memorymapped_mode(void)
     return QSPI_OK;
 }
 
+// for some godforsaken reason if this is optimised in any way when returning from the function
+// it jumps off into the normal SPI code!
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
 int qspi_init(void) {
   qspi_reset(&hqspi);
   qspi_enable_quad(&hqspi);
+  return(0);
 }
+#pragma GCC pop_options
+
 /* USER CODE END 1 */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/32blit-stm32/Src/system_stm32h7xx.c
+++ b/32blit-stm32/Src/system_stm32h7xx.c
@@ -227,7 +227,7 @@ void SystemInit (void)
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal D1 AXI-RAM */
 #else
-  SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  SCB->VTOR = APPLICATION_VTOR | VECT_TAB_OFFSET; /* Vector Table Relocation set by APPLICATION_VTOR */
 #endif
 
 #endif /*DUAL_CORE && CORE_CM4*/

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -12,8 +12,9 @@ namespace blit {
   void (*set_screen_mode)(screen_mode new_mode) = nullptr;
   uint32_t (*now)()                             = nullptr;
   uint32_t (*random)()                          = nullptr;
-  void (*debug)(std::string message) = nullptr;
+  void (*debug)(std::string message) 								= nullptr;
   int  (*debugf)(const char * psFormatString, ...) 	= nullptr;
+  void (*switch_execution)()												= nullptr;
 
   surface null_surface(nullptr, pixel_format::RGB565, size(0, 0));
   surface &fb = null_surface;

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -22,6 +22,7 @@ namespace blit {
   extern int      (*debugf)           (const char * psFormatString, ...);
   extern uint32_t (*read_file)        (std::string file, uint32_t offset, uint32_t length, uint8_t* buffer);
   extern void     (*reset)            ();
+  extern void			(*switch_execution) ();
 
   bool tick(uint32_t time);
   void fast_tick(uint32_t time);

--- a/32blitEXT.toolchain
+++ b/32blitEXT.toolchain
@@ -9,7 +9,7 @@ set(CMAKE_RANLIB arm-none-eabi-gcc-ranlib CACHE PATH "Path to ranlib")
 set(CMAKE_AR arm-none-eabi-gcc-ar CACHE PATH "Path to ar")
 set(CMAKE_DFU "${CMAKE_CURRENT_LIST_DIR}/tools/dfu" CACHE PATH "Path to DFU builder")
 
-set(MCU_LINKER_SCRIPT STM32H750VBTx_FLASH.ld)
+set(MCU_LINKER_SCRIPT STM32H750VBTxEXT_FLASH.ld)
 set(MCU_ARCH cortex-m7)
 set(MCU_FLOAT_ABI hard)
 set(MCU_FPU fpv5-d16)
@@ -19,13 +19,12 @@ if (MCU_FLOAT_ABI STREQUAL hard)
     set(MCU_FLAGS "${MCU_FLAGS} -mfpu=${MCU_FPU}")
 endif ()
 
-set(APPLICATION_VTOR 0x08000000)
-set(EXTERNAL_LOAD_ADDRESS 0x90000000)
-set(INITIALISE_QSPI 1)
+set(APPLICATION_VTOR 0x90000000)
+set(EXTERNAL_LOAD_ADDRESS 0x08000000)
+set(INITIALISE_QSPI 0)
 set(CDC_FIFO_BUFFERS 2)
 
-
-set(COMMON_FLAGS "${MCU_FLAGS} -O0 -g -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Wno-unused-variable -Wno-write-strings")
+set(COMMON_FLAGS "${MCU_FLAGS} -O3 -g -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Wno-unused-variable -Wno-write-strings")
 
 set(CMAKE_C_FLAGS_INIT "${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS} -fpermissive")


### PR DESCRIPTION
Notes
=====

Sorry, I tried to get the flash-loader going as an example via CMake and failed miserably.
So currently it is being built by the makefile in 32blit-stm32



Overview
========

Consists of three parts:

1. Ability to switch execution between internal and external flash

2. Generalised command handling via CDC streaming.
	There is a single CDCCommandStream hanging off of the CDC receive via a FIFO.
	There can be many CDCCommandHandlers registered with the CDCCommandStream with a FourCC key.
	A CDCCommandHandler can register more that 1 FourCC key.
	The CDCCommandStream parses the incoming data and dispatches a CDCDataStream to the registered CDCCommandHandler

	User code needs placing in a subclass of CDCCommandHandler and implements StreamData() and StreamInit()
	In StreamInit() return true if more data is expected, otherwise false for non streaming commands.
	In StreamData() return a StreamResult, currently implemented:
		srError 	: Somethings gone wrong
		srContinue	: Everything fine but need more data
		srFinish	: Everything fine and finished with stream.

	For examples of simple non streaming commands see CDCInfoHandler and CDCResetHandler.
	For an example of streaming commands see the flash-loader.

3. flash-loader example
	Simple example flash loader
		Display list of bin files on SDCard (just one page), program external flash and run.
		Switch between running loader and app from "System Menu"
		Save bin files to SDCard over CDC
		Program external flash over CDC.


Changes
=======

Changed 32blit.toolchain
	Added variables needed for switching execution and CDC Fifo Buffering

Added 	32blitEXT.toolchain
	Use this toolchain to build for external flash

Changed Engine.hpp and Engine.cpp
	Added code to switch execution

Changed 32blit-stm32/CMakeLists.txt
	Added ccsbcs.c for unicode/ascii
	Added CDC source files
	Added defines for toolchain variables
	Added more Elf info displayed when building

Changed 32blit-stm32/Makefile
	flash-Loader is being built here, sorry I tried looking
	at getting this going via Make but after a couple of hours gave up
	someone that knows about make will need to work this out.

Changed 32blit-stm32/STM32H750VBTx_FLASH.ld
	Increase heap slightly

Added	32blit-stm32/STM32H750VBTxEXT_FLASH.ld
	ld for linking against EXT flash

Changed 32blit.h and 32blit.c
	added blit_switch_executable
	added code to disable ADC, used when transferring data via CDC
	there is an issue in the ADC polling code where it can fail on the second channel read
	causing a long delay/hang. Someone needs to look at this.

changed ffconf.h
	enable findfile and LFN

Changed quadspi.h and quadspi.c
	set QSPI_FLASH_SIZE correctly
	make QSPI_WriteEnable() and qspi_chip_erase() public.
	Set clockPrescaler to 5
	Return status in some functions
	Disable optimisations for qspi_init() as this was causing issues!


Added 	CDCCommandHandler.cpp
	CDCCommandHandler.h
	CDCCommandStream.cpp
	CDCCommandStream.h
	CDCDataStream.cpp
	CDCDataStream.h
		CDC streaming infrastructure.

	CDCInfoHandler.cpp
	CDCInfoHandler.h
		Used to probe 32Blit to see if CDC working and where code is running

	CDCResetHandler.cpp
	CDCResetHandler.h
		Used to reset the 32Blit

Added 	flash-loader.h and flash-loader.cpp
	The simple flash loader
	Handles CDC SAVE and CDC PROG
	simple screen of bin files on SDCard to program

Changed main.c
	Added g_commandStream global for CDC streaming
	Use INITIALISE_QSPI define to init qspi
	Add command handlers for _RST and INFO
	Call Stream() in main loop to handle buffered usb data.

Changed system_stm32h7xx.c
	use APPLICATION_VTOR define to set VTOR

Changed usbd_cdc_if.c
	Use g_commandStream and Fifo fo receiving CDC USB data.


	
	
