### PR TITLE
Add support for different sized fonts.

### DIFF
--- a/32blit/graphics/font.cpp
+++ b/32blit/graphics/font.cpp
@@ -300,7 +300,7 @@ static const uint8_t minimal_font_data[96][6] = {
 };
 
 namespace blit {
-  const Font outline_font(&outline_font_data[0][0]);
-  const Font fat_font(&fat_font_data[0][0]);
-  const Font minimal_font(&minimal_font_data[0][0]);
+  const Font outline_font(&outline_font_data[0][0], 6, 8);
+  const Font fat_font(&fat_font_data[0][0], 6, 8);
+  const Font minimal_font(&minimal_font_data[0][0], 6, 8);
 }

--- a/32blit/graphics/font.cpp
+++ b/32blit/graphics/font.cpp
@@ -101,6 +101,15 @@ static const uint8_t outline_font_data[96][6] = {
   {0x00,0x00,0x00,0x00,0x00,0x00}
 };
 
+static const uint8_t outline_font_width[96] = {
+  3, 4, 6, 7, 6, 6, 7, 4, 5, 5, 7, 7, 5, 6, 4, 6,
+  6, 4, 6, 6, 6, 6, 6, 6, 6, 6, 4, 5, 6, 7, 6, 6,
+  7, 6, 6, 6, 6, 6, 6, 6, 6, 4, 6, 6, 6, 7, 7, 6,
+  6, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 5, 6, 5, 6, 7,
+  5, 6, 6, 6, 6, 6, 6, 6, 6, 4, 6, 6, 6, 7, 7, 6,
+  6, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 4, 6, 7, 2
+};
+
 static const uint8_t fat_font_data[96][6] = {
   {0x00,0x00,0x00,0x00,0x00,0x00}, //  
   {0x5e,0x06,0x06,0x00,0x00,0x00}, // !
@@ -198,6 +207,15 @@ static const uint8_t fat_font_data[96][6] = {
   {0x42,0x7e,0x24,0x00,0x00,0x00}, // }
   {0x04,0x06,0x06,0x02,0x04,0x06}, // ~
   {0x00,0x00,0x00,0x00,0x00,0x00}
+};
+
+static const uint8_t fat_font_width[96] = {
+  3, 4, 5, 7, 5, 7, 6, 2, 5, 5, 7, 6, 4, 4, 4, 6,
+  7, 5, 6, 5, 6, 6, 6, 7, 6, 6, 4, 3, 6, 4, 6, 6,
+  7, 6, 6, 6, 6, 5, 5, 6, 6, 4, 5, 6, 5, 7, 6, 7,
+  6, 7, 6, 6, 6, 6, 6, 7, 7, 6, 6, 5, 6, 5, 4, 6,
+  5, 6, 6, 6, 6, 6, 5, 6, 6, 4, 5, 6, 5, 7, 6, 7,
+  6, 7, 5, 5, 6, 6, 6, 7, 6, 6, 6, 5, 2, 4, 7, 2
 };
 
 static const uint8_t minimal_font_data[96][6] = {
@@ -299,8 +317,17 @@ static const uint8_t minimal_font_data[96][6] = {
   {0x00,0x00,0x00,0x00,0x00,0x00}
 };
 
+static const uint8_t minimal_font_width[96] = {
+  3, 2, 4, 6, 6, 6, 7, 2, 3, 3, 4, 4, 2, 4, 2, 4,
+  6, 3, 5, 5, 6, 5, 6, 6, 6, 6, 2, 2, 4, 4, 4, 5,
+  7, 6, 6, 5, 6, 5, 5, 6, 5, 4, 5, 5, 5, 6, 6, 6,
+  6, 6, 6, 5, 6, 6, 6, 6, 5, 5, 5, 3, 4, 3, 4, 4,
+  3, 6, 6, 5, 6, 5, 5, 6, 5, 4, 5, 5, 5, 6, 6, 6,
+  6, 6, 6, 5, 6, 6, 6, 6, 5, 5, 5, 4, 2, 4, 4, 2
+};
+
 namespace blit {
-  const Font outline_font(&outline_font_data[0][0], 6, 8);
-  const Font fat_font(&fat_font_data[0][0], 6, 8);
-  const Font minimal_font(&minimal_font_data[0][0], 6, 8);
+  const Font outline_font(&outline_font_data[0][0], outline_font_width, 6, 8);
+  const Font fat_font(&fat_font_data[0][0], fat_font_width, 6, 8);
+  const Font minimal_font(&minimal_font_data[0][0], minimal_font_width, 6, 8);
 }

--- a/32blit/graphics/font.hpp
+++ b/32blit/graphics/font.hpp
@@ -4,10 +4,11 @@
 
 namespace blit {
   struct Font {
-    Font(const uint8_t *data, uint8_t char_w, uint8_t char_h) : data(data), char_w(char_w), char_h(char_h) {}
+    Font(const uint8_t *data, uint8_t char_w, uint8_t char_h, uint8_t spacing_x = 2, uint8_t spacing_y = 1) : data(data), char_w(char_w), char_h(char_h), spacing_x(spacing_x), spacing_y(spacing_y) {}
 
     const uint8_t *data;
     uint8_t char_w, char_h;
+    uint8_t spacing_x, spacing_y;
   };
 
   extern const Font outline_font;

--- a/32blit/graphics/font.hpp
+++ b/32blit/graphics/font.hpp
@@ -4,9 +4,10 @@
 
 namespace blit {
   struct Font {
-    Font(const uint8_t *data) : data(data) {}
+    Font(const uint8_t *data, uint8_t char_w, uint8_t char_h) : data(data), char_w(char_w), char_h(char_h) {}
 
     const uint8_t *data;
+    uint8_t char_w, char_h;
   };
 
   extern const Font outline_font;

--- a/32blit/graphics/font.hpp
+++ b/32blit/graphics/font.hpp
@@ -4,11 +4,17 @@
 
 namespace blit {
   struct Font {
-    Font(const uint8_t *data, uint8_t char_w, uint8_t char_h, uint8_t spacing_x = 2, uint8_t spacing_y = 1) : data(data), char_w(char_w), char_h(char_h), spacing_x(spacing_x), spacing_y(spacing_y) {}
+    Font(const uint8_t *data, const uint8_t *char_w_variable, uint8_t char_w, uint8_t char_h, uint8_t spacing_y = 1)
+      : data(data), char_w_variable(char_w_variable), char_w(char_w), char_h(char_h), spacing_y(spacing_y) {}
 
     const uint8_t *data;
+
+    // fixed size
     uint8_t char_w, char_h;
-    uint8_t spacing_x, spacing_y;
+    // variable width
+    const uint8_t *char_w_variable;
+
+    uint8_t spacing_y;
   };
 
   extern const Font outline_font;

--- a/32blit/graphics/text.cpp
+++ b/32blit/graphics/text.cpp
@@ -83,8 +83,6 @@ namespace blit {
           if (font_chr[x * height_bytes + y / 8] & bit) {
             if(clip.contains(Point(c.x + x, c.y + y)))
               pbf(&pen, this, po, 1);
-
-            char_width = char_width < x ? x : char_width;
           }
 
           po++;
@@ -94,11 +92,7 @@ namespace blit {
       if (!variable)
         char_width = font.char_w;
       else
-        char_width += font.spacing_x;
-
-      if (chr == ' ' && variable) {
-        char_width = 3;
-      }
+        char_width = font.char_w_variable[chr_idx];
 
       // increment the cursor
       c.x += char_width;
@@ -129,28 +123,10 @@ namespace blit {
     if (!variable)
       return font.char_w;
 
-    if (c == ' ')
-      return 3;
-
-    uint8_t char_width = 0;
     uint8_t chr_idx = c & 0x7F;
     chr_idx = chr_idx < ' ' ? 0 : chr_idx - ' ';
 
-    const int height_bytes = (font.char_h + 7) / 8;
-    const int char_size = font.char_w * height_bytes;
-
-    const uint8_t* font_chr = &font.data[chr_idx * char_size];
-
-    for (uint8_t y = 0; y < font.char_h; y++) {
-      for (uint8_t x = 0; x < font.char_w; x++) {
-        int bit = 1 << (y & 7);
-        if (font_chr[x * height_bytes + y / 8] & bit) {
-          char_width = char_width < x ? x : char_width;
-        }
-      }
-    }
-
-    return char_width + font.spacing_x;
+    return font.char_w_variable[chr_idx];
   }
 
   Size Surface::measure_text(std::string message, const Font &font, bool variable) {

--- a/32blit/graphics/text.cpp
+++ b/32blit/graphics/text.cpp
@@ -61,6 +61,9 @@ namespace blit {
         c.x += (r.w - bounds.w) / 2;
     }
 
+    const int height_bytes = (font.char_h + 7) / 8;
+    const int char_size = font.char_w * height_bytes;
+
     size_t char_off = 0;
     for (char &chr : message) {
       // draw character
@@ -70,13 +73,14 @@ namespace blit {
 
       uint8_t char_width = 0;
 
-      const uint8_t* font_chr = &font.data[chr_idx * 6];
+      const uint8_t* font_chr = &font.data[chr_idx * char_size];
 
-      for (uint8_t y = 0; y < 8; y++) {
+      for (uint8_t y = 0; y < font.char_h; y++) {
         uint32_t po = offset(Point(c.x, c.y + y));
 
-        for (uint8_t x = 0; x < 6; x++) {
-          if (font_chr[x] & (1 << y)) {
+        for (uint8_t x = 0; x < font.char_w; x++) {
+          int bit = 1 << (y & 7);
+          if (font_chr[x * height_bytes + y / 8] & bit) {
             if(clip.contains(Point(c.x + x, c.y + y)))
               pbf(&pen, this, po, 1);
 
@@ -88,9 +92,9 @@ namespace blit {
       }
 
       if (!variable)
-        char_width = 4;
-
-      char_width += 2;
+        char_width = font.char_w;
+      else
+        char_width += 2;
 
       if (chr == ' ' && variable) {
         char_width = 3;
@@ -100,7 +104,7 @@ namespace blit {
       c.x += char_width;
       if (chr == 10) {
         c.x = r.x;
-        c.y += 9;
+        c.y += font.char_h + 1;
 
         // check horizontal alignment
         if ((align & 0b1100) != TextAlign::left) {
@@ -122,9 +126,8 @@ namespace blit {
   }
 
   uint8_t get_char_width(const Font &font, char c, bool variable) {
-    const int fixed_char_width = 6;
     if (!variable)
-      return fixed_char_width;
+      return font.char_w;
 
     if (c == ' ')
       return 3;
@@ -133,11 +136,15 @@ namespace blit {
     uint8_t chr_idx = c & 0x7F;
     chr_idx = chr_idx < ' ' ? 0 : chr_idx - ' ';
 
-    const uint8_t* font_chr = &font.data[chr_idx * 6];
+    const int height_bytes = (font.char_h + 7) / 8;
+    const int char_size = font.char_w * height_bytes;
 
-    for (uint8_t y = 0; y < 8; y++) {
-      for (uint8_t x = 0; x < 6; x++) {
-        if (font_chr[x] & (1 << y)) {
+    const uint8_t* font_chr = &font.data[chr_idx * char_size];
+
+    for (uint8_t y = 0; y < font.char_h; y++) {
+      for (uint8_t x = 0; x < font.char_w; x++) {
+        int bit = 1 << (y & 7);
+        if (font_chr[x * height_bytes + y / 8] & bit) {
           char_width = char_width < x ? x : char_width;
         }
       }
@@ -147,8 +154,7 @@ namespace blit {
   }
 
   Size Surface::measure_text(std::string message, const Font &font, bool variable) {
-    const int fixed_char_width = 6;
-    const int line_height = 9;
+    const int line_height = font.char_h + 1;
 
     Size bounds(0, 0);
 
@@ -165,7 +171,7 @@ namespace blit {
         if (end == std::string::npos)
           end = message.length();
 
-        line_len = (end - char_off) * fixed_char_width;
+        line_len = (end - char_off) * font.char_w;
         char_off = end;
       }
 

--- a/32blit/graphics/text.cpp
+++ b/32blit/graphics/text.cpp
@@ -94,7 +94,7 @@ namespace blit {
       if (!variable)
         char_width = font.char_w;
       else
-        char_width += 2;
+        char_width += font.spacing_x;
 
       if (chr == ' ' && variable) {
         char_width = 3;
@@ -104,7 +104,7 @@ namespace blit {
       c.x += char_width;
       if (chr == 10) {
         c.x = r.x;
-        c.y += font.char_h + 1;
+        c.y += font.char_h + font.spacing_y;
 
         // check horizontal alignment
         if ((align & 0b1100) != TextAlign::left) {
@@ -150,11 +150,11 @@ namespace blit {
       }
     }
 
-    return char_width + 2;
+    return char_width + font.spacing_x;
   }
 
   Size Surface::measure_text(std::string message, const Font &font, bool variable) {
-    const int line_height = font.char_h + 1;
+    const int line_height = font.char_h + font.spacing_y;
 
     Size bounds(0, 0);
 


### PR DESCRIPTION
Also stores the widths of individual characters to avoid having to loop through the character data when measuring.

Here's a slightly modified 2x version of minimal_font:
![Big](https://user-images.githubusercontent.com/3074891/74370594-489c6700-4dcf-11ea-9684-6526afd76f31.png)

And my attempt at drawing a font (which is surprisingly not that bad):
![Mine](https://user-images.githubusercontent.com/3074891/74370612-53ef9280-4dcf-11ea-8b5d-fd593ee2d1fa.png)

(Doesn't add any new fonts)