### PR TITLE
Fix JPEG decoding after the compiler changes

### DIFF
--- a/32blit-stm32/Src/jpeg.cpp
+++ b/32blit-stm32/Src/jpeg.cpp
@@ -3,7 +3,9 @@
 #include "stm32h7xx_hal.h"
 #include "stm32h7xx_hal_jpeg.h"
 
+extern "C" {
 #include "JPEG/jpeg_utils.h"
+}
 
 #include "engine/file.hpp"
 #include "graphics/jpeg.hpp"


### PR DESCRIPTION
Wrapping the include in `extern "C"` isn't the nicest way to handle this, but jpeg_utils.h is a generated file. Missed this since there are no users in the repo.