### PR TITLE
Add crude remember-last-menu-item feature to firmware

### DIFF
--- a/32blit-stm32/Inc/32blit.h
+++ b/32blit-stm32/Inc/32blit.h
@@ -3,6 +3,8 @@
 
 #include "32blit.hpp"
 #include "fatfs.h"
+#include "persistence.h"
+
 
 // Functions defined by user code files
 extern void init();

--- a/32blit-stm32/Inc/persistence.h
+++ b/32blit-stm32/Inc/persistence.h
@@ -1,0 +1,22 @@
+/*
+In combination with a reserved section in volatile memory this struct provies 1k
+of "persistent" storage in volatile RAM.
+
+This storage is reserved for 32blit firmware level use, and will survive resets,
+switches into bootloader mode and jumps between internal/external flash.
+
+This storage will not survive a loss of power.
+*/
+struct Persist {
+  uint32_t magic_word;
+  float volume;
+  float backlight;
+  uint32_t selected_menu_item;
+  uint32_t reset_target;
+};
+
+extern Persist persist;
+
+// This magic word lets us know our persistent values are valid
+// and not just random uninitialised memory.
+constexpr uint32_t persistence_magic_word = 0x03281170;

--- a/32blit-stm32/STM32H750VBTxEXT_FLASH.ld
+++ b/32blit-stm32/STM32H750VBTxEXT_FLASH.ld
@@ -46,7 +46,8 @@ RAM_D1 (xrw)        : ORIGIN = 0x24000000, LENGTH = 362K
 LTDC (rw)           : ORIGIN = 0x2405A800, LENGTH = 150K
 RAM_D2 (xrw)        : ORIGIN = 0x30000000, LENGTH = 63K
 FRAMEBUFFER (rw)    : ORIGIN = 0x3000FC00, LENGTH = 225K
-RAM_D3 (xrw)        : ORIGIN = 0x38000000, LENGTH = 64K
+RAM_D3 (xrw)        : ORIGIN = 0x38000000, LENGTH = 63K
+PERSIST (rw)        : ORIGIN = 0x3800FC00, LENGTH = 1K
 ITCMISR (xrw)       : ORIGIN = 0x00000000, LENGTH = 4K
 ITCMRAM (xrw)       : ORIGIN = 0x00001000, LENGTH = 60K
 FLASH (rx)          : ORIGIN = 0x90000000, LENGTH = 32768K
@@ -177,6 +178,14 @@ SECTIONS
     KEEP(*(.ltdc))         /* LTDC buffer section */
     __ltdc_end = .;
   } >LTDC
+
+  .persist (NOLOAD):
+  {
+    . = ALIGN(4);
+    __persist_start = .;
+    KEEP(*(.persist))         /* Persistent data section */
+    __persist_end = .;
+  } >PERSIST
 
   .fb (NOLOAD):
   {

--- a/32blit-stm32/STM32H750VBTx_FLASH.ld
+++ b/32blit-stm32/STM32H750VBTx_FLASH.ld
@@ -46,7 +46,8 @@ RAM_D1 (xrw)        : ORIGIN = 0x24000000, LENGTH = 362K
 LTDC (rw)           : ORIGIN = 0x2405A800, LENGTH = 150K
 RAM_D2 (xrw)        : ORIGIN = 0x30000000, LENGTH = 63K
 FRAMEBUFFER (rw)    : ORIGIN = 0x3000FC00, LENGTH = 225K
-RAM_D3 (xrw)        : ORIGIN = 0x38000000, LENGTH = 64K
+RAM_D3 (xrw)        : ORIGIN = 0x38000000, LENGTH = 63K
+PERSIST (rw)        : ORIGIN = 0x3800FC00, LENGTH = 1K
 ITCMISR (xrw)       : ORIGIN = 0x00000000, LENGTH = 4K
 ITCMRAM (xrw)       : ORIGIN = 0x00001000, LENGTH = 60K
 FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 128K
@@ -177,6 +178,14 @@ SECTIONS
     KEEP(*(.ltdc))         /* LTDC buffer section */
     __ltdc_end = .;
   } >LTDC
+
+  .persist (NOLOAD):
+  {
+    . = ALIGN(4);
+    __persist_start = .;
+    KEEP(*(.persist))         /* Persistent data section */
+    __persist_end = .;
+  } >PERSIST
 
   .fb (NOLOAD):
   {

--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -45,10 +45,9 @@ FRESULT SD_FileOpenError = FR_INVALID_PARAMETER;
 
 bool needs_render = true;
 uint32_t flip_cycle_count = 0;
-float global_volume = 0.5f;
 float volume_log_base = 2.0f;
 
-
+__attribute__((section(".persist"))) Persist persist;
 
 void DFUBoot(void)
 {
@@ -113,7 +112,21 @@ void hook_render(uint32_t time) {
   }
 }
 
+void blit_update_volume() {
+    blit::volume = (uint16_t)(65535.0f * log(1.0f + (volume_log_base - 1.0f) * persist.volume) / log(volume_log_base));
+}
+
 void blit_init() {
+    if(persist.magic_word != persistence_magic_word) {
+      // Set persistent defaults if the magic word does not match
+      persist.magic_word = persistence_magic_word;
+      persist.volume = 0.5f;
+      persist.backlight = 1.0f;
+      persist.selected_menu_item = 0;
+    }
+
+    blit_update_volume();
+
     // enable cycle counting
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
     DWT->CYCCNT = 0;
@@ -130,15 +143,12 @@ void blit_init() {
     f_mount(&filesystem, "", 1);  // this shouldn't be necessary here right?
     msa301_init(&hi2c4, MSA301_CONTROL2_POWR_MODE_NORMAL, 0x00, MSA301_CONTROL1_ODR_62HZ5);
     bq24295_init(&hi2c4);
-    blit::backlight = 1.0f;
     blit::debug = blit_debug;
     blit::debugf = blit_debugf;
     blit::now = HAL_GetTick;
     blit::random = HAL_GetRandom;
-    blit::volume = (uint16_t)(65535.0f * log(1.0f + (volume_log_base - 1.0f) * global_volume) / log(volume_log_base));
     blit::set_screen_mode = display::set_screen_mode;
     display::set_screen_mode(blit::lores);
-
     blit::update = ::update;
     blit::render = ::render;
     blit::init   = ::init;
@@ -220,25 +230,25 @@ void blit_menu_update(uint32_t time) {
   } else if (blit::buttons & blit::Button::DPAD_RIGHT ) {
     switch(menu_item) {
       case BACKLIGHT:
-        blit::backlight += 1.0f / 256.0f;
-        blit::backlight = std::fmin(1.0f, std::fmax(0.0f, blit::backlight));
+        persist.backlight += 1.0f / 256.0f;
+        persist.backlight = std::fmin(1.0f, std::fmax(0.0f, persist.backlight));
         break;
       case VOLUME:
-        global_volume += 1.0f / 256.0f;
-        global_volume = std::fmin(1.0f, std::fmax(0.0f, global_volume));
-        blit::volume = (uint16_t)(65535.0f * log(1.0f + (volume_log_base - 1.0f) * global_volume) / log(volume_log_base));
+        persist.volume += 1.0f / 256.0f;
+        persist.volume = std::fmin(1.0f, std::fmax(0.0f, persist.volume));
+        blit_update_volume();
         break;
     }
   } else if (blit::buttons & blit::Button::DPAD_LEFT ) {
     switch(menu_item) {
       case BACKLIGHT:
-        blit::backlight -= 1.0f / 256.0f;
-        blit::backlight = std::fmin(1.0f, std::fmax(0.0f, blit::backlight));
+        persist.backlight -= 1.0f / 256.0f;
+        persist.backlight = std::fmin(1.0f, std::fmax(0.0f, persist.backlight));
         break;
       case VOLUME:
-        global_volume -= 1.0f / 256.0f;
-        global_volume = std::fmin(1.0f, std::fmax(0.0f, global_volume));
-        blit::volume = (uint16_t)(65535.0f * log(1.0f + (volume_log_base - 1.0f) * global_volume) / log(volume_log_base));
+        persist.volume -= 1.0f / 256.0f;
+        persist.volume = std::fmin(1.0f, std::fmax(0.0f, persist.volume));
+        blit_update_volume();
         break;
     }
   } else if (blit::buttons & changed_buttons & blit::Button::A) {
@@ -327,14 +337,14 @@ void blit_menu_render(uint32_t time) {
         screen.pen = bar_background_color;
         screen.rectangle(Rect(screen_width / 2, 21, 75, 5));
         screen.pen = Pen(255, 255, 255);
-        screen.rectangle(Rect(screen_width / 2, 21, 75 * blit::backlight, 5));
+        screen.rectangle(Rect(screen_width / 2, 21, 75 * persist.backlight, 5));
 
         break;
       case VOLUME:
         screen.pen = bar_background_color;
         screen.rectangle(Rect(screen_width / 2, 31, 75, 5));
         screen.pen = Pen(255, 255, 255);
-        screen.rectangle(Rect(screen_width / 2, 31, 75 * global_volume, 5));
+        screen.rectangle(Rect(screen_width / 2, 31, 75 * persist.volume, 5));
 
         break;
       default:
@@ -382,7 +392,7 @@ void blit_update_led() {
     __HAL_TIM_SetCompare(&htim3, TIM_CHANNEL_2, compare_b);
 
     // Backlight
-    __HAL_TIM_SetCompare(&htim15, TIM_CHANNEL_1, 962 - (962 * blit::backlight));
+    __HAL_TIM_SetCompare(&htim15, TIM_CHANNEL_1, 962 - (962 * persist.backlight));
 }
 
 void HAL_ADC_ErrorCallback(ADC_HandleTypeDef* hadc){

--- a/32blit/engine/output.cpp
+++ b/32blit/engine/output.cpp
@@ -7,6 +7,5 @@ namespace blit {
 
   Pen LED;
   float vibration;
-  float backlight;
 
 }

--- a/firmware/flash-loader/flash-loader.cpp
+++ b/firmware/flash-loader/flash-loader.cpp
@@ -46,6 +46,10 @@ void FlashLoader::Init()
 
 	// register LS
 	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'_', '_', 'L', 'S'>::value, this);
+
+	uint32_t* p = (uint32_t *)0x3800fff8;
+
+	m_uCurrentFile = p[0];
 }
 
 
@@ -70,6 +74,10 @@ void FlashLoader::FSInit(void)
 			m_uFileCount++;
 		}
 		fr = f_findnext(&dj, &fno);
+	}
+
+	if(m_uCurrentFile > m_uFileCount) {
+		m_uCurrentFile = m_uFileCount;
 	}
 
 	f_closedir(&dj);
@@ -270,6 +278,10 @@ void FlashLoader::RenderFlashFile(uint32_t time)
 			blit::switch_execution();
 		}
 	}
+
+	*((uint32_t *)0x3800fff8) = m_uCurrentFile;
+
+	SCB_CleanDCache();
 }
 
 

--- a/firmware/flash-loader/flash-loader.cpp
+++ b/firmware/flash-loader/flash-loader.cpp
@@ -47,9 +47,7 @@ void FlashLoader::Init()
 	// register LS
 	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'_', '_', 'L', 'S'>::value, this);
 
-	uint32_t* p = (uint32_t *)0x3800fff8;
-
-	m_uCurrentFile = p[0];
+	m_uCurrentFile = persist.selected_menu_item;
 }
 
 
@@ -279,9 +277,7 @@ void FlashLoader::RenderFlashFile(uint32_t time)
 		}
 	}
 
-	*((uint32_t *)0x3800fff8) = m_uCurrentFile;
-
-	SCB_CleanDCache();
+	persist.selected_menu_item = m_uCurrentFile;
 }
 
 

--- a/firmware/flash-loader/flash-loader.hpp
+++ b/firmware/flash-loader/flash-loader.hpp
@@ -1,6 +1,7 @@
 #include "32blit.hpp"
 #include "CDCCommandHandler.h"
 #include "fatfs.h"
+#include "persistence.h"
 
 #define SCREEN_WIDTH 320
 #define SCREEN_HEIGHT 240


### PR DESCRIPTION
This PR now reflects what I want out of system setting persistence.

We have 1K of volatile memory reserved in `RAM_D3` (which hilariously gives us a 63K leftover in D2 and a 63K leftover in D3. Balance is restored) by the linker scripts.

We then create a struct; `Persist` like so:

```c
struct Persist {
  uint32_t magic_word;
  float volume;
  float backlight;
  uint32_t selected_menu_item;
  uint32_t reset_target;
};
```

And tell the linker to place it in the uninitialised memory section we've set aside:

```c
__attribute__((section(".persist"))) Persist persist;
```

The `magic_word` is a sentinel value that lets us determine if the RAM has been initialised to a known good state. We check this on init and apply defaults if it's just random garbage:

```c
    if(persist.magic_word != persistence_magic_word) {
      // Set persistent defaults if the magic word does not match
      persist.magic_word = persistence_magic_word;
      persist.volume = 0.5f;
      persist.backlight = 1.0f;
      persist.selected_menu_item = 0;
    }
```

A couple of refinements to the system menu have come along for the ride!

Original PR message for posterity:

> This is a crude hack to get the flash-loader firmware to remember the last menu item selected. It's raised here as a draft to promote discussion about how we should handle persistent system state.
> 
> My proposal is some take on this hack, but slightly more formalised and coupled with a magic-word that lets us determine if memory is uninitialised or "remembered" from a previous init (due to no loss of power).
> 
> We should reserve a section of memory- probably at the back end of the framebuffer- where we can put a struct that includes:
> 
> - A sentinel value, to determine if the data in memory is valid or not (uint32_t enough?)
> - float Volume
> - float Brightness
> - uint16_t Selected Menu Item
> - etc
> 
> This will allow us to persist system state between resets and game launches without excessive writing to SD or Flash. We should - perhaps - consider a more permemant state save to SD card where possible.
> 
> Note: Volume and Brightness should be moved out of the Engine into this "persistent" storage. They don't belong in the engine at all.