### PR TITLE
Delete unused variables to avoid wasting flash space

### DIFF
--- a/examples/logo/logo.cpp
+++ b/examples/logo/logo.cpp
@@ -10,16 +10,6 @@ using namespace blit;
 
 const Size screen_size(160, 120);
 
-/* define storage for the framebuffer, spritesheet, and mask */
-//rgb     __fb[160 * 120] __SECTION__(".fb")));
-RGBA    __ss[128 * 128] __SECTION__(".ss");
-uint8_t __m[160 * 120] __SECTION__(".m");
-
-/* create surfaces */
-//surface fb((uint8_t *)__fb, screen_size, pixel_format::RGB);
-Surface ss((uint8_t *)__ss, PixelFormat::RGBA, Size(128, 128));
-Surface m((uint8_t *)__m, PixelFormat::M, screen_size);
-
 uint8_t logo[] = {
   1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 2,
   0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2,

--- a/examples/matrix-test/matrix-test.cpp
+++ b/examples/matrix-test/matrix-test.cpp
@@ -10,15 +10,6 @@ using namespace blit;
 const uint16_t screen_width = 320;
 const uint16_t screen_height = 240;
 
-/* define storage for the framebuffer, spritesheet, and mask */
-//rgb     __fb[screen_width * screen_height] __SECTION__(".fb");
-uint8_t __m[screen_width * screen_height] __SECTION__(".m");
-uint8_t __pb[screen_width * screen_height] __SECTION__(".fb");
-
-/* create surfaces */
-//surface fb((uint8_t *)__fb, size(screen_width, screen_height), pixel_format::RGB);
-Surface m((uint8_t *)__m, PixelFormat::M, Size(screen_width, screen_height));
-Surface fbb((uint8_t *)__pb, PixelFormat::P, Size(screen_width, screen_height));
 
 /* setup */
 void init() {

--- a/examples/sprite-test/sprite-test.cpp
+++ b/examples/sprite-test/sprite-test.cpp
@@ -10,16 +10,6 @@ using namespace blit;
 const uint16_t screen_width = 320;
 const uint16_t screen_height = 240;
 
-/* define storage for the framebuffer, spritesheet, and mask */
-//rgb     __fb[screen_width * screen_height] __SECTION__(".fb")));
-uint8_t __m[screen_width * screen_height] __SECTION__(".m");
-uint8_t __pb[screen_width * screen_height] __SECTION__(".fb");
-
-/* create surfaces */
-//surface fb((uint8_t *)__fb, size(screen_width, screen_height), pixel_format::RGB);
-Surface m((uint8_t *)__m, PixelFormat::M, Size(screen_width, screen_height));
-Surface fbb((uint8_t *)__pb, PixelFormat::P, Size(screen_width, screen_height));
-
 /* setup */
 void init() {
 }


### PR DESCRIPTION
Fixes the build if targeting the internal flash