### PR TITLE
Handle SDL built with CMake with only a static library

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -33,6 +33,9 @@ else()
 	# If SDL2 was built using CMake, the generated configuration files define SDL2::* targets instead of the SDL2_* variables
 	if(TARGET SDL2::SDL2)
 		set(SDL2_LIBRARIES SDL2::SDL2 SDL2::SDL2main)
+	# handle SDL2 built with only a static library
+	elseif(TARGET SDL2::SDL2-static)
+		set(SDL2_LIBRARIES SDL2::SDL2-static SDL2::SDL2main)
 	else()
 		target_include_directories(BlitHalSDL
 			PRIVATE	${SDL2_INCLUDE_DIRS}


### PR DESCRIPTION
Shared/static SDL have different target names, if the shared library wasn't built we would fall back to the old `_INCLUDE_DIRS`/`_LIBRARIES` path and find nothing. (#231)