### PR TITLE
Class based file API

### DIFF
--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -21,4 +21,57 @@ namespace blit {
   extern uint32_t (*get_file_length)         (uint32_t fh);
 
   extern std::vector<FileInfo> (*list_files) (std::string path);
+  
+  class File final {
+  public:
+    File() {}
+    File(std::string filename) {open(filename);}
+    File(const File &) = delete;
+    File(File &&other) {
+      *this = std::move(other);
+    }
+
+    ~File() {
+      close();
+    }
+
+    File &operator=(const File &) = delete;
+
+    File &operator=(File &&other) {
+      if (this != &other) {
+        close();
+        std::swap(fh, other.fh);
+      }
+      return *this;
+    }
+
+    bool open(std::string file) {
+      close();
+      fh = open_file(file);
+      return fh != -1;
+    }
+
+    int32_t read(uint32_t offset, uint32_t length, char *buffer) {
+      return read_file(fh, offset, length, buffer);
+    }
+
+    void close() {
+      if(fh == -1)
+        return;
+
+      close_file(fh);
+      fh = -1;
+    }
+
+    uint32_t get_length() {
+      return get_file_length(fh);
+    }
+
+    bool is_open() const {
+      return fh != -1;
+    }
+
+  private:
+    int32_t fh = -1;
+  };
 }


### PR DESCRIPTION
Wraps the existing API in a class. I think this is a bit nicer (okay, I mainly did this because I kept forgetting to close files...).

```c++
int32_t file = blit::open_file("some.thing")
blit::read_file(file, ...);
return; // oops
```
->
```c++
blit::File file("some.thing")
file.read(...);
return; // yay, destructors
```

Guess the next step would be to make the old API internal...