### PR TITLE
Audio Improvements

### DIFF
--- a/32blit/engine/audio.cpp
+++ b/32blit/engine/audio.cpp
@@ -9,7 +9,6 @@
 namespace blit {
 
   uint32_t sample_rate = 22050;
-  uint32_t frame_ms = (1000 << 16) / 22050;
 
   uint16_t volume = 0xffff;
   const int16_t sine_waveform[256] = {0,804,1608,2411,3212,4011,4808,5602,6393,7180,7962,8740,9512,10279,11039,11793,12540,13279,14010,14733,15447,16151,16846,17531,18205,18868,19520,20160,20788,21403,22006,22595,23170,23732,24279,24812,25330,25833,26320,26791,27246,27684,28106,28511,28899,29269,29622,29957,30274,30572,30853,31114,31357,31581,31786,31972,32138,32286,32413,32522,32610,32679,32729,32758,32767,32758,32729,32679,32610,32522,32413,32286,32138,31972,31786,31581,31357,31114,30853,30572,30274,29957,29622,29269,28899,28511,28106,27684,27246,26791,26320,25833,25330,24812,24279,23732,23170,22595,22006,21403,20788,20160,19520,18868,18205,17531,16846,16151,15447,14733,14010,13279,12540,11793,11039,10279,9512,8740,7962,7180,6393,5602,4808,4011,3212,2411,1608,804,0,-804,-1608,-2411,-3212,-4011,-4808,-5602,-6393,-7180,-7962,-8740,-9512,-10279,-11039,-11793,-12540,-13279,-14010,-14733,-15447,-16151,-16846,-17531,-18205,-18868,-19520,-20160,-20788,-21403,-22006,-22595,-23170,-23732,-24279,-24812,-25330,-25833,-26320,-26791,-27246,-27684,-28106,-28511,-28899,-29269,-29622,-29957,-30274,-30572,-30853,-31114,-31357,-31581,-31786,-31972,-32138,-32286,-32413,-32522,-32610,-32679,-32729,-32758,-32768,-32758,-32729,-32679,-32610,-32522,-32413,-32286,-32138,-31972,-31786,-31581,-31357,-31114,-30853,-30572,-30274,-29957,-29622,-29269,-28899,-28511,-28106,-27684,-27246,-26791,-26320,-25833,-25330,-24812,-24279,-23732,-23170,-22595,-22006,-21403,-20788,-20160,-19520,-18868,-18205,-17531,-16846,-16151,-15447,-14733,-14010,-13279,-12540,-11793,-11039,-10279,-9512,-8740,-7962,-7180,-6393,-5602,-4808,-4011,-3212,-2411,-1608,-804};
@@ -29,6 +28,23 @@ namespace blit {
       if(channel.adsr_phase == ADSRPhase::OFF) {
         continue;
       }
+
+      if ((channel.adsr_frame >= channel.adsr_end_frame) && (channel.adsr_phase != ADSRPhase::SUSTAIN)) {
+        switch (channel.adsr_phase) {
+          case ADSRPhase::ATTACK:
+            channel.trigger_decay();
+            break;
+          case ADSRPhase::DECAY:
+            channel.trigger_sustain();
+            break;
+          case ADSRPhase::RELEASE:
+            channel.off();
+            break;
+        }
+      }
+ 
+      channel.adsr += channel.adsr_step;
+      channel.adsr_frame++;
 
       if(channel.waveform_offset & 0xfffff000) {
         // if the waveform offset overflows then generate a new
@@ -72,71 +88,17 @@ namespace blit {
           channel_sample += sine_waveform[channel.waveform_offset >> 8];
         }
 
-        switch(channel.adsr_phase) {
-          case ADSRPhase::ATTACK:
-            if(channel.adsr_phase_ms < channel.attack_ms) {
-              channel.adsr = channel.adsr_phase_ms / channel.attack_ms;
-            } else {
-              channel.trigger_decay();
-            }
-            break;
-          case ADSRPhase::DECAY:
-            if(channel.adsr_phase_ms < channel.decay_ms) {
-              uint32_t decay = channel.adsr_phase_ms / channel.decay_ms;
-              channel.adsr = 0xffff - (((0xffff - channel.sustain) * decay) >> 16);
-            } else {
-              channel.trigger_sustain();
-            }
-            break;
-          case ADSRPhase::SUSTAIN:
-            channel.adsr = channel.sustain;
-            break;
-          case ADSRPhase::RELEASE:
-            if(channel.adsr_phase_ms < channel.decay_ms) {
-              uint32_t release = channel.adsr_phase_ms / channel.release_ms;
-              channel.adsr = channel.sustain - ((channel.sustain * release) >> 16);
-            }
-            else{
-              channel.off();
-            }
-            break;
-        }
-/*
-        if(channel.gate) {
-          if((channel.time_ms >> 16) < channel.attack_ms) {
-            // attack phase
-            //channel.adsr = (((channel.time_ms / channel.attack_ms) * (0xffff - channel.attack_start_adsr)) >> 16) + channel.attack_start_adsr; // (Q16)
-            channel.adsr = channel.time_ms / channel.attack_ms;
-          } else if((channel.time_ms >> 16) < (channel.attack_ms + channel.decay_ms)) {
-            // decay phase
-            uint32_t decay = (channel.time_ms - (channel.attack_ms << 16)) / channel.decay_ms;
-            channel.adsr = 0xffff - (((0xffff - channel.sustain) * decay) >> 16);
-          } else {
-            // sustain phase
-            channel.adsr = channel.sustain;
-          }  
-        }else{
-          if((channel.time_ms >> 16) < channel.release_ms) {
-            // release phase
-            uint32_t release = channel.time_ms / channel.release_ms;
-            channel.adsr = channel.sustain - ((channel.sustain * release) >> 16);
-          }
-        }
-*/
-
-        channel_sample = (channel_sample * channel.adsr) >> 16;
+        channel_sample = (channel_sample * int32_t(channel.adsr >> 8)) >> 16;
 
         // apply channel volume
-        channel_sample = (channel_sample * channel.volume) >> 16;
+        channel_sample = (channel_sample * int32_t(channel.volume)) >> 16;
 
         // combine channel sample into the final sample
         sample += channel_sample;
-
-        channel.adsr_phase_ms += frame_ms;
       }
     }
 
-    sample = (sample * volume) >> 16;
+    sample = (sample * int32_t(volume)) >> 16;
 
     // clip result to 16-bit and convert to unsigned
     sample = sample <= -0x7fff ? -0x7fff : (sample > 0x7fff ? 0x7fff : sample);      

--- a/32blit/engine/audio.cpp
+++ b/32blit/engine/audio.cpp
@@ -12,7 +12,7 @@ namespace blit {
   uint32_t frame_ms = (1000 << 16) / 22050;
 
   uint16_t volume = 0xffff;
-  int16_t sine_voice[256] = {0,804,1608,2411,3212,4011,4808,5602,6393,7180,7962,8740,9512,10279,11039,11793,12540,13279,14010,14733,15447,16151,16846,17531,18205,18868,19520,20160,20788,21403,22006,22595,23170,23732,24279,24812,25330,25833,26320,26791,27246,27684,28106,28511,28899,29269,29622,29957,30274,30572,30853,31114,31357,31581,31786,31972,32138,32286,32413,32522,32610,32679,32729,32758,32767,32758,32729,32679,32610,32522,32413,32286,32138,31972,31786,31581,31357,31114,30853,30572,30274,29957,29622,29269,28899,28511,28106,27684,27246,26791,26320,25833,25330,24812,24279,23732,23170,22595,22006,21403,20788,20160,19520,18868,18205,17531,16846,16151,15447,14733,14010,13279,12540,11793,11039,10279,9512,8740,7962,7180,6393,5602,4808,4011,3212,2411,1608,804,0,-804,-1608,-2411,-3212,-4011,-4808,-5602,-6393,-7180,-7962,-8740,-9512,-10279,-11039,-11793,-12540,-13279,-14010,-14733,-15447,-16151,-16846,-17531,-18205,-18868,-19520,-20160,-20788,-21403,-22006,-22595,-23170,-23732,-24279,-24812,-25330,-25833,-26320,-26791,-27246,-27684,-28106,-28511,-28899,-29269,-29622,-29957,-30274,-30572,-30853,-31114,-31357,-31581,-31786,-31972,-32138,-32286,-32413,-32522,-32610,-32679,-32729,-32758,-32768,-32758,-32729,-32679,-32610,-32522,-32413,-32286,-32138,-31972,-31786,-31581,-31357,-31114,-30853,-30572,-30274,-29957,-29622,-29269,-28899,-28511,-28106,-27684,-27246,-26791,-26320,-25833,-25330,-24812,-24279,-23732,-23170,-22595,-22006,-21403,-20788,-20160,-19520,-18868,-18205,-17531,-16846,-16151,-15447,-14733,-14010,-13279,-12540,-11793,-11039,-10279,-9512,-8740,-7962,-7180,-6393,-5602,-4808,-4011,-3212,-2411,-1608,-804};
+  const int16_t sine_waveform[256] = {0,804,1608,2411,3212,4011,4808,5602,6393,7180,7962,8740,9512,10279,11039,11793,12540,13279,14010,14733,15447,16151,16846,17531,18205,18868,19520,20160,20788,21403,22006,22595,23170,23732,24279,24812,25330,25833,26320,26791,27246,27684,28106,28511,28899,29269,29622,29957,30274,30572,30853,31114,31357,31581,31786,31972,32138,32286,32413,32522,32610,32679,32729,32758,32767,32758,32729,32679,32610,32522,32413,32286,32138,31972,31786,31581,31357,31114,30853,30572,30274,29957,29622,29269,28899,28511,28106,27684,27246,26791,26320,25833,25330,24812,24279,23732,23170,22595,22006,21403,20788,20160,19520,18868,18205,17531,16846,16151,15447,14733,14010,13279,12540,11793,11039,10279,9512,8740,7962,7180,6393,5602,4808,4011,3212,2411,1608,804,0,-804,-1608,-2411,-3212,-4011,-4808,-5602,-6393,-7180,-7962,-8740,-9512,-10279,-11039,-11793,-12540,-13279,-14010,-14733,-15447,-16151,-16846,-17531,-18205,-18868,-19520,-20160,-20788,-21403,-22006,-22595,-23170,-23732,-24279,-24812,-25330,-25833,-26320,-26791,-27246,-27684,-28106,-28511,-28899,-29269,-29622,-29957,-30274,-30572,-30853,-31114,-31357,-31581,-31786,-31972,-32138,-32286,-32413,-32522,-32610,-32679,-32729,-32758,-32768,-32758,-32729,-32679,-32610,-32522,-32413,-32286,-32138,-31972,-31786,-31581,-31357,-31114,-30853,-30572,-30274,-29957,-29622,-29269,-28899,-28511,-28106,-27684,-27246,-26791,-26320,-25833,-25330,-24812,-24279,-23732,-23170,-22595,-22006,-21403,-20788,-20160,-19520,-18868,-18205,-17531,-16846,-16151,-15447,-14733,-14010,-13279,-12540,-11793,-11039,-10279,-9512,-8740,-7962,-7180,-6393,-5602,-4808,-4011,-3212,-2411,-1608,-804};
 
   AudioChannel channels[CHANNEL_COUNT];
 
@@ -21,61 +21,87 @@ namespace blit {
 
     for(auto &channel : channels) {
 
-      // increment the voice position counter. this provides an 
+      // increment the waveform position counter. this provides an 
       // Q16 fixed point value representing how far through 
-      // the current voice pattern we are
-      channel.voice_offset += ((channel.frequency * 256) << 8) / sample_rate;
+      // the current waveform we are
+      channel.waveform_offset += ((channel.frequency * 256) << 8) / sample_rate;
 
-      if(channel.voice_offset & 0xfffff000) {
-        // if the voice offset overflows then generate a new random
-        // noise sample
+      if(channel.adsr_phase == ADSRPhase::OFF) {
+        continue;
+      }
+
+      if(channel.waveform_offset & 0xfffff000) {
+        // if the waveform offset overflows then generate a new
+        // random noise sample
         channel.noise = (rand() & 0xffff) - (0xffff >> 1); 
       }
 
-      channel.voice_offset &= 0xffff;
+      channel.waveform_offset &= 0xffff;
 
-      // gate bit has changed, reset note timer
-      if((channel.flags & 0b1) != (channel.gate & 0b1)) {
-        channel.time_ms = 0;
-
-        channel.attack_start_adsr = channel.adsr;
-      }        
-
-      // check if any voices are active for this channel
-      if(channel.voices) {
+      // check if any waveforms are active for this channel
+      if(channel.waveforms) {
         int64_t channel_sample = 0;
-                
-        
-        if(channel.voices & AudioVoice::NOISE) {
+
+        if(channel.waveforms & Waveform::NOISE) {
           //channel_sample += (channel.noise - 0x7fff) >> 2;
           channel_sample += channel.noise;
         }
 
-        if(channel.voices & AudioVoice::SAW) {
-          channel_sample += (int32_t)channel.voice_offset - 0x7fff;
+        if(channel.waveforms & Waveform::SAW) {
+          channel_sample += (int32_t)channel.waveform_offset - 0x7fff;
         }
 
-        if(channel.voices & AudioVoice::TRIANGLE) {
-          if(channel.voice_offset < 0x3fff) {
-            channel_sample += channel.voice_offset * 2;
-          } else if(channel.voice_offset < 0xbfff) {
-            channel_sample += (int32_t)0x7fff - (((int32_t)channel.voice_offset - 0x3fff) * 2);              
+        if(channel.waveforms & Waveform::TRIANGLE) {
+          if(channel.waveform_offset < 0x3fff) {
+            channel_sample += channel.waveform_offset * 2;
+          } else if(channel.waveform_offset < 0xbfff) {
+            channel_sample += (int32_t)0x7fff - (((int32_t)channel.waveform_offset - 0x3fff) * 2);              
           } else {
-            channel_sample += -(int32_t)0x7fff + (((int32_t)channel.voice_offset - 0xbfff) * 2);              
+            channel_sample += -(int32_t)0x7fff + (((int32_t)channel.waveform_offset - 0xbfff) * 2);              
           }            
         }
 
-        if(channel.voices & AudioVoice::SQUARE) {
-          channel_sample += ((channel.voice_offset >> 8) < channel.pulse_width) ? 0x7fff : -0x7fff;
+        if(channel.waveforms & Waveform::SQUARE) {
+          channel_sample += ((channel.waveform_offset >> 8) < channel.pulse_width) ? 0x7fff : -0x7fff;
         }
 
-        if(channel.voices & AudioVoice::SINE) {
-          // the sine_voice sample contains 256 samples in total
-          // so we'll just use the most significant bits of the
-          // current voice position to index into it
-          channel_sample += sine_voice[channel.voice_offset >> 8];
+        if(channel.waveforms & Waveform::SINE) {
+          // the sine_waveform sample contains 256 samples in
+          // total so we'll just use the most significant bits
+          // of the current waveform position to index into it
+          channel_sample += sine_waveform[channel.waveform_offset >> 8];
         }
 
+        switch(channel.adsr_phase) {
+          case ADSRPhase::ATTACK:
+            if(channel.adsr_phase_ms < channel.attack_ms) {
+              channel.adsr = channel.adsr_phase_ms / channel.attack_ms;
+            } else {
+              channel.trigger_decay();
+            }
+            break;
+          case ADSRPhase::DECAY:
+            if(channel.adsr_phase_ms < channel.decay_ms) {
+              uint32_t decay = channel.adsr_phase_ms / channel.decay_ms;
+              channel.adsr = 0xffff - (((0xffff - channel.sustain) * decay) >> 16);
+            } else {
+              channel.trigger_sustain();
+            }
+            break;
+          case ADSRPhase::SUSTAIN:
+            channel.adsr = channel.sustain;
+            break;
+          case ADSRPhase::RELEASE:
+            if(channel.adsr_phase_ms < channel.decay_ms) {
+              uint32_t release = channel.adsr_phase_ms / channel.release_ms;
+              channel.adsr = channel.sustain - ((channel.sustain * release) >> 16);
+            }
+            else{
+              channel.off();
+            }
+            break;
+        }
+/*
         if(channel.gate) {
           if((channel.time_ms >> 16) < channel.attack_ms) {
             // attack phase
@@ -95,7 +121,8 @@ namespace blit {
             uint32_t release = channel.time_ms / channel.release_ms;
             channel.adsr = channel.sustain - ((channel.sustain * release) >> 16);
           }
-        }      
+        }
+*/
 
         channel_sample = (channel_sample * channel.adsr) >> 16;
 
@@ -103,14 +130,10 @@ namespace blit {
         channel_sample = (channel_sample * channel.volume) >> 16;
 
         // combine channel sample into the final sample
-        sample += channel_sample;     
+        sample += channel_sample;
 
-        channel.time_ms += frame_ms;          
+        channel.adsr_phase_ms += frame_ms;
       }
-
-      // copy the current gate value into the status flags
-      channel.flags &= ~0b0000001;
-      channel.flags |= channel.gate & 0b0000001;
     }
 
     sample = (sample * volume) >> 16;

--- a/32blit/engine/audio.hpp
+++ b/32blit/engine/audio.hpp
@@ -42,7 +42,6 @@ namespace blit {
   #define CHANNEL_COUNT 8
 
   extern uint32_t sample_rate;
-  extern uint32_t frame_ms;       // number of milliseconds per audio frame (Q16)
   extern uint16_t volume;
 
   enum Waveform {
@@ -65,7 +64,6 @@ namespace blit {
   struct AudioChannel {
       uint8_t   waveforms     = 0;      // bitmask for enabled waveforms (see AudioWaveform enum for values)
       uint16_t  frequency     = 660;    // frequency of the voice (Hz)
-      uint32_t  adsr_phase_ms = 0;      // play time of current note in milliseconds used for ADSR calculations (Q16)
       uint16_t  volume        = 0xffff; // channel volume (default 50%)
 
       uint16_t  attack_ms     = 2;      // attack period
@@ -77,15 +75,41 @@ namespace blit {
   
       uint32_t  waveform_offset  = 0;   // voice offset (Q8)
 
-      uint16_t  adsr          = 0;
-      uint16_t  attack_start_adsr     = 0;
+      uint32_t  adsr_frame    = 0;      // number of frames into the current ADSR phase
+      uint32_t  adsr_end_frame = 0;     // frame target at which the ADSR changes to the next phase
+      uint32_t  adsr          = 0;
       ADSRPhase adsr_phase    = ADSRPhase::OFF;
+	    int32_t   adsr_step	    = 0;
 
-      void trigger_attack()  {adsr_phase_ms = 0; adsr_phase = ADSRPhase::ATTACK; attack_start_adsr = adsr;}
-      void trigger_sustain() {adsr_phase_ms = 0; adsr_phase = ADSRPhase::SUSTAIN;}
-      void trigger_decay()   {adsr_phase_ms = 0; adsr_phase = ADSRPhase::DECAY;}
-      void trigger_release() {adsr_phase_ms = 0; adsr_phase = ADSRPhase::RELEASE;}
-      void off()             {adsr_phase_ms = 0; adsr_phase = ADSRPhase::OFF;}
+      void trigger_attack()  {
+        adsr_frame = 0;
+		    adsr_phase = ADSRPhase::ATTACK;
+        adsr_end_frame = (attack_ms * sample_rate) / 1000;
+		    adsr_step = (int32_t(0xffffff) - int32_t(adsr)) / int32_t(adsr_end_frame);
+	    }
+	    void trigger_decay() {
+        adsr_frame = 0;
+		    adsr_phase = ADSRPhase::DECAY;
+        adsr_end_frame = (decay_ms * sample_rate) / 1000;
+		    adsr_step = (int32_t(sustain << 8) - int32_t(adsr)) / int32_t(adsr_end_frame);
+	    }
+      void trigger_sustain() {
+        adsr_frame = 0;
+		    adsr_phase = ADSRPhase::SUSTAIN;
+        adsr_end_frame = 0;
+		    adsr_step = 0;
+	    }
+      void trigger_release() {
+        adsr_frame = 0;
+		    adsr_phase = ADSRPhase::RELEASE;
+        adsr_end_frame = (release_ms * sample_rate) / 1000;
+		    adsr_step = (int32_t(0) - int32_t(adsr)) / int32_t(adsr_end_frame);
+	    }
+      void off() {
+        adsr_frame = 0;
+		    adsr_phase = ADSRPhase::OFF;
+		    adsr_step = 0;
+	    }
   };
 
   extern AudioChannel channels[CHANNEL_COUNT];

--- a/examples/audio-test/audio-test.cpp
+++ b/examples/audio-test/audio-test.cpp
@@ -52,7 +52,7 @@ void init() {
   channels[2].release_ms  = 100;
 
   // set global volume
-  volume = 0x3fff;
+  // volume = 2048;
   
   screen.pen(RGBA(0, 0, 0, 255));
   screen.clear();  

--- a/examples/audio-test/audio-test.cpp
+++ b/examples/audio-test/audio-test.cpp
@@ -31,21 +31,21 @@ void init() {
   // configure voices
 
   // melody track
-  channels[0].voices      = AudioVoice::TRIANGLE | AudioVoice::SQUARE;
+  channels[0].waveforms   = Waveform::TRIANGLE | Waveform::SQUARE;
   channels[0].attack_ms   = 16;
   channels[0].decay_ms    = 168;
   channels[0].sustain     = 0xafff;
   channels[0].release_ms  = 168;
 
   // rhythm track
-  channels[1].voices      = AudioVoice::SQUARE;
+  channels[1].waveforms   = Waveform::SQUARE;
   channels[1].attack_ms   = 38;
   channels[1].decay_ms    = 300;
   channels[1].sustain     = 0;
   channels[1].release_ms  = 0;
 
   // drum track
-  channels[2].voices       = AudioVoice::NOISE;
+  channels[2].waveforms   = Waveform::NOISE;
   channels[2].attack_ms   = 10;
   channels[2].decay_ms    = 750;
   channels[2].sustain     = 0;

--- a/examples/scrolly-tile/scrolly-tile.cpp
+++ b/examples/scrolly-tile/scrolly-tile.cpp
@@ -399,7 +399,7 @@ void new_game() {
 void init(void) {
     set_screen_mode(lores);
 #ifdef __AUDIO__
-    channels[0].voices      = AudioVoice::NOISE;
+    channels[0].waveforms   = Waveform::NOISE;
     channels[0].frequency   = 4200;
     channels[0].attack_ms   = 1;
     channels[0].decay_ms    = 1;
@@ -407,7 +407,7 @@ void init(void) {
     channels[0].release_ms  = 1;
     channels[0].trigger_attack();
 
-    channels[1].voices      = AudioVoice::SQUARE;
+    channels[1].waveforms   = Waveform::SQUARE;
     channels[1].frequency   = 0;
     channels[1].attack_ms   = 30;
     channels[1].decay_ms    = 100;


### PR DESCRIPTION
This set of changes includes several improvements to the audio engine, and some breaking name changes:

* Now uses a state-machine to handle the envelope generation
* The envelope generator now uses frame timing, rather than trying to work in milliseconds
* attack/decay/sustain/release are converted into frame timings as the state-machine progresses
* The last ADSR value is observed when progressing to the next phase, avoiding pops/clicks
* `AudioVoice` is now `Waveform`

This should fix the issue raised in #113 in addition to preventing any unwanted, jarring transitions between envelope states.