### PR TITLE
clang-tidy cleanups

### DIFF
--- a/32blit-sdl/Audio.cpp
+++ b/32blit-sdl/Audio.cpp
@@ -16,7 +16,7 @@ Audio::Audio() {
     desired.samples = 256;
     desired.callback = _audio_callback;
 
-    audio_device = SDL_OpenAudioDevice(NULL, 0, &desired, &audio_spec, 0);
+    audio_device = SDL_OpenAudioDevice(nullptr, 0, &desired, &audio_spec, 0);
 
     if(audio_device == 0){
         std::cout << "Audio Init Failed: " << SDL_GetError() << std::endl;

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -24,7 +24,7 @@
 
 static bool running = true;
 
-SDL_Window* window = NULL;
+SDL_Window* window = nullptr;
 
 System *blit_system;
 Input *blit_input;
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
 		SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
 	);
 
-	if (window == NULL) {
+	if (window == nullptr) {
 		fprintf(stderr, "could not create window: %s\n", SDL_GetError());
 		return 1;
 	}

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -8,7 +8,7 @@
 Renderer::Renderer(SDL_Window *window, int width, int height) : sys_width(width), sys_height(height) {
 	//SDL_SetHint(SDL_HINT_RENDER_DRIVER, "openGL");
 	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
-	if (renderer == NULL) {
+	if (renderer == nullptr) {
 		fprintf(stderr, "could not create renderer: %s\n", SDL_GetError());
 	}
 
@@ -76,18 +76,18 @@ void Renderer::_render(SDL_Texture *target, SDL_Rect *destination) {
 	SDL_SetRenderTarget(renderer, target);
 	SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
 	SDL_RenderClear(renderer);
-	SDL_RenderCopy(renderer, current, NULL, destination);
+	SDL_RenderCopy(renderer, current, nullptr, destination);
 }
 
 void Renderer::present() {
-	_render(NULL, &dest);
+	_render(nullptr, &dest);
 	SDL_RenderPresent(renderer);
 }
 
 void Renderer::read_pixels(int width, int height, Uint32 format, Uint8 *buffer) {
 	SDL_Texture *record_target = SDL_CreateTexture(renderer, format, SDL_TEXTUREACCESS_TARGET, width, height);
-	_render(record_target, NULL);
-	SDL_RenderReadPixels(renderer, NULL, format, buffer, width*SDL_BYTESPERPIXEL(format));
+	_render(record_target, nullptr);
+	SDL_RenderReadPixels(renderer, nullptr, format, buffer, width*SDL_BYTESPERPIXEL(format));
 	SDL_DestroyTexture(record_target);
 }
 

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -20,10 +20,10 @@ class Renderer {
 		int win_width, win_height;
 
 		Mode mode = KeepPixels;
-		SDL_Renderer *renderer = NULL;
+		SDL_Renderer *renderer = nullptr;
 		SDL_Rect dest = {0, 0, 0, 0};
 
-		SDL_Texture *fb_lores_texture = NULL;
-		SDL_Texture *fb_hires_texture = NULL;
-		SDL_Texture *current = NULL;
+		SDL_Texture *fb_lores_texture = nullptr;
+		SDL_Texture *fb_hires_texture = nullptr;
+		SDL_Texture *current = nullptr;
 };

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -196,11 +196,11 @@ Uint32 System::mode() {
 void System::update_texture(SDL_Texture *texture) {
 	blit::render(::now());
 	if (_mode == blit::ScreenMode::lores) {
-		SDL_UpdateTexture(texture, NULL, __fb_lores.data, 160 * 3);
+		SDL_UpdateTexture(texture, nullptr, __fb_lores.data, 160 * 3);
 	}
 	else
 	{
-		SDL_UpdateTexture(texture, NULL, __fb_hires.data, 320 * 3);
+		SDL_UpdateTexture(texture, nullptr, __fb_hires.data, 320 * 3);
 	}
 }
 

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -27,15 +27,15 @@ class System {
 
 	private:
 
-		SDL_Thread *t_system_timer = NULL;
-		SDL_Thread *t_system_loop = NULL;
+		SDL_Thread *t_system_timer = nullptr;
+		SDL_Thread *t_system_loop = nullptr;
 
-		SDL_mutex *m_input = NULL;
+		SDL_mutex *m_input = nullptr;
 
-		SDL_sem *s_timer_stop = NULL;
-		SDL_sem *s_loop_update = NULL;
-		SDL_sem *s_loop_redraw = NULL;
-		SDL_sem *s_loop_ended = NULL;
+		SDL_sem *s_timer_stop = nullptr;
+		SDL_sem *s_loop_update = nullptr;
+		SDL_sem *s_loop_redraw = nullptr;
+		SDL_sem *s_loop_ended = nullptr;
 
 		bool running = false;
 

--- a/32blit-sdl/VideoCaptureFfmpeg.cpp
+++ b/32blit-sdl/VideoCaptureFfmpeg.cpp
@@ -27,10 +27,10 @@
   * codecs are used.
   * @example muxing.c
   */
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cmath>
 
 extern "C" {
 #include <libavutil/avassert.h>

--- a/32blit/audio/audio.hpp
+++ b/32blit/audio/audio.hpp
@@ -53,7 +53,7 @@ namespace blit {
     WAVE      = 1
   };
 
-  enum class ADSRPhase {
+  enum class ADSRPhase : uint8_t {
     ATTACK,
     DECAY,
     SUSTAIN,
@@ -75,15 +75,15 @@ namespace blit {
   
       uint32_t  waveform_offset  = 0;   // voice offset (Q8)
 
+      int64_t   filter_last_sample = 0;
       bool      filter_enable = false;
       uint16_t  filter_cutoff_frequency = 0;
-      int64_t   filter_last_sample = 0;
 
       uint32_t  adsr_frame    = 0;      // number of frames into the current ADSR phase
       uint32_t  adsr_end_frame = 0;     // frame target at which the ADSR changes to the next phase
       uint32_t  adsr          = 0;
-      ADSRPhase adsr_phase    = ADSRPhase::OFF;
 	    int32_t   adsr_step	    = 0;
+      ADSRPhase adsr_phase    = ADSRPhase::OFF;
 
       uint8_t   wave_buf_pos  = 0;      // 
       int16_t   wave_buffer[64];        // buffer for arbitrary waveforms. small as it's filled by user callback

--- a/32blit/audio/audio.hpp
+++ b/32blit/audio/audio.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace blit {  
 

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "../graphics/surface.hpp"

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -28,10 +28,10 @@ namespace blit {
   
   class File final {
   public:
-    File() {}
+    File() = default;
     File(std::string filename, int mode = OpenMode::read) {open(filename, OpenMode::read);}
     File(const File &) = delete;
-    File(File &&other) {
+    File(File &&other) noexcept {
       *this = std::move(other);
     }
 
@@ -41,7 +41,7 @@ namespace blit {
 
     File &operator=(const File &) = delete;
 
-    File &operator=(File &&other) {
+    File &operator=(File &&other) noexcept {
       if (this != &other) {
         close();
         std::swap(fh, other.fh);

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/32blit/engine/input.hpp
+++ b/32blit/engine/input.hpp
@@ -2,7 +2,7 @@
 
 #include "../types/vec2.hpp"
 #include "../types/vec3.hpp"
-#include <stdint.h>
+#include <cstdint>
 
 namespace blit {
 

--- a/32blit/engine/output.hpp
+++ b/32blit/engine/output.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../graphics/surface.hpp"
-#include <stdint.h>
+#include <cstdint>
 
 namespace blit {
 

--- a/32blit/engine/particle.hpp
+++ b/32blit/engine/particle.hpp
@@ -2,7 +2,7 @@
 
 #include <queue>
 #include <functional>
-#include <stdint.h>
+#include <cstdint>
 #include "../types/vec2.hpp"
 
 struct Particle {

--- a/32blit/engine/profiler.hpp
+++ b/32blit/engine/profiler.hpp
@@ -67,7 +67,7 @@ public:
 	};
 
 
-	ProfilerProbe(const char *pszName, uint32_t uRunningAverageSize = 0, uint32_t uRunningAverageSpan = 1) : m_pszName(pszName), m_uStartUs(0), m_metrics(), m_pRunningAverage(NULL), m_uGraphTimeUs(20000)
+	ProfilerProbe(const char *pszName, uint32_t uRunningAverageSize = 0, uint32_t uRunningAverageSpan = 1) : m_pszName(pszName), m_uStartUs(0), m_metrics(), m_pRunningAverage(nullptr), m_uGraphTimeUs(20000)
 	{
 		if(uRunningAverageSize)
 		{

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -6,8 +6,7 @@
 namespace blit {
   std::vector<Timer *> timers;
 
-  Timer::Timer() {
-  }
+  Timer::Timer() = default;
 
   /**
    * Initialize the timer.

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace blit {

--- a/32blit/engine/tweening.hpp
+++ b/32blit/engine/tweening.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #ifndef M_PI

--- a/32blit/graphics/blend.cpp
+++ b/32blit/graphics/blend.cpp
@@ -1,4 +1,4 @@
-#include <stdint.h>
+#include <cstdint>
 #include <cstring>
 
 #include "surface.hpp"

--- a/32blit/graphics/blend.hpp
+++ b/32blit/graphics/blend.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace blit {
   struct Surface;

--- a/32blit/graphics/font.cpp
+++ b/32blit/graphics/font.cpp
@@ -1,4 +1,4 @@
-#include <stdint.h>
+#include <cstdint>
 
 #include "font.hpp"
 

--- a/32blit/graphics/font.hpp
+++ b/32blit/graphics/font.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace blit {
   struct Font {

--- a/32blit/graphics/jpeg.hpp
+++ b/32blit/graphics/jpeg.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "types/size.hpp"

--- a/32blit/graphics/mode7.cpp
+++ b/32blit/graphics/mode7.cpp
@@ -3,7 +3,6 @@
 
     Functions to emulate the mode7 graphics effect from classic consoles.
 */
-#include "math.h"
 #include <cmath>
 #include <cfloat>
 

--- a/32blit/graphics/mode7.hpp
+++ b/32blit/graphics/mode7.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "surface.hpp"
 #include "../types/map.hpp"

--- a/32blit/graphics/primitive.cpp
+++ b/32blit/graphics/primitive.cpp
@@ -3,7 +3,7 @@
 */
 
 #include <cstdlib>
-#include <math.h>
+#include <cmath>
 
 #include "surface.hpp"
 

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 #include <array>
-#include <stdint.h>
+#include <cstdint>
 
 #ifdef WIN32 
 #define __attribute__(A)

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "../32blit.hpp"
 #include "../types/size.hpp"

--- a/32blit/math/geometry.cpp
+++ b/32blit/math/geometry.cpp
@@ -3,8 +3,8 @@
 
     These are some neat functions for geometry stuff!
 */
-#include <string.h>
-#include <float.h>
+#include <cstring>
+#include <cfloat>
 
 #include "../types/vec3.hpp"
 #include "../types/vec2.hpp"

--- a/32blit/math/geometry.cpp
+++ b/32blit/math/geometry.cpp
@@ -22,7 +22,7 @@
  *
  * \return `true` if intersection occurs
  */
-bool ray_sphere_intersect(Vec3 ray_origin, Vec3 ray_vector, Vec3 sphere_origin, float sphere_radius, Vec3 *point = NULL, float *distance = NULL, Vec3 *normal = NULL) {
+bool ray_sphere_intersect(Vec3 ray_origin, Vec3 ray_vector, Vec3 sphere_origin, float sphere_radius, Vec3 *point = nullptr, float *distance = nullptr, Vec3 *normal = nullptr) {
   Vec3 l = sphere_origin - ray_origin;
   float tca = l.dot(ray_vector);
   float d2 = l.dot(l) - tca * tca;
@@ -73,7 +73,7 @@ bool ray_sphere_intersect(Vec3 ray_origin, Vec3 ray_vector, Vec3 sphere_origin, 
  *
  * \return `true` if intersection occurs
  */
-bool ray_circle_intersect(Vec2 ray_origin, Vec2 ray_vector, Vec2 circle_origin, float circle_radius, Vec2 *point = NULL, float *distance = NULL, Vec2 *normal = NULL) {  
+bool ray_circle_intersect(Vec2 ray_origin, Vec2 ray_vector, Vec2 circle_origin, float circle_radius, Vec2 *point = nullptr, float *distance = nullptr, Vec2 *normal = nullptr) {  
   Vec2 l = ray_origin - circle_origin;
 
   float a = ray_vector.length() * ray_vector.length();
@@ -123,7 +123,7 @@ bool ray_circle_intersect(Vec2 ray_origin, Vec2 ray_vector, Vec2 circle_origin, 
  *
  * \return `true` if intersection occurs
  */
-bool ray_line_intersect(Vec2 ray_origin, Vec2 ray_vector, Vec2 start, Vec2 end, Vec2 *point = NULL, float *distance = NULL) {
+bool ray_line_intersect(Vec2 ray_origin, Vec2 ray_vector, Vec2 start, Vec2 end, Vec2 *point = nullptr, float *distance = nullptr) {
   Vec2 v1 = ray_origin - start;
   Vec2 v2 = end - start;
   Vec2 v3 = Vec2(-ray_vector.y, ray_vector.x);

--- a/32blit/types/mat3.cpp
+++ b/32blit/types/mat3.cpp
@@ -1,6 +1,6 @@
 /*! \file mat3.cpp
 */
-#include <math.h>
+#include <cmath>
 
 #undef M_PI
 #define M_PI           3.14159265358979323846f  /* pi */

--- a/32blit/types/mat4.cpp
+++ b/32blit/types/mat4.cpp
@@ -1,6 +1,6 @@
 /*! \file mat4.cpp
 */
-#include <math.h>
+#include <cmath>
 
 #undef M_PI
 #define M_PI           3.14159265358979323846f  /* pi */

--- a/32blit/types/point.hpp
+++ b/32blit/types/point.hpp
@@ -6,10 +6,10 @@
 namespace blit {
 
   struct Point {
-    int32_t x, y;
+    int32_t x = 0, y = 0;
 
-    Point() : x(0), y(0) {}
-    Point(const Point &p) : x(p.x), y(p.y) {}
+    Point() = default;
+    Point(const Point &p) = default;
     Point(int32_t x, int32_t y) : x(x), y(y) {}
     Point(Vec2 v) : x(int32_t(v.x)), y(int32_t(v.y)) {}
 

--- a/32blit/types/rect.hpp
+++ b/32blit/types/rect.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <algorithm>
-#include <stdint.h>
+#include <cstdint>
 
 #include "point.hpp"
 #include "size.hpp"

--- a/32blit/types/rect.hpp
+++ b/32blit/types/rect.hpp
@@ -10,9 +10,9 @@ namespace blit {
 
   struct Rect {
 
-    int32_t x, y, w, h;
+    int32_t x = 0, y = 0, w = 0, h = 0;
 
-    Rect() : x(0), y(0), w(0), h(0) {}
+    Rect() = default;
     Rect(Point tl, Point br) : x(tl.x), y(tl.y), w(br.x - tl.x), h(br.y - tl.y) {}
     Rect(Point tl, Size s) : x(tl.x), y(tl.y), w(s.w), h(s.h) {}
     Rect(int32_t x, int32_t y, int32_t w, int32_t h) : x(x), y(y), w(w), h(h) {}

--- a/32blit/types/size.hpp
+++ b/32blit/types/size.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "point.hpp"
 

--- a/32blit/types/vec2.cpp
+++ b/32blit/types/vec2.cpp
@@ -1,6 +1,6 @@
 /*! \file vec2.cpp
 */
-#include <string.h>
+#include <cstring>
 
 #include "vec2.hpp"
 #include "mat3.hpp"

--- a/32blit/types/vec2.hpp
+++ b/32blit/types/vec2.hpp
@@ -8,7 +8,7 @@ struct Vec2 {
   float x;
   float y;
 
-  Vec2(const Vec2 &v) : x(v.x), y(v.y) {}
+  Vec2(const Vec2 &v) = default;
   Vec2(const float x = 0, const float y = 0) : x(x), y(y) {}
 
   inline Vec2& operator-= (const Vec2 &a) { x -= a.x; y -= a.y; return *this; }

--- a/32blit/types/vec2.hpp
+++ b/32blit/types/vec2.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "math.h"
+#include <cmath>
 
 struct Mat3;
 

--- a/32blit/types/vec3.cpp
+++ b/32blit/types/vec3.cpp
@@ -12,7 +12,6 @@ extern "C" {
   #include <lua\lauxlib.h>
 }*/
 
-Vec3::Vec3(const Vec3 &v) : x(v.x), y(v.y), z(v.z) {}
 Vec3::Vec3(const float x, const float y, const float z) : x(x), y(y), z(z) {}
 
 

--- a/32blit/types/vec3.cpp
+++ b/32blit/types/vec3.cpp
@@ -1,7 +1,7 @@
 /*! \file vec3.cpp
 */
-#include <math.h>
-#include <string.h>
+#include <cmath>
+#include <cstring>
 
 #include "vec3.hpp"
 #include "mat4.hpp"

--- a/32blit/types/vec3.hpp
+++ b/32blit/types/vec3.hpp
@@ -13,7 +13,7 @@ struct Vec3 {
   float y;
   float z;  
 
-  Vec3(const Vec3 &v);
+  Vec3(const Vec3 &v) = default;
   Vec3(const float x = 0, const float y = 0, const float z = 0);
 
   inline Vec3& operator-= (const Vec3 &a) { x -= a.x; y -= a.y;  z -= a.z; return *this; }

--- a/examples/another-world/another-world.cpp
+++ b/examples/another-world/another-world.cpp
@@ -4,7 +4,7 @@
   by Jonathan Williamson (lowfatcode)
 */
 
-#include <string.h>
+#include <cstring>
 
 #include "32blit.hpp"
 #include "virtual-machine.hpp"

--- a/examples/another-world/byte-killer.hpp
+++ b/examples/another-world/byte-killer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 struct ByteKiller {
   private:

--- a/examples/another-world/byte-killer.hpp
+++ b/examples/another-world/byte-killer.hpp
@@ -70,7 +70,7 @@ struct ByteKiller {
   }
 
   public:
-  ByteKiller() {}
+  ByteKiller() = default;
 
   bool unpack(uint8_t *buffer, uint32_t packed_size) {
     // the data is unpacked from end to start using two pointers

--- a/examples/another-world/resource.cpp
+++ b/examples/another-world/resource.cpp
@@ -5,8 +5,8 @@
   big endian
 */
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 #include <algorithm>
 #include <ctime>
 

--- a/examples/another-world/virtual-machine.cpp
+++ b/examples/another-world/virtual-machine.cpp
@@ -5,8 +5,8 @@
   big endian
 */
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 #include <algorithm>
 #include <ctime>
 

--- a/examples/another-world/virtual-machine.hpp
+++ b/examples/another-world/virtual-machine.hpp
@@ -4,8 +4,8 @@
 #include <array>
 #include <map>
 #include <string>
-#include <stdint.h>
-#include <stdarg.h>
+#include <cstdint>
+#include <cstdarg>
 
 
 #include "byte-killer.hpp"

--- a/examples/audio-test/audio-test.cpp
+++ b/examples/audio-test/audio-test.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/audio-test/audio-test.hpp
+++ b/examples/audio-test/audio-test.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/audio-wave/audio-wave.cpp
+++ b/examples/audio-wave/audio-wave.cpp
@@ -74,7 +74,7 @@ void buffCallBack(void *) {
   if (wavPos >= wavSize) {
     channels[0].off();        // Stop playback of this channel.
     //Clear buffer
-    wavSample = 0;
+    wavSample = nullptr;
     wavSize = 0;
     wavPos = 0;
     wavSampleRate = 0;

--- a/examples/audio-wave/audio-wave.cpp
+++ b/examples/audio-wave/audio-wave.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/audio-wave/audio-wave.hpp
+++ b/examples/audio-wave/audio-wave.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/doom-fire/doom-fire.cpp
+++ b/examples/doom-fire/doom-fire.cpp
@@ -4,7 +4,7 @@
  * 
  */
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/doom-fire/doom-fire.hpp
+++ b/examples/doom-fire/doom-fire.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/fizzlefade/fizzlefade.hpp
+++ b/examples/fizzlefade/fizzlefade.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/flight/flight.cpp
+++ b/examples/flight/flight.cpp
@@ -1,6 +1,6 @@
 
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/flight/flight.hpp
+++ b/examples/flight/flight.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/geometry/geometry.cpp
+++ b/examples/geometry/geometry.cpp
@@ -340,12 +340,12 @@ void update(uint32_t time) {
             if(p.x > screen.bounds.w - 1) {
                 offset.x = std::min(offset.x, screen.bounds.w - p.x);
             } else if (p.x < 0) {
-                offset.x = std::max(offset.x, abs(p.x));
+                offset.x = std::max(offset.x, std::abs(p.x));
             }
             if(p.y > screen.bounds.h - 1) {
                 offset.y = std::min(offset.y, screen.bounds.h - p.y);
             } else if (p.y < 0) {
-                offset.y = std::max(offset.y, abs(p.y));
+                offset.y = std::max(offset.y, std::abs(p.y));
             }
         }
 
@@ -371,12 +371,12 @@ void update(uint32_t time) {
         if(p.x > screen.bounds.w - 1) {
             offset.x = std::min(offset.x, screen.bounds.w - p.x);
         } else if (p.x < 0) {
-            offset.x = std::max(offset.x, abs(p.x));
+            offset.x = std::max(offset.x, std::abs(p.x));
         }
         if(p.y > screen.bounds.h - 1) {
             offset.y = std::min(offset.y, screen.bounds.h - p.y);
         } else if (p.y < 0) {
-            offset.y = std::max(offset.y, abs(p.y));
+            offset.y = std::max(offset.y, std::abs(p.y));
         }
     }
 

--- a/examples/logo/logo.hpp
+++ b/examples/logo/logo.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/matrix-test/matrix-test.cpp
+++ b/examples/matrix-test/matrix-test.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/matrix-test/matrix-test.hpp
+++ b/examples/matrix-test/matrix-test.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/particle/particle.cpp
+++ b/examples/particle/particle.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/particle/particle.hpp
+++ b/examples/particle/particle.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 #include "engine/particle.hpp"

--- a/examples/platformer/platformer.hpp
+++ b/examples/platformer/platformer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/raycaster/raycaster.cpp
+++ b/examples/raycaster/raycaster.cpp
@@ -1,4 +1,4 @@
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <sstream>
 #include <cstdlib>

--- a/examples/raycaster/raycaster.hpp
+++ b/examples/raycaster/raycaster.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/rotozoom/rotozoom.cpp
+++ b/examples/rotozoom/rotozoom.cpp
@@ -1,6 +1,6 @@
 
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/rotozoom/rotozoom.hpp
+++ b/examples/rotozoom/rotozoom.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/serial-debug/serial-debug.cpp
+++ b/examples/serial-debug/serial-debug.cpp
@@ -1,5 +1,5 @@
 #include <cinttypes>
-#include <stdint.h>
+#include <cstdint>
 
 #include "serial-debug.hpp"
 #include "graphics/color.hpp"

--- a/examples/sprite-test/sprite-test.cpp
+++ b/examples/sprite-test/sprite-test.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/sprite-test/sprite-test.hpp
+++ b/examples/sprite-test/sprite-test.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/tilemap-test/tilemap-test.cpp
+++ b/examples/tilemap-test/tilemap-test.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/tilemap-test/tilemap-test.hpp
+++ b/examples/tilemap-test/tilemap-test.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/tilt/tilt.cpp
+++ b/examples/tilt/tilt.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/tilt/tilt.hpp
+++ b/examples/tilt/tilt.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/timer-test/timer-test.cpp
+++ b/examples/timer-test/timer-test.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/timer-test/timer-test.hpp
+++ b/examples/timer-test/timer-test.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/tunnel/tunnel.hpp
+++ b/examples/tunnel/tunnel.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/tween-test/tween-test.cpp
+++ b/examples/tween-test/tween-test.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <cstdlib>
 

--- a/examples/tween-test/tween-test.hpp
+++ b/examples/tween-test/tween-test.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "32blit.hpp"
 

--- a/examples/voxel/voxel.cpp
+++ b/examples/voxel/voxel.cpp
@@ -4,7 +4,7 @@
   by Jonathan Williamson (lowfatcode)
 */
 
-#include <string.h>
+#include <cstring>
 
 #include "32blit.hpp"
 #include "map.hpp"

--- a/tools/src/32Blit.cpp
+++ b/tools/src/32Blit.cpp
@@ -1,9 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
 #include <string>
-#include <string.h>
-#include <time.h>
+#include <cstring>
+#include <ctime>
 
 #if defined(WIN32) || defined(__MINGW32__)
 #include <windows.h>
@@ -11,7 +11,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
-#include <errno.h>
+#include <cerrno>
 #include <dirent.h>
 
 #ifdef __APPLE__

--- a/tools/src/32Blit.cpp
+++ b/tools/src/32Blit.cpp
@@ -42,10 +42,10 @@ void usage(void)
 const char *getFileName(const char *pszPath)
 {
   const char *pszFilename = strrchr(pszPath, '\\');
-  if (pszFilename == NULL)
+  if (pszFilename == nullptr)
     pszFilename = strrchr(pszPath, '/');
 
-  if (pszFilename == NULL)
+  if (pszFilename ==nullptr)
     pszFilename = pszPath;
   else
     pszFilename++;
@@ -484,8 +484,8 @@ int main(int argc, char *argv[])
 
   const char *pszProcess = argv[1];
   std::string sComPort = argv[2];
-  const char *pszBinPath = NULL;
-  const char *pszBinFile = NULL;
+  const char *pszBinPath = nullptr;
+  const char *pszBinFile = nullptr;
   bool bShouldReconnect = false;
 
   if (argc >= 4)


### PR DESCRIPTION
Turns out that CMake has a magic variable to run clang-tidy. So I stuck this in my settings.json...
```
"CMAKE_CXX_CLANG_TIDY": ["clang-tidy", "-header-filter=32blit", "-checks=performance-*,portability-*,modernize-*"]
```

.. and now I have thousands of warnings. This fixes some of the easier find/replace-y ones,