### PR TITLE
Improve tga functions

### DIFF
--- a/32blit/engine/utility.cpp
+++ b/32blit/engine/utility.cpp
@@ -20,7 +20,7 @@ namespace utility {
     FILE_READ_ERROR = -3,
   };
 
-  tga tga_header(std::string file) {
+  tga tga_header(const std::string & file) {
     FILE *fp = fopen(file.c_str(), "rb");
 
     tga tga;
@@ -29,7 +29,7 @@ namespace utility {
     return tga;
   }
   
-  int8_t tga_load(std::string file, void *data, bool auto_alpha) {
+  int8_t tga_load(const std::string & file, void *data, bool auto_alpha) {
     FILE *fp = fopen(file.c_str(), "rb");
 
     tga tga;
@@ -112,7 +112,7 @@ namespace utility {
     return tga_status::OK;
   }
 
-  int8_t map_load(std::string file, uint8_t *data) {
+  int8_t map_load(const std::string & file, uint8_t *data) {
     FILE *fp = fopen(file.c_str(), "rb");
 
     uint8_t width, height;

--- a/32blit/engine/utility.cpp
+++ b/32blit/engine/utility.cpp
@@ -20,8 +20,8 @@ namespace utility {
     FILE_READ_ERROR = -3,
   };
 
-  tga tga_header(const std::string & file) {
-    FILE *fp = fopen(file.c_str(), "rb");
+  tga tga_header(const char * file) {
+    FILE *fp = fopen(file, "rb");
 
     tga tga;
     fread((void *)&tga, sizeof(tga), 1, fp);
@@ -29,8 +29,8 @@ namespace utility {
     return tga;
   }
   
-  int8_t tga_load(const std::string & file, void *data, bool auto_alpha) {
-    FILE *fp = fopen(file.c_str(), "rb");
+  int8_t tga_load(const char * file, void *data, bool auto_alpha) {
+    FILE *fp = fopen(file, "rb");
 
     tga tga;
     fread((void *)&tga, sizeof(tga), 1, fp);
@@ -112,8 +112,8 @@ namespace utility {
     return tga_status::OK;
   }
 
-  int8_t map_load(const std::string & file, uint8_t *data) {
-    FILE *fp = fopen(file.c_str(), "rb");
+  int8_t map_load(const char * file, uint8_t *data) {
+    FILE *fp = fopen(file, "rb");
 
     uint8_t width, height;
     fread((void *)&width, sizeof(width), 1, fp);
@@ -195,5 +195,17 @@ namespace utility {
     return tga_status::OK;*/
 
     return 1;
+  }
+
+  tga     tga_header(const std::string & file) {
+    return tga_header(file.c_str());
+  }
+  
+  int8_t  tga_load(const std::string & file, void *data, bool auto_alpha) {
+    return tga_load(file.c_str(), data, auto_alpha);
+  }
+  
+  int8_t  map_load(const std::string & file, uint8_t *data) {
+    return map_load(file.c_str(), data);
   }
 }

--- a/32blit/engine/utility.hpp
+++ b/32blit/engine/utility.hpp
@@ -21,6 +21,10 @@ namespace utility {
   };
   #pragma pack(pop)
   
+  tga     tga_header(const char * file);
+  int8_t  tga_load(const char * file, void *data, bool auto_alpha);
+  int8_t  map_load(const char * file, uint8_t *data);
+
   tga     tga_header(const std::string & file);
   int8_t  tga_load(const std::string & file, void *data, bool auto_alpha);
   int8_t  map_load(const std::string & file, uint8_t *data);

--- a/32blit/engine/utility.hpp
+++ b/32blit/engine/utility.hpp
@@ -20,9 +20,9 @@ namespace utility {
     uint8_t   descriptor;
   };
   #pragma pack(pop)
-
-  tga     tga_header(std::string file);
-  int8_t  tga_load(std::string file, void *data, bool auto_alpha);
-  int8_t  map_load(std::string file, uint8_t *data);
+  
+  tga     tga_header(const std::string & file);
+  int8_t  tga_load(const std::string & file, void *data, bool auto_alpha);
+  int8_t  map_load(const std::string & file, uint8_t *data);
   
 }


### PR DESCRIPTION
Two simple changes that should help to avoid dynamic allocation and string copying when using the TGA-related functions.