### PR TITLE
Interrupt on GPIO_PIN_5 for system menu

### DIFF
--- a/32blit-stm32/Inc/stm32h7xx_it.h
+++ b/32blit-stm32/Inc/stm32h7xx_it.h
@@ -67,6 +67,7 @@ void TIM3_IRQHandler(void);
 void TIM4_IRQHandler(void);
 //void TIM6_DAC_IRQHandler(void);
 void OTG_HS_IRQHandler(void);
+void EXTI9_5_IRQHandler(void);
 
 
 /* USER CODE BEGIN EFP */

--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -293,7 +293,13 @@ void blit_menu_update(uint32_t time) {
 }
 
 void blit_menu_render(uint32_t time) {
+#if EXTERNAL_LOAD_ADDRESS == 0x90000000  // TODO We probably need a nicer way of detecting that we're compiling a firmware build (-DFIRMWARE maybe?)
+  // Don't attempt to render firmware game selection menu behind system menu
+  // At the moment `render` handles input in the firmware, so this results
+  // in all kinds of fun an exciting weirdness.
+#else
   ::render(time);
+#endif
   int screen_width = 160;
   int screen_height = 120;
   if (display::mode == blit::ScreenMode::hires) {

--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -47,6 +47,8 @@ bool needs_render = true;
 uint32_t flip_cycle_count = 0;
 float volume_log_base = 2.0f;
 
+const uint32_t long_press_exit_time = 1000;
+
 uint32_t home_button_pressed_time = 0;
 
 __attribute__((section(".persist"))) Persist persist;
@@ -88,7 +90,7 @@ void blit_tick() {
 
   blit::tick(blit::now());
 
-  if(home_button_pressed_time > 0 && HAL_GetTick() - home_button_pressed_time > 500) {
+  if(home_button_pressed_time > 0 && HAL_GetTick() - home_button_pressed_time > long_press_exit_time) {
       #if EXTERNAL_LOAD_ADDRESS == 0x90000000
         // Already in firmware menu
       #else
@@ -461,7 +463,7 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
   if(!HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port, BUTTON_MENU_Pin)) {
     home_button_pressed_time = HAL_GetTick();
   } else {
-    if(home_button_pressed_time > 0) {
+    if(home_button_pressed_time > 0 && HAL_GetTick() - home_button_pressed_time > 20) {
       // TODO is it a good idea to swap out the render/update functions potentially in the middle of a loop?
       // We were more or less doing this before by handling the menu update between render/update so perhaps it's mostly fine.
       blit_menu();

--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -675,6 +675,7 @@ void blit_switch_execution(void)
   HAL_NVIC_DisableIRQ(DMA1_Stream1_IRQn);
   HAL_NVIC_DisableIRQ(TIM6_DAC_IRQn);
   HAL_NVIC_DisableIRQ(OTG_HS_IRQn);
+  HAL_NVIC_DisableIRQ(EXTI9_5_IRQn);
 
 	volatile uint32_t uAddr = EXTERNAL_LOAD_ADDRESS;
 	// enable qspi memory mapping if needed

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -127,7 +127,7 @@ namespace display {
 
     if(mode == ScreenMode::lores) {
       //dma2d_lores_flip(source);
-      screen.text(std::to_string(flip_time), minimal_font, Point(100,40));
+      //screen.text(std::to_string(flip_time), minimal_font, Point(100,40));
 
       uint32_t flip_start = DWT->CYCCNT;
 

--- a/32blit-stm32/Src/gpio.cpp
+++ b/32blit-stm32/Src/gpio.cpp
@@ -80,8 +80,12 @@ namespace gpio {
     init_pin(GPIOD, BUTTON_B_Pin, GPIO_MODE_INPUT, GPIO_PULLUP);
 
     // system buttons
-    init_pin(GPIOD, BUTTON_MENU_Pin, GPIO_MODE_INPUT, GPIO_PULLUP);
-    init_pin(GPIOD, BUTTON_HOME_Pin, GPIO_MODE_INPUT, GPIO_PULLUP);
+    init_pin(GPIOD, BUTTON_MENU_Pin, GPIO_MODE_IT_RISING_FALLING, GPIO_PULLUP);
+    init_pin(GPIOD, BUTTON_HOME_Pin, GPIO_MODE_INPUT, GPIO_PULLDOWN);
+
+    /* EXTI interrupt init*/
+    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 
     // user hack headers
     init_pin(GPIOC, USER_LEFT1_Pin, GPIO_MODE_ANALOG, GPIO_NOPULL); // left analog

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -148,7 +148,7 @@ int main(void)
 
 #if (INITIALISE_QSPI==1)
   qspi_init();
-  if((persist.reset_target == prtGame) && !HAL_GPIO_ReadPin(BUTTON_HOME_GPIO_Port,  BUTTON_HOME_Pin))
+  if((persist.reset_target == prtGame) && HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port,  BUTTON_MENU_Pin))
     blit_switch_execution();
 #endif
 

--- a/32blit-stm32/Src/stm32h7xx_it.c
+++ b/32blit-stm32/Src/stm32h7xx_it.c
@@ -307,6 +307,19 @@ void ADC3_IRQHandler(void)
   /* USER CODE END ADC3_IRQn 1 */
 }
 
+/**
+  * @brief This function handles EXTI line[9:5] interrupts.
+  */
+void EXTI9_5_IRQHandler(void)
+{
+  /* USER CODE BEGIN EXTI9_5_IRQn 0 */
+
+  /* USER CODE END EXTI9_5_IRQn 0 */
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_5);
+  /* USER CODE BEGIN EXTI9_5_IRQn 1 */
+
+  /* USER CODE END EXTI9_5_IRQn 1 */
+}
 
 /* USER CODE BEGIN 1 */
 


### PR DESCRIPTION
This changes the home button behaviour from polling in the main loop to triggering on an interrupt.

It defines two behaviours:

1. Short press = Open/Close system menu
2. Long press (500ms) = Immediately reset to firmware (only happens in app)

The latter is to replace the force-of-habit "press reset to return to system menu" with a more sensibly defined behaviour, since the reset button will not be so easily accesible on final units.

The former fixes the horrible bounce issue on the menu button.

TODO: Disable button interrupt when switching exe, because it breaks horribly (read: drops to `Default_Handler`) when apps don't define the interrupt vector but the interrupt is still enabled.