### PR TITLE
Find python and use it to execute the dfu script

### DIFF
--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -150,6 +150,8 @@ set(MCU_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT}")
 set(MCU_LINKER_SCRIPT "${MCU_LINKER_SCRIPT}" PARENT_SCOPE)
 set(MCU_LINKER_SCRIPT_EXT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT_EXT}" PARENT_SCOPE)
 
+find_package(PythonInterp 3 REQUIRED)
+
 function(blit_executable_common NAME)
 	target_link_libraries(${NAME} BlitEngine)
 	set_property(TARGET ${NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-Map=${NAME}.map,--cref")
@@ -196,6 +198,6 @@ function(blit_executable_int_flash NAME SOURCES)
 
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.dfu"
-		COMMAND ${CMAKE_DFU} build --force --out ${NAME}.dfu ${NAME}.bin
+		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_DFU} build --force --out ${NAME}.dfu ${NAME}.bin
 	)
 endfunction()


### PR DESCRIPTION
This is pretty much the only thing preventing doing an arm build on windows. The PythonInterp module is deprecated, but the replacement isn't available until CMake 3.12.