### PR TITLE
Add blit_assets_yaml heavily borrowed from @Daft-Freak

### DIFF
--- a/32blit.cmake
+++ b/32blit.cmake
@@ -44,6 +44,26 @@ if (NOT DEFINED BLIT_ONCE)
 		set(${OUT_PATH} ${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME}.blit PARENT_SCOPE)
 	endfunction()
 
+	function (blit_assets_yaml TARGET FILE)
+		# cause cmake to reconfigure whenever the asset list changes
+		set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+
+		# get the inputs/outputs for the asset tool (at configure time)
+		execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit --debug cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR} --cmake ${CMAKE_CURRENT_BINARY_DIR}/assets.cmake)
+		include(${CMAKE_CURRENT_BINARY_DIR}/assets.cmake)
+
+		# do asset packing (at build time)
+		add_custom_command(
+			OUTPUT ${ASSET_OUTPUTS}
+			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit --debug  pack --force --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR}
+			DEPENDS ${ASSET_DEPENDS}
+		)
+
+		# add the outputs as dependencies of the project (also compile any cpp files)
+		target_sources(${TARGET} PRIVATE ${ASSET_OUTPUTS})
+		target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+	endfunction()
+
 	function (blit_assets TARGET)
 		set(ASSET_TYPE "")
 		set(ASSET_FILES)


### PR DESCRIPTION
Thanks to @Daft-Freak for suggesting this approach here - https://github.com/pimoroni/32blit-beta/issues/212 - and providing the core of the CMake output functionality for the 32blit tool.