### PR TITLE
Add support for linking binary assets

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -79,6 +79,31 @@ if(DEFINED VIDEO_CAPTURE AND VIDEO_CAPTURE)
 	)
 endif()
 
+function(blit_asset NAME ASSET)
+	add_custom_command(OUTPUT ${ASSET}.o
+		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_LINKER} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${ASSET}
+		COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o
+	)
+	# Add object as a library
+	add_library(${ASSET}
+		STATIC
+		${ASSET}.o)
+	# Tell CMake this object file has already been built by custom command
+	SET_SOURCE_FILES_PROPERTIES(
+		${ASSET}.o
+		PROPERTIES
+		EXTERNAL_OBJECT true
+		GENERATED true
+	)
+	# Avoid language warning
+	SET_TARGET_PROPERTIES(
+		${ASSET}
+		PROPERTIES
+		LINKER_LANGUAGE C
+	)
+	# Link our asset to our output
+	target_link_libraries(${NAME} ${ASSET})
+endfunction()
 
 function(blit_executable NAME SOURCES)
 	add_executable(${NAME} ${SOURCES} ${ARGN})

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -154,6 +154,32 @@ set(MCU_LINKER_SCRIPT_EXT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT_EXT}" P
 
 find_package(PythonInterp 3 REQUIRED)
 
+function(blit_asset NAME ASSET)
+	add_custom_command(OUTPUT ${ASSET}.o
+		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_LINKER} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${ASSET}
+		COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o
+	)
+	# Add object as a library
+	add_library(${ASSET}
+		STATIC
+		${ASSET}.o)
+	# Tell CMake this object file has already been built by custom command
+	SET_SOURCE_FILES_PROPERTIES(
+		${ASSET}.o
+		PROPERTIES
+		EXTERNAL_OBJECT true
+		GENERATED true
+	)
+	# Avoid language warning
+	SET_TARGET_PROPERTIES(
+		${ASSET}
+		PROPERTIES
+		LINKER_LANGUAGE C
+	)
+	# Link our asset to our output
+	target_link_libraries(${NAME} ${ASSET})
+endfunction()
+
 function(blit_executable_common NAME)
 	target_link_libraries(${NAME} BlitEngine)
 	set_property(TARGET ${NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-Map=${NAME}.map,--cref")

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -3,10 +3,13 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 
 set(CMAKE_C_COMPILER arm-none-eabi-gcc CACHE PATH "Path to C compiler")
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++ CACHE PATH "Path to C++ compiler")
+
 set(CMAKE_SIZE arm-none-eabi-size CACHE PATH "Path to size tool")
 set(CMAKE_READELF arm-none-eabi-readelf CACHE PATH "Path to readelf tool")
 set(CMAKE_RANLIB arm-none-eabi-gcc-ranlib CACHE PATH "Path to ranlib")
 set(CMAKE_AR arm-none-eabi-gcc-ar CACHE PATH "Path to ar")
+set(CMAKE_OBJCOPY arm-none-eabi-objcopy CACHE PATH "Path to objcopy")
+set(CMAKE_LINKER arm-none-eabi-ld CACHE PATH "Path to linker")
 set(CMAKE_DFU "${CMAKE_CURRENT_LIST_DIR}/tools/dfu" CACHE PATH "Path to DFU builder")
 
 set(MCU_LINKER_SCRIPT STM32H750VBTx_FLASH.ld)

--- a/mingw.toolchain
+++ b/mingw.toolchain
@@ -7,6 +7,8 @@ include(sdl2-config REQUIRED)
 set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
 set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_OBJCOPY x86_64-w64-mingw32-objcopy CACHE PATH "Path to objcopy")
+set(CMAKE_LINKER x86_64-w64-mingw32-ld CACHE PATH "Path to linker")
 set(CMAKE_CXX_FLAGS_INIT "-static-libstdc++ -static-libgcc -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic")
 set(SDL2_BINDIR ${SDL2_PREFIX}/bin)
 


### PR DESCRIPTION
This is an attempt at adding support for linking binary assets, so that map data, graphics, sound, or other useful bits and bobs can be appended to a binary without having to deal with header files.

It's used by invoking `blit_asset` in an example/project CMakeLists.txt.

`blit_asset` takes two arguments:

1. The project name
2. The binary file to link into the project

For example, to link the audio `rising.raw` into `doom-fire` I might use: `blit_asset (doom-fire rising.raw)`

There's a much more interesting take on this by @Daft-Freak - https://github.com/Daft-Freak/32blit-beta/commit/a373fa4c096a86dff6d65fd3298db1a176b0a4db

Which introduces the concept of executing a packer tool (in this case our `sprite-builder`) to perform build-time conversion of assets. This is *really* cool since it takes a whole manual step out of the build and avoids the user having to care about how/when their lovely image files are converted.

I think these two approaches should be combined into something that:

- Takes an asset- be it a map, image, data, whatever
- Accepts a "tool name" or "asset type" which governs how that asset will be transformed into binary data
- Executes the tool against the asset
- Converts the binary result into an object file
- And additionally a header file with a convinient pointer at the data for the user to hook into
- Links the result against the project

So a user can just:

```
#include "my-asset.h"
```

```
blit_asset (my-project sprite my-asset)
```

Or something similar.