### PR TITLE
Allow custom name for assets

### DIFF
--- a/32blit.cmake
+++ b/32blit.cmake
@@ -75,7 +75,19 @@ if (NOT DEFINED BLIT_ONCE)
 		set(PACKER_ARGS)
 		set(PACKER_OUTPUTS assets.bin assets.cpp assets.hpp)
 
-		list(JOIN ASSET_NAMES , ASSET_NAMES)
+		if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+			# Polyfill for CMake < 3.12.0 where list(JOIN ...) is not available
+			# Found here: https://stackoverflow.com/questions/7172670/best-shortest-way-to-join-a-list-in-cmake
+			function(list_join VALUES GLUE OUTPUT)
+				string (REGEX REPLACE "([^\\]|^);" "\\1${GLUE}" _TMP_STR "${VALUES}")
+				string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") #fixes escaping
+				set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+			endfunction()
+
+			list_join("${ASSET_NAMES}" "," ASSET_NAMES)
+		else()
+			list(JOIN ASSET_NAMES , ASSET_NAMES)
+		endif()
 
 		if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 			set(PACKER_ARGS --inline-data)

--- a/tools/asset-packer
+++ b/tools/asset-packer
@@ -11,8 +11,11 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--base-path', action='append', type=str)
     parser.add_argument('--inline-data', action='store_true', help='embed data as an array in assets.cpp')
+    parser.add_argument('--names', type=str, help='list of names for asset files (default is to mangle filename)', default='')
     parser.add_argument('files', nargs='+', type=str, help='input files')
     args = parser.parse_args()
+
+    args.names = args.names.split(',')
 
     bin_out = open('assets.bin', 'wb')
     cpp_out = open('assets.cpp', 'w')
@@ -25,32 +28,41 @@ if __name__ == '__main__':
     cpp_out.write('#include "assets.hpp"\n\n')
     cpp_out.write('extern const uint8_t _binary_assets_bin_start[];\n\n')
 
+    file_index = 0
     for file in args.files:
+        name = None
+
+        if file_index < len(args.names):
+            name = args.names[file_index]
+        file_index += 1
+
         offset = bin_out.tell()
         length = os.stat(file).st_size
 
         # tidy up name
-        name = file
-        for base_path in args.base_path:
-            if file.startswith(base_path):
-                name = os.path.relpath(file, base_path)
+        if name is None:
+            name = file
+            for base_path in args.base_path:
+                if file.startswith(base_path):
+                    name = os.path.relpath(file, base_path)
 
-        name = os.path.splitext(name)[0]
-        name = name.replace('../', '')
-        name = re.sub('[^0-9A-Za-z_]', '_', name)
+            name = os.path.splitext(name)[0]
+            name = name.replace('../', '')
+            name = re.sub('[^0-9A-Za-z_]', '_', name)
+            name = 'asset_' + name
 
         bin_out.write(open(file, 'rb').read())
-        hpp_out.write('extern const blit::Asset asset_{};\n'.format(name))
+        hpp_out.write('extern const blit::Asset {};\n'.format(name))
 
-        cpp_out.write('const blit::Asset asset_{}(_binary_assets_bin_start + {}, {});\n'.format(name, offset, length))
+        cpp_out.write('const blit::Asset {}(_binary_assets_bin_start + {}, {});\n'.format(name, offset, length))
 
 
     if args.inline_data:
         bin_out.close()
         bin_out = open('assets.bin', 'rb')
 
-        data = bin_out.read();
+        data = bin_out.read()
 
-        cpp_out.write('\nconst uint8_t _binary_assets_bin_start[] = {\n\t');
+        cpp_out.write('\nconst uint8_t _binary_assets_bin_start[] = {\n\t')
         cpp_out.write(format_hex(data))
-        cpp_out.write('};\n');
+        cpp_out.write('};\n')


### PR DESCRIPTION
At the request of @lowfatcode this improves the asset pipeline to allow for custom asset names. This is preferable to the name-mangling default since you can call your `sprite.png` or `level.tmx` by whatever name you so choose instead of `asset_sprite_png` and `asset_level_tmx`.

May not yet fix the pack_sprites function TODO, but allows the assets to be given names independent of their filename

It does this by popping 3 args at a time from blit_assets- type, file and name

Type and file are processed as usual, but names are collated and passed to asset-packer via a new argument: `--names`

This is a comma-separated list of asset names that must match the order of files supplied.

You can now use (for example):

```
blit_assets (rocks-and-diamonds
    MAP_TILED2BIN level.tmx asset_level
    SPRITE_PACKED sprites.png asset_sprites)
```

Include `assets.hpp`

And then access `asset_level.data` and `asset_sprites.data` in your code.