### PR TITLE
Enable Deployment for Win64, Lin64 and STM32 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
           libnewlib-arm-none-eabi
           libstdc++-arm-none-eabi-newlib
           python3-pip
+          python3-setuptools
       install:
         - python3 -m pip install bitstring construct
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ jobs:
           gcc-arm-none-eabi
           libnewlib-arm-none-eabi
           libstdc++-arm-none-eabi-newlib
+      install:
+        - python3 -m pip install bitstring construct
       before_deploy:
         - make install
         - tar -zcf ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,16 @@ jobs:
     
     - name: "Linux"
       env:
-        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-LIN64.tar.gz
+        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-LIN64
       addons:
         apt:
           libsdl2-dev
       before_deploy:
         - make install
-        - tar -zcf ${RELEASE_FILE} bin/
+        - tar -zcf ${RELEASE_FILE}.tar.gz bin/
       deploy:
         provider: releases
-        file: ${RELEASE_FILE}
+        file: ${RELEASE_FILE}.tar.gz
         on:
           tags: true
         edge: true
@@ -46,7 +46,7 @@ jobs:
     - name: "STM32"
       env:
         - TOOLCHAIN=../32blit.toolchain
-        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-STM32.tar.gz
+        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-STM32
       addons:
         apt:
           gcc-arm-none-eabi
@@ -54,14 +54,18 @@ jobs:
           libstdc++-arm-none-eabi-newlib
           python3-pip
           python3-setuptools
+          zip
       install:
         - python3 -m pip install bitstring construct
       before_deploy:
         - make install
-        - tar -zcf ${RELEASE_FILE} bin/
+        - tar -zcf ${RELEASE_FILE}.tar.gz bin/
+        - zip -9 ${RELEASE_FILE}.zip bin/*
       deploy:
         provider: releases
-        file: ${RELEASE_FILE}
+        file:
+          - ${RELEASE_FILE}.tar.gz
+          - ${RELEASE_FILE}.zip
         on:
           tags: true
         edge: true
@@ -70,7 +74,7 @@ jobs:
       env:
         - TOOLCHAIN=../mingw.toolchain
         - CMAKE_ARGS="-DSDL2_DIR=$TRAVIS_BUILD_DIR/SDL2-2.0.10/x86_64-w64-mingw32/lib/cmake/SDL2/ -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-WIN64.zip
+        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-WIN64
       cache:
         directories:
          - SDL2-2.0.10/
@@ -88,10 +92,10 @@ jobs:
           fi
       before_deploy:
         - make install
-        - zip -9 ${RELEASE_FILE} bin/*
+        - zip -9 ${RELEASE_FILE}.zip bin/*
       deploy:
         provider: releases
-        file: ${RELEASE_FILE}
+        file: ${RELEASE_FILE}.zip
         on:
           tags: true
         edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ jobs:
         file: ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz
         on:
           tags: true
+        edge: true
 
     - name: "MinGW"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,3 +114,12 @@ script:
   - cmake -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN $CMAKE_ARGS ..
   - cmake --build .
   - ccache --show-stats || true
+
+before_deploy:
+  - make install
+  - tar -zcf ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz bin
+deploy:
+  provider: releases
+  file: ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,14 @@ jobs:
           gcc-arm-none-eabi
           libnewlib-arm-none-eabi
           libstdc++-arm-none-eabi-newlib
+      before_deploy:
+        - make install
+        - tar -zcf ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz bin
+      deploy:
+        provider: releases
+        file: ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz
+        on:
+          tags: true
 
     - name: "MinGW"
       env:
@@ -111,15 +119,6 @@ jobs:
 script:
   - ccache --zero-stats || true
   - mkdir build && cd build
-  - cmake -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN $CMAKE_ARGS ..
+  - cmake -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN -DCMAKE_INSTALL_PREFIX=`pwd` $CMAKE_ARGS ..
   - cmake --build .
   - ccache --show-stats || true
-
-before_deploy:
-  - make install
-  - tar -zcf ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz bin
-deploy:
-  provider: releases
-  file: ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz
-  on:
-    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,25 @@ jobs:
         - docker exec -it emscripten make -C build.em
     
     - name: "Linux"
+      env:
+        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-LIN64.tar.gz
       addons:
         apt:
           libsdl2-dev
+      before_deploy:
+        - make install
+        - tar -zcf ${RELEASE_FILE} bin/
+      deploy:
+        provider: releases
+        file: ${RELEASE_FILE}
+        on:
+          tags: true
+        edge: true
 
     - name: "STM32"
-      env: TOOLCHAIN=../32blit.toolchain
+      env:
+        - TOOLCHAIN=../32blit.toolchain
+        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-STM32.tar.gz
       addons:
         apt:
           gcc-arm-none-eabi
@@ -45,10 +58,10 @@ jobs:
         - python3 -m pip install bitstring construct
       before_deploy:
         - make install
-        - tar -zcf ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz bin
+        - tar -zcf ${RELEASE_FILE} bin/
       deploy:
         provider: releases
-        file: ${TRAVIS_BUILD_DIR}${REPO}-${BUILD_ENV}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.tar.gz
+        file: ${RELEASE_FILE}
         on:
           tags: true
         edge: true
@@ -57,6 +70,7 @@ jobs:
       env:
         - TOOLCHAIN=../mingw.toolchain
         - CMAKE_ARGS="-DSDL2_DIR=$TRAVIS_BUILD_DIR/SDL2-2.0.10/x86_64-w64-mingw32/lib/cmake/SDL2/ -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-WIN64.tar.gz
       cache:
         directories:
          - SDL2-2.0.10/
@@ -71,6 +85,15 @@ jobs:
             tar -xf SDL2.tar.gz
             sed -i "s|/opt/local|$PWD/SDL2-2.0.10|g" ./SDL2-2.0.10/x86_64-w64-mingw32/lib/cmake/SDL2/sdl2-config.cmake
           fi
+      before_deploy:
+        - make install
+        - tar -zcf ${RELEASE_FILE} bin/
+      deploy:
+        provider: releases
+        file: ${RELEASE_FILE}
+        on:
+          tags: true
+        edge: true
 
     - name: "macOS"
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
           gcc-arm-none-eabi
           libnewlib-arm-none-eabi
           libstdc++-arm-none-eabi-newlib
+          python3-pip
       install:
         - python3 -m pip install bitstring construct
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
       env:
         - TOOLCHAIN=../mingw.toolchain
         - CMAKE_ARGS="-DSDL2_DIR=$TRAVIS_BUILD_DIR/SDL2-2.0.10/x86_64-w64-mingw32/lib/cmake/SDL2/ -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-WIN64.tar.gz
+        - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-WIN64.zip
       cache:
         directories:
          - SDL2-2.0.10/
@@ -78,6 +78,7 @@ jobs:
       addons:
         apt:
           g++-mingw-w64
+          zip
       before_script:
         - |
           if [ ! -f SDL2-2.0.10/README.txt ]; then
@@ -87,7 +88,7 @@ jobs:
           fi
       before_deploy:
         - make install
-        - tar -zcf ${RELEASE_FILE} bin/
+        - zip -9 ${RELEASE_FILE} bin/*
       deploy:
         provider: releases
         file: ${RELEASE_FILE}

--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_executable(32Blit 32Blit.cpp)
 
+install(TARGETS 32Blit
+    RUNTIME DESTINATION bin
+)
+
 if(APPLE)
     find_library(COREFOUNDATION_LIBRARY CoreFoundation)
     find_library(IOKIT_LIBRARY IOKit)


### PR DESCRIPTION
Title says it all, really. This will now attach files to our tagged releases so users can just grab a set of prebuilt binaries.