### PR TITLE
Warning cleanup cleanup

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -32,7 +32,7 @@ set(APPLICATION_VTOR_EXT 0x90000000)
 set(EXTERNAL_LOAD_ADDRESS_EXT 0x08000000)
 set(INITIALISE_QSPI_EXT 0)
 
-set(COMMON_FLAGS "${MCU_FLAGS} -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Wno-unused-variable -Wno-write-strings -Wmisleading-indentation -fpermissive")
+set(COMMON_FLAGS "${MCU_FLAGS} -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Wno-unused-variable -Wno-write-strings")
 
 set(CMAKE_C_FLAGS_INIT "${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS}")


### PR DESCRIPTION
Cleanup https://github.com/pimoroni/32blit-beta/commit/efabdbdacd3f5a5eda0526957087280462bc5ed9#diff-4d6fa8f73bd863c9d065f958fcc0a3ac a bit.

- `-fpermissive` is already in `32blit-stm32/CMakeLists.txt` (see 2b835012bbea2e36e6360115b1f5932c7d8c6dfe)
- `-fpermissive` isn't a valid flag for compiling C (only C++)
- `-Wmisleading-indentation` enables the warning (and doesn't do anything since it's already enabled). It's disabled for the appropriate file in `32blit-stm32/CMakeLists.txt`