### PR TITLE
Fix measure text for multiple consecutive newlines

### DIFF
--- a/32blit/graphics/text.cpp
+++ b/32blit/graphics/text.cpp
@@ -138,7 +138,16 @@ namespace blit {
     int line_len = 0;
 
     while (char_off < message.length()) {
-      if (variable) {
+      // newline
+      if (message[char_off] == '\n') {
+        if (line_len > bounds.w)
+          bounds.w = line_len;
+
+        bounds.h += line_height;
+
+        line_len = 0;
+        char_off++;
+      } else if (variable) {
         line_len += get_char_width(font, message[char_off], true);
         char_off++;
       } else {
@@ -150,18 +159,13 @@ namespace blit {
         line_len = (end - char_off) * font.char_w;
         char_off = end;
       }
-
-      // new line/end
-      if (char_off == message.length() || message[char_off] == '\n') {
-        if (line_len > bounds.w)
-          bounds.w = line_len;
-
-        bounds.h += line_height;
-
-        line_len = 0;
-        char_off++;
-      }
     }
+
+    // update for final line
+    if (line_len > bounds.w)
+      bounds.w = line_len;
+
+    bounds.h += line_height;
 
     return bounds;
   }


### PR DESCRIPTION
...and I find another font/text issue. The old code would check if the next character was a newline and skip it, which would fail if there were consecutive newlines (it would treat the additional newlines as spaces).