### PR TITLE
Add CMakeLists.txt for timer-test

### DIFF
--- a/examples/timer-test/CMakeLists.txt
+++ b/examples/timer-test/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+project (timer-test)
+include (../../32blit.cmake)
+blit_executable (timer-test timer-test.cpp)


### PR DESCRIPTION
Adds the missing `CMakeLists.txt` file for the `timer-test` example.