### PR TITLE
Improvement/menu refactoring

### DIFF
--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -337,9 +337,7 @@ void blit_menu_render(uint32_t time) {
         screen.rectangle(Rect(screen_width / 2, 31, 75 * global_volume, 5));
 
         break;
-      case DFU:
-      case SHIPPING:
-      case SWITCH_EXE:
+      default:
         screen.pen = Pen(255, 255, 255);
         screen.text("Press A", minimal_font, press_a_origin(item, screen_width));
         break;  


### PR DESCRIPTION
- Created `MenuItem` enum
- Created helper functions for locations etc
- Menu now wraps
- Brought it together by writing a loop that creates menu items in a reusable way.
So
- Now, if you want to reorganise menu items, just reorganise the enum cases (less the last one).
- If you want to add a new item, 
    1. add an enum case, 
    2. add a case for the string, 
    3. add a case for the action when pressing A. 
    4. "Press A" is default. If you want something else, add a case for it in the for loop in `blit_menu_render`