### PR TITLE
Allow longer file size in flash loader

### DIFF
--- a/firmware/flash-loader/flash-loader.hpp
+++ b/firmware/flash-loader/flash-loader.hpp
@@ -10,7 +10,7 @@
 #define ROW_HEIGHT 10
 #define ROW(x) Point(0,x * ROW_HEIGHT)
 #define MAX_FILENAME 256+1
-#define MAX_FILELEN 5+1
+#define MAX_FILELEN 16+1
 #define PAGE_SIZE 256
 
 class FlashLoader : public CDCCommandHandler


### PR DESCRIPTION
Okay this one really got us.

We were flashing a ~2MB voxel example via the Flash Loader using the old firmware on Jon's blit.

It worked *fine*. Then I rolled up and said "hey try changing the SD card scalar, it'll flash and load so much quicker."

After flashing the latest firmware, the 2MB file suddenly wouldn't copy over.

I traced the issue back to https://github.com/pimoroni/32blit-beta/commit/c94848851ac7d251da30a67e1111b9e0e92655e6

"What on earth does this seemingly innocuous set of changes have to do with saving to SD card?" I hear you ask.

Well, it turns out the only relevant change was `MAX_FILENAMES` being adjusted from 30 to 24.

This made the difference between the code just scraping by and working on a fluke with Jon's oversized file, and it simply bailing out altogether. We think this is because the extra MAX_FILENAMES caused variable alignment to change, so the filename length was getting a bonus unallocated byte... or something. One heck of a bug, to be sure!