### PR TITLE
Remove configure and install steps for SDL2.dll

### DIFF
--- a/mingw.toolchain
+++ b/mingw.toolchain
@@ -10,8 +10,7 @@ set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
 set(CMAKE_OBJCOPY x86_64-w64-mingw32-objcopy CACHE PATH "Path to objcopy")
 set(CMAKE_LINKER x86_64-w64-mingw32-ld CACHE PATH "Path to linker")
 set(CMAKE_CXX_FLAGS_INIT "-static-libstdc++ -static-libgcc -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic")
-set(SDL2_BINDIR ${SDL2_PREFIX}/bin)
 
-configure_file(${SDL2_BINDIR}/SDL2.dll ${CMAKE_CURRENT_BINARY_DIR}/SDL2.dll COPYONLY)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/SDL2.dll DESTINATION bin)
+if(EXISTS "${SDL2_PREFIX}/bin/SDL2.dll")
+	set(SDL2_DLL "${SDL2_PREFIX}/bin/SDL2.dll")
+endif()


### PR DESCRIPTION
These steps don't belong in mingw.toolchain.

Since duplicate commands already exist in 32blit-sdl's CMakeLists.txt it makes sense to invoke them by setting `SDL2_DLL`

Right now they still make potentially incorrect assumptions about where SDL2.dll is located, but this assumption *should* be correct for all versions of SDL2 that have been cross-compiled as per the docs.