### PR TITLE
Fix for 32blit_BINARY_DIR not set for MSVC builds

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(BlitHalSDL PUBLIC BlitEngine ${SDL2_LIBRARIES})
 
 # copy SDL2.dll to build/install dir for windows users
 if(SDL2_DLL)
-	configure_file(${SDL2_DLL} ${32blit_BINARY_DIR}/SDL2.dll COPYONLY)
+	configure_file(${SDL2_DLL} ${CMAKE_BINARY_DIR}/SDL2.dll COPYONLY)
 	install(FILES ${SDL2_DLL} DESTINATION bin)
 endif()
 


### PR DESCRIPTION
For some reason despite CMake purportedly creating a `<TARGET_NAME>_BINARY_DIR` for each target, this value wasn't being set in my build using VSCode, CMake Tools and the Visual Studio kit.

I had to swap to `CMAKE_BINARY_DIR` which shoud accomplish the same thing.

Keen to know if this breaks anyone's local builds (or Travis)