### PR TITLE
Avoid unwanted bleeping

### DIFF
--- a/32blit/engine/audio.cpp
+++ b/32blit/engine/audio.cpp
@@ -88,12 +88,16 @@ namespace blit {
           } else {
             // sustain phase
             channel.adsr = channel.sustain;
-          }  
+          }
+
+          if((channel.time_ms >> 16) < channel.attack_ms + channel.decay_ms)
+            channel.time_ms += frame_ms;
         }else{
           if((channel.time_ms >> 16) < channel.release_ms) {
             // release phase
             uint32_t release = channel.time_ms / channel.release_ms;
             channel.adsr = channel.sustain - ((channel.sustain * release) >> 16);
+            channel.time_ms += frame_ms;
           }
         }      
 
@@ -104,8 +108,6 @@ namespace blit {
 
         // combine channel sample into the final sample
         sample += channel_sample;     
-
-        channel.time_ms += frame_ms;          
       }
 
       // copy the current gate value into the status flags

--- a/32blit/engine/audio.cpp
+++ b/32blit/engine/audio.cpp
@@ -93,7 +93,7 @@ namespace blit {
           if((channel.time_ms >> 16) < channel.attack_ms + channel.decay_ms)
             channel.time_ms += frame_ms;
         }else{
-          if((channel.time_ms >> 16) < channel.release_ms) {
+          if((channel.time_ms >> 16) < channel.release_ms && channel.adsr) {
             // release phase
             uint32_t release = channel.time_ms / channel.release_ms;
             channel.adsr = channel.sustain - ((channel.sustain * release) >> 16);


### PR DESCRIPTION
First one is every 65535ms in scrolly-tile after jumping at least once, second is when audio-test starts.