### PR TITLE
Rebuild stale assets, move to 32blit.cmake to avoid duplication

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -79,32 +79,6 @@ if(DEFINED VIDEO_CAPTURE AND VIDEO_CAPTURE)
 	)
 endif()
 
-function(blit_asset NAME ASSET)
-	add_custom_command(OUTPUT ${ASSET}.o
-		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_LINKER} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${ASSET}
-		COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o
-	)
-	# Add object as a library
-	add_library(${ASSET}
-		STATIC
-		${ASSET}.o)
-	# Tell CMake this object file has already been built by custom command
-	SET_SOURCE_FILES_PROPERTIES(
-		${ASSET}.o
-		PROPERTIES
-		EXTERNAL_OBJECT true
-		GENERATED true
-	)
-	# Avoid language warning
-	SET_TARGET_PROPERTIES(
-		${ASSET}
-		PROPERTIES
-		LINKER_LANGUAGE C
-	)
-	# Link our asset to our output
-	target_link_libraries(${NAME} ${ASSET})
-endfunction()
-
 function(blit_executable NAME SOURCES)
 	add_executable(${NAME} ${SOURCES} ${ARGN})
 

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -154,32 +154,6 @@ set(MCU_LINKER_SCRIPT_EXT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT_EXT}" P
 
 find_package(PythonInterp 3 REQUIRED)
 
-function(blit_asset NAME ASSET)
-	add_custom_command(OUTPUT ${ASSET}.o
-		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_LINKER} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${ASSET}
-		COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o
-	)
-	# Add object as a library
-	add_library(${ASSET}
-		STATIC
-		${ASSET}.o)
-	# Tell CMake this object file has already been built by custom command
-	SET_SOURCE_FILES_PROPERTIES(
-		${ASSET}.o
-		PROPERTIES
-		EXTERNAL_OBJECT true
-		GENERATED true
-	)
-	# Avoid language warning
-	SET_TARGET_PROPERTIES(
-		${ASSET}
-		PROPERTIES
-		LINKER_LANGUAGE C
-	)
-	# Link our asset to our output
-	target_link_libraries(${NAME} ${ASSET})
-endfunction()
-
 function(blit_executable_common NAME)
 	target_link_libraries(${NAME} BlitEngine)
 	set_property(TARGET ${NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-Map=${NAME}.map,--cref")

--- a/32blit.cmake
+++ b/32blit.cmake
@@ -10,6 +10,34 @@ if (NOT DEFINED BLIT_ONCE)
 
 	add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/32blit 32blit)
 
+	function(blit_asset NAME ASSET)
+		add_custom_command(
+			OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o
+			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_LINKER} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${ASSET}
+			COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o ${CMAKE_CURRENT_BINARY_DIR}/${ASSET}.o
+			DEPENDS ${ASSET}
+		)
+		# Add object as a library
+		add_library(asset_${ASSET}
+			STATIC
+			${ASSET}.o)
+		# Tell CMake this object file has already been built by custom command
+		SET_SOURCE_FILES_PROPERTIES(
+			${ASSET}.o
+			PROPERTIES
+			EXTERNAL_OBJECT true
+			GENERATED true
+		)
+		# Avoid language warning
+		SET_TARGET_PROPERTIES(
+			asset_${ASSET}
+			PROPERTIES
+			LINKER_LANGUAGE C
+		)
+		# Link our asset to our output
+		target_link_libraries(${NAME} asset_${ASSET})
+	endfunction()
+
 	if (${CMAKE_SYSTEM_NAME} STREQUAL Generic)
 		set(FLASH_PORT "AUTO" CACHE STRING "Port to use for flash")
 


### PR DESCRIPTION
This change combines the asset build functions from SDL and STM32 into a single function in 32blit.cmake.

Additionally the library target is renamed to `asset_${ASSET}` to avoid a circular dependency being triggered when the custom command depends upon `${ASSET}`.