### PR TITLE
Windows SDL cmake config improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,6 @@ jobs:
             unzip SDL2.zip -d vs/sdl
             # move dirs up
             mv vs/sdl/SDL2-2.0.10/* vs/sdl
-            mv vs/sdl/lib/x86 vs/sdl/lib/Win32 #small hack
           fi
 
 

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -39,6 +39,12 @@ endif()
 
 target_link_libraries(BlitHalSDL PUBLIC BlitEngine ${SDL2_LIBRARIES})
 
+# copy SDL2.dll to build/install dir for windows users
+if(SDL2_DLL)
+	configure_file(${SDL2_DLL} ${32blit_BINARY_DIR}/SDL2.dll COPYONLY)
+	install(FILES ${SDL2_DLL} DESTINATION bin)
+endif()
+
 target_compile_definitions(BlitHalSDL
 	PRIVATE
 		-DWINDOW_TITLE=\"CMake!\"

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -1,2 +1,11 @@
 set(SDL2_INCLUDE_DIRS "${SDL2_DIR}/include")
-set(SDL2_LIBRARIES "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2.lib" "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2main.lib")
+
+if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
+    set(SDL2_LIBRARIES "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2.lib" "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2main.lib")
+else()
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(SDL2_LIBRARIES "${SDL2_DIR}/lib/x64/SDL2.lib" "${SDL2_DIR}/lib/x64/SDL2main.lib")
+    else()
+        set(SDL2_LIBRARIES "${SDL2_DIR}/lib/x86/SDL2.lib" "${SDL2_DIR}/lib/x86/SDL2main.lib")
+    endif()
+endif()

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -1,2 +1,2 @@
 set(SDL2_INCLUDE_DIRS "${SDL2_DIR}/include")
-set(SDL2_LIBRARIES "${SDL2_DIR}/lib/$(Platform)/SDL2.lib" "${SDL2_DIR}/lib/$(Platform)/SDL2main.lib")
+set(SDL2_LIBRARIES "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2.lib" "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2main.lib")

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -1,11 +1,15 @@
 set(SDL2_INCLUDE_DIRS "${SDL2_DIR}/include")
 
 if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
-    set(SDL2_LIBRARIES "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2.lib" "${SDL2_DIR}/lib/$(PlatformTarget)/SDL2main.lib")
+    set(SDL2_LIBDIR "${SDL2_DIR}/lib/$(PlatformTarget)")
 else()
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        set(SDL2_LIBRARIES "${SDL2_DIR}/lib/x64/SDL2.lib" "${SDL2_DIR}/lib/x64/SDL2main.lib")
+        set(SDL2_LIBDIR "${SDL2_DIR}/lib/x64/")
     else()
-        set(SDL2_LIBRARIES "${SDL2_DIR}/lib/x86/SDL2.lib" "${SDL2_DIR}/lib/x86/SDL2main.lib")
+        set(SDL2_LIBDIR "${SDL2_DIR}/lib/x86/")
     endif()
 endif()
+
+set(SDL2_LIBRARIES "${SDL2_LIBDIR}/SDL2.lib" "${SDL2_LIBDIR}/SDL2main.lib")
+
+set(SDL2_DLL "${SDL2_LIBDIR}/SDL2.dll")

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -1,7 +1,7 @@
 set(SDL2_INCLUDE_DIRS "${SDL2_DIR}/include")
 
-if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
-    set(SDL2_LIBDIR "${SDL2_DIR}/lib/$(PlatformTarget)")
+if(CMAKE_GENERATOR_PLATFORM)
+    set(SDL2_LIBDIR "${SDL2_DIR}/lib/${CMAKE_GENERATOR_PLATFORM}")
 else()
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(SDL2_LIBDIR "${SDL2_DIR}/lib/x64/")


### PR DESCRIPTION
This removes the need to rename folders for the x86 build and also makes it usable in VS Code with Ninja. Should help with windows problems from #139.