### PR TITLE
Move _estack to end of user RAM section

### DIFF
--- a/32blit-stm32/STM32H750VBTxEXT_FLASH.ld
+++ b/32blit-stm32/STM32H750VBTxEXT_FLASH.ld
@@ -33,7 +33,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20020000;    /* end of RAM */
+_estack = 0x2405A800;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x400;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */

--- a/32blit-stm32/STM32H750VBTx_FLASH.ld
+++ b/32blit-stm32/STM32H750VBTx_FLASH.ld
@@ -33,7 +33,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20020000;    /* end of RAM */
+_estack = 0x2405A800;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x400;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */


### PR DESCRIPTION
This prevents the stack from stepping all over the heap. Or something like that. I've really lost the plot.

Thanks @trollied and @andrewcapon for pointing this out!