### PR TITLE
Patch tools

### DIFF
--- a/tools/dfu
+++ b/tools/dfu
@@ -215,9 +215,9 @@ if __name__ == '__main__':
                     dest = str(args.file).replace('.dfu', '')
                     filename = f"{dest}-{target_id}-{address}.bin"
 
-                    if pathlib.Path(dest).is_file() and not args.force:
+                    if pathlib.Path(filename).is_file() and not args.force:
                         raise parser.error(f'Existing output file "{filename}", use --force to overwrite!')
 
                     print(f"Dumping image at {address} to {filename} ({len(data)} bytes)")
 
-                    open(dest, 'wb').write(data)
+                    open(filename, 'wb').write(data)

--- a/tools/sprite-builder
+++ b/tools/sprite-builder
@@ -110,8 +110,8 @@ SpriteFormat = SmartEnum(
     Int8ul,
     rgba=0,
     rgb888=1,
-    rgb565=2,
-    p=3
+    p=2,
+    rgb565=3
 )
 
 asset_rgba = Struct(


### PR DESCRIPTION
Patches a couple of bugs in the tools:

1. Fix sprite-builder so sprites are output with pixel type `0x02` instead of `0x03` which is the new type for palette-based sprites.
2. Fix `dfu` so that dumping a .dfu file to a .bin file actually results in a file with the mentioned name being created, rather than just `test.dfu` being output to `test`. Oof.