### PR TITLE
Hopefully fix the 99% send over CDC.

### DIFF
--- a/32blit-stm32/Src/CDCCommandStream.cpp
+++ b/32blit-stm32/Src/CDCCommandStream.cpp
@@ -39,7 +39,7 @@ void CDCCommandStream::Stream(void)
 	}
 
 	// restart USB CDC if fifo was full
-	if(m_bNeedsUSBResume)
+	if(m_bNeedsUSBResume && m_uFifoUsedCount == 0)
 	{
 		m_bNeedsUSBResume = false;
 	  USBD_CDC_SetRxBuffer(&hUsbDeviceHS, GetFifoWriteBuffer());
@@ -178,7 +178,7 @@ uint32_t CDCCommandStream::GetTimeTaken(void)
 uint8_t	*CDCCommandStream::GetFifoWriteBuffer(void)
 {
 	uint8_t *pData = NULL;
-	if(m_uFifoUsedCount < CDC_FIFO_BUFFERS)
+	if(m_uFifoUsedCount < CDC_FIFO_BUFFERS - 1)
 	{
 		pData = m_fifoElements[m_uFifoWritePos].m_data;
 	}


### PR DESCRIPTION
Hopefully this will fix the getting stuck at 99% problem when sending data to the 32Blit.

I also tested with removing the Sleep() at the end of the 32Blit app but that still causes issues fo it went back in!

I'm currently running a test with the 32Blit executable in a loop, so far it is at 230 times without a problem so I think this is probably now fixed.