### PR TITLE
Force double-promotion to a compiler error

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -33,7 +33,7 @@ set(EXTERNAL_LOAD_ADDRESS_EXT 0x08000000)
 set(INITIALISE_QSPI_EXT 0)
 set(CDC_FIFO_BUFFERS_EXT 4)
 
-set(COMMON_FLAGS "${MCU_FLAGS} -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Wno-unused-variable -Wno-write-strings")
+set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Werror=double-promotion -Wno-unused-variable -Wno-write-strings")
 
 set(CMAKE_C_FLAGS_INIT "${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS}")

--- a/32blit/engine/tweening.cpp
+++ b/32blit/engine/tweening.cpp
@@ -47,7 +47,7 @@ namespace blit {
   }
 
   float tween_sine(uint32_t t, float b, float c, uint32_t d) {
-    return b + (sin((float(t) / float(d) * M_PI * 2.0f) + (M_PI / 2.0f)) + 1.0f) / 2.0f * (c - b);
+    return b + (sinf((float(t) / float(d) * M_PI * 2.0f) + (M_PI / 2.0f)) + 1.0f) / 2.0f * (c - b);
   }
 
   float tween_linear(uint32_t t, float b, float c, uint32_t d) {

--- a/32blit/graphics/mode7.cpp
+++ b/32blit/graphics/mode7.cpp
@@ -39,16 +39,16 @@ namespace blit {
     float wd = (w - pos).length();
     float dot = f.dot(v);
     float det = f.x * v.y - f.y * v.x;
-    float theta = atan2(det, dot);
-    float costheta = cos(theta);
+    float theta = atan2f(det, dot);
+    float costheta = cosf(theta);
     float ctd = wd * costheta;
 
-    float pd = ctd / cos(hfov);
+    float pd = ctd / cosf(hfov);
 
     float theta_sign = std::copysign(1.0f, theta);
     
-    float hsl = sqrt((pd * pd) - (ctd * ctd));
-    float so = hsl + (sqrt((wd * wd) - (ctd * ctd)) * theta_sign);
+    float hsl = sqrtf((pd * pd) - (ctd * ctd));
+    float so = hsl + (sqrtf((wd * wd) - (ctd * ctd)) * theta_sign);
     float r = so / (hsl * 2.0f);
 
     Vec2 s(

--- a/32blit/types/map.cpp
+++ b/32blit/types/map.cpp
@@ -32,8 +32,8 @@ void MapLayer::mipmap_texture_span(Surface *dest, Point s, uint16_t c, Surface *
   // calculate the mipmap index to use for drawing
   float span_length = (ewc - swc).length();
   float mipmap = ((span_length / float(c)) / 2.0f);
-  uint16_t mipmap_index = floor(mipmap);
-  uint8_t blend = (mipmap - floor(mipmap)) * 255;
+  uint16_t mipmap_index = floorf(mipmap);
+  uint8_t blend = (mipmap - floorf(mipmap)) * 255;
 
   mipmap_index = mipmap_index >= (int)sprites->mipmaps.size() ? sprites->mipmaps.size() - 1 : mipmap_index;
   mipmap_index = mipmap_index < 0 ? 0 : mipmap_index;

--- a/examples/flight/flight.cpp
+++ b/examples/flight/flight.cpp
@@ -245,11 +245,11 @@ void render(uint32_t time_ms) {
 }
 
 bool compare (float v1, float v2) {
-  return fabs(v1-v2) < 0.001f;
+  return fabsf(v1 - v2) < 0.001f;
 }
 
 bool is_off_ground () {
-  return !compare(500.0f,far);
+  return !compare(500.0f, far);
 }
 
 float lerping(float a, float b, float f) {

--- a/examples/hardware-test/hardware-test.cpp
+++ b/examples/hardware-test/hardware-test.cpp
@@ -116,9 +116,9 @@ void render(uint32_t time) {
     screen.text(text_buf, minimal_font, Point(COL2, ROW1+21));
 
     blit::LED = Pen(
-        (float)((sin(blit::now() / 100.0f) + 1) / 2.0f),
-        (float)((cos(blit::now() / 100.0f) + 1) / 2.0f),
-        (float)((sin(blit::now() / 100.0f) + 1) / 2.0f)
+        (float)((sinf(blit::now() / 100.0f) + 1) / 2.0f),
+        (float)((cosf(blit::now() / 100.0f) + 1) / 2.0f),
+        (float)((sinf(blit::now() / 100.0f) + 1) / 2.0f)
     );
 }
 

--- a/examples/palette-cycle/palette-cycle.cpp
+++ b/examples/palette-cycle/palette-cycle.cpp
@@ -41,7 +41,7 @@ void cycle(uint32_t time) {
         int offset = cycle_gradients[g].offset;
         float speed = cycle_gradients[g].speed;
         float t = time / speed;
-        float phase = (t - floor(t));
+        float phase = (t - floorf(t));
         for(int i = 0; i < 12; i++){
             int index = i + t;
             index %= 12;

--- a/examples/palette-swap/palette-swap.cpp
+++ b/examples/palette-swap/palette-swap.cpp
@@ -73,8 +73,8 @@ void all_ships_at_once_demo(uint32_t time) {
 
     Point pos = position[p];
 
-    pos.x += sin(time / 5000.0 + p) * 20;
-    pos.y += sin(time / 500.0 + p) * 10;
+    pos.x += sinf(time / 5000.0f + p) * 20.0f;
+    pos.y += sinf(time / 500.0f + p) * 10.0f;
 
     screen.stretch_blit(screen.sprites,
         Rect(0, 0, boar_ship_size.w, boar_ship_size.h),

--- a/examples/particle/particle.cpp
+++ b/examples/particle/particle.cpp
@@ -69,7 +69,7 @@ void smoke(uint32_t time_ms) {
   if (generate_index >= 150)
     generate_index = 0;
 
-  float w = sin(time_ms / 1000.0f) * 0.05f;
+  float w = sinf(time_ms / 1000.0f) * 0.05f;
 
   for (auto &p : s) {
     if (p.generated) {
@@ -108,7 +108,7 @@ void spark(uint32_t time_ms) {
   if (generate_index >= 500)
     generate_index = 0;
 
-  float w = sin(time_ms / 1000.0f) * 0.05f;
+  float w = sinf(time_ms / 1000.0f) * 0.05f;
 
   Vec2 gravity = Vec2(0, 9.8 * 2) * td;
 
@@ -164,7 +164,7 @@ void rain(uint32_t time_ms) {
   if (generate_index >= 200)
     generate_index = 0;
 
-  float w = sin(time_ms / 1000.0f) * 0.05f;
+  float w = sinf(time_ms / 1000.0f) * 0.05f;
 
   Vec2 gravity = g * td;
 
@@ -229,20 +229,13 @@ void render_basic_rain() {
 uint32_t prev_buttons = blit::buttons;
 
 void render(uint32_t time_ms) {
-
-uint16_t width;
-uint16_t height;
-    if ((blit::buttons ^ prev_buttons) & blit::Button::A) {
-        blit::set_screen_mode(blit::lores);
-        width = 160;
-        height = 120;
-    }
-    else if ((blit::buttons ^ prev_buttons) & blit::Button::B) {
-        blit::set_screen_mode(blit::hires);
-        width = 320;
-        height = 240;
-    }
-    prev_buttons = blit::buttons;
+  if ((blit::buttons ^ prev_buttons) & blit::Button::A) {
+      blit::set_screen_mode(blit::lores);
+  }
+  else if ((blit::buttons ^ prev_buttons) & blit::Button::B) {
+      blit::set_screen_mode(blit::hires);
+  }
+  prev_buttons = blit::buttons;
 
   screen.pen = Pen(0, 0, 0, 255);
   screen.clear();

--- a/examples/raycaster/raycaster.cpp
+++ b/examples/raycaster/raycaster.cpp
@@ -597,7 +597,7 @@ void render_world(uint32_t time) {
 				}*/
 			}
 
-			wall_x -= floor(wall_x);
+			wall_x -= floorf(wall_x);
 
 			// While the perpendicular wall distance prevents fish-eye effect, generally we want
 			// lighting and distance based overlay effects to use the "real" wall distance
@@ -725,8 +725,8 @@ void render_world(uint32_t time) {
 
 				// Get the tile-relative x/y texture coordinates
 				Point tile_uv(
-					(current_floor.x - floor(current_floor.x)) * 32,
-					(current_floor.y - floor(current_floor.y)) * 32
+					(current_floor.x - floorf(current_floor.x)) * 32,
+					(current_floor.y - floorf(current_floor.y)) * 32
 				);
 
 				uint8_t floor_texture = map_layer_floor->tile_at(Point(int(current_floor.x), int(current_floor.y))) - 1;

--- a/examples/scrolly-tile/scrolly-tile.cpp
+++ b/examples/scrolly-tile/scrolly-tile.cpp
@@ -235,7 +235,7 @@ uint8_t render_tile(uint8_t tile, uint8_t x, uint8_t y, void *args) {
 
 uint16_t generate_new_row_mask() {
     uint16_t new_row_mask = 0x0000;
-    uint8_t passage_width = floorf(((sin(current_row / 10.0f) + 1.0f) / 2.0f) * PASSAGE_COUNT);
+    uint8_t passage_width = floorf(((sinf(current_row / 10.0f) + 1.0f) / 2.0f) * PASSAGE_COUNT);
 
     // Cut our consistent winding passage through the level
     // by tracking the x coord of our passage we can ensure
@@ -504,7 +504,7 @@ void update(uint32_t time_ms) {
         water_dist = 0;
     }
 #ifdef __AUDIO__
-    channels[0].volume      = 4000 + (sin(float(time_ms) / 1000.0f) * 3000);
+    channels[0].volume      = 4000 + (sinf(float(time_ms) / 1000.0f) * 3000);
 #endif
 
     if (game_state == enum_state::menu) {
@@ -715,7 +715,7 @@ void render(uint32_t time_ms) {
 
         uint8_t x = 10;
         for(auto c : text) {
-            uint8_t y = 20 + (5.0f * sin((time_ms / 250.0f) + (float(x) / text.length() * 2.0f * M_PIf)));
+            uint8_t y = 20 + (5.0f * sinf((time_ms / 250.0f) + (float(x) / text.length() * 2.0f * M_PIf)));
             Pen color_letter = hsv_to_rgba((x - 10) / 140.0f, 0.5f, 0.8f);
             screen.pen = color_letter;
             char buf[2];
@@ -740,7 +740,7 @@ void render(uint32_t time_ms) {
         screen.rectangle(Rect(0, SCREEN_H - water_level, SCREEN_W, water_level + 1));
 
         for(auto x = 0; x < SCREEN_W; x++){
-            uint16_t offset = x + uint16_t(sin(time_ms / 500.0f) * 5.0f);
+            uint16_t offset = x + uint16_t(sinf(time_ms / 500.0f) * 5.0f);
             if((offset % 5) > 0){
                 screen.pixel(Point(x, SCREEN_H - water_level - 1));
             }
@@ -774,7 +774,7 @@ void render(uint32_t time_ms) {
         screen.rectangle(Rect(0, SCREEN_H - water_level, SCREEN_W, water_level + 1));
 
         for(auto x = 0; x < SCREEN_W; x++){
-            uint16_t offset = x + uint16_t(sin(time_ms / 500.0f) * 5.0f);
+            uint16_t offset = x + uint16_t(sinf(time_ms / 500.0f) * 5.0f);
             if((offset % 5) > 0){
                 screen.pixel(Point(x, SCREEN_H - water_level - 1));
             }

--- a/examples/tilemap-test/tilemap-test.cpp
+++ b/examples/tilemap-test/tilemap-test.cpp
@@ -38,44 +38,44 @@ using namespace blit;
 
 
   std::function<Mat3(uint8_t)> dream = [](uint8_t y) -> Mat3 {
-    float progress = (sin(current_time / 2000.0f) + 1.0f) * 0.6f;  // two second animation
+    float progress = (sinf(current_time / 2000.0f) + 1.0f) * 0.6f;  // two second animation
     progress = progress > 1.0f ? 1.0f : progress;
 
     screen.alpha = progress * 255.0f;
     float step = (current_time / 200.0f) + (y / 10.0f);
-    float x_offset = (sin(step) * (cos(step) * 50.0f)) * (1.0f - progress);
+    float x_offset = (sinf(step) * (cosf(step) * 50.0f)) * (1.0f - progress);
 
     Mat3 transform = Mat3::identity();
-    transform *= Mat3::translation(Vec2(256, 156)); // offset to middle of world      
-    transform *= Mat3::translation(Vec2(x_offset, 0)); // apply dream effect wave      
+    transform *= Mat3::translation(Vec2(256, 156)); // offset to middle of world
+    transform *= Mat3::translation(Vec2(x_offset, 0)); // apply dream effect wave
     transform *= Mat3::translation(Vec2(-80, -60)); // transform to centre of framebuffer
 
     return transform;
   };
 
   std::function<Mat3(uint8_t)> rotozoom = [](uint8_t y) -> Mat3 {
-    float progress = (sin(current_time / 2000.0f) + 1.0f) / 2.0f;  // two second animation
+    float progress = (sinf(current_time / 2000.0f) + 1.0f) / 2.0f;  // two second animation
 
     float angle = (1.0f - progress) * 360.0f;
     float scale = progress;
 
     Mat3 transform = Mat3::identity();
-    transform *= Mat3::translation(Vec2(256, 156)); // offset to middle of world      
-    transform *= Mat3::rotation(deg2rad(angle)); // apply dream effect wave      
-    transform *= Mat3::scale(Vec2(scale, scale)); // apply dream effect wave      
+    transform *= Mat3::translation(Vec2(256, 156)); // offset to middle of world
+    transform *= Mat3::rotation(deg2rad(angle)); // apply dream effect wave
+    transform *= Mat3::scale(Vec2(scale, scale)); // apply dream effect wave
     transform *= Mat3::translation(Vec2(-80, -60)); // transform to centre of framebuffer
 
     return transform;
   };
 
   std::function<Mat3(uint8_t)> zoom = [](uint8_t y) -> Mat3 {
-    float progress = (sin(current_time / 1000.0f) + 1.0f) / 2.0f;  // two second animation    
+    float progress = (sinf(current_time / 1000.0f) + 1.0f) / 2.0f;  // two second animation
 
     float scale = progress;
 
     Mat3 transform = Mat3::identity();
-    transform *= Mat3::translation(Vec2(256, 156)); // offset to middle of world      
-    transform *= Mat3::scale(Vec2(scale, scale)); // apply dream effect wave      
+    transform *= Mat3::translation(Vec2(256, 156)); // offset to middle of world
+    transform *= Mat3::scale(Vec2(scale, scale)); // apply dream effect wave
     transform *= Mat3::translation(Vec2(-80, -60)); // transform to centre of framebuffer
 
     return transform;
@@ -83,7 +83,7 @@ using namespace blit;
 
 
   std::function<Mat3(uint8_t)> perspective = [](uint8_t y) -> Mat3 {
-    float progress = (sin(current_time / 2000.0f) + 1.0f) / 2.0f;  // two second animation
+    float progress = (sinf(current_time / 2000.0f) + 1.0f) / 2.0f;  // two second animation
     progress = progress > 1.0f ? 1.0f : progress;
 
     screen.alpha = y + (255 - 120);
@@ -100,7 +100,7 @@ using namespace blit;
 
   std::function<Mat3(uint8_t)> water = [](uint8_t y) -> Mat3 {
     float step = (current_time / 200.0f) + (y / 10.0f);
-    float x_offset = (sin(step) + sin(step / 3.0f) + sin(step * 2.0f)) * 2.0f;
+    float x_offset = (sinf(step) + sinf(step / 3.0f) + sinf(step * 2.0f)) * 2.0f;
 
     Mat3 transform = Mat3::identity();
     transform *= Mat3::translation(Vec2(156, 130)); // offset to middle of world      
@@ -112,9 +112,9 @@ using namespace blit;
 
   std::function<Mat3(uint8_t)> warp = [](uint8_t y) -> Mat3 {
     float step = (current_time / 1000.0f) + (y / 100.0f);
-    float x_offset = (sin(step) * (cos(step) * 50.0f));
+    float x_offset = (sinf(step) * (cosf(step) * 50.0f));
 
-    float angle = sin(current_time / 500.0f) * 50.0f;
+    float angle = sinf(current_time / 500.0f) * 50.0f;
 
     Mat3 transform = Mat3::identity();
     transform *= Mat3::translation(Vec2(140, 140)); // offset to middle of world      
@@ -128,7 +128,7 @@ using namespace blit;
   std::function<Mat3(uint8_t)> ripple = [](uint8_t y) -> Mat3 {
     float step = (current_time / 250.0f) + (y / 25.0f);
 
-    float scale = (sin(step) / 4.0f) + 1.0f;
+    float scale = (sinf(step) / 4.0f) + 1.0f;
 
     Mat3 transform = Mat3::identity();
     transform *= Mat3::translation(Vec2(256, 156)); // offset to middle of world      
@@ -141,7 +141,7 @@ using namespace blit;
   std::function<Mat3(uint8_t)> betamax = [](uint8_t y) -> Mat3 {
     float step = (current_time / 250.0f) + (y / 25.0f);
 
-    int8_t scale = int8_t((sin(step) + 1.0f) * 5);
+    int8_t scale = int8_t((sinf(step) + 1.0f) * 5);
     Point shake((blit::random() % scale) - scale / 2, (blit::random() % scale) - scale / 2);
 
     Mat3 transform = Mat3::identity();
@@ -160,7 +160,7 @@ using namespace blit;
 
       uint8_t clamp = 20;
       shake = Point(blit::random() % clamp, blit::random() % clamp);
-      float scale = sin(current_time / 300.0f);
+      float scale = sinf(current_time / 300.0f);
 
       scale = scale < 0.0f ? 0.0f : scale;
       shake *= scale;
@@ -225,20 +225,24 @@ using namespace blit;
     }
 
     uint32_t ms_end = now();
+
     /*
     // draw FPS meter
     screen.alpha = 255;
-    screen.pen(Pen(0, 0, 0));
-    screen.rectangle(rect(1, 120 - 10, 12, 9));
-    screen.pen(Pen(255, 255, 255, 200));
+    screen.pen = Pen(0, 0, 0);
+    screen.rectangle(Rect(1, 120 - 10, 12, 9));
+    screen.pen = Pen(255, 255, 255, 200);
     std::string fms = std::to_string(ms_end - ms_start);
-    screen.text(fms, minimal_font, rect(3, 120 - 9, 10, 16));
+    screen.text(fms, minimal_font, Rect(3, 120 - 9, 10, 16));
 
     int block_size = 4;
     for (int i = 0; i < (ms_end - ms_start); i++) {
-      screen.pen(Pen(i * 5, 255 - (i * 5), 0));
-      screen.rectangle(rect(i * (block_size + 1) + 1 + 13, screen.bounds.h - block_size - 1, block_size, block_size));
-    }*/
+      screen.pen = Pen(i * 5, 255 - (i * 5), 0);
+      screen.rectangle(Rect(i * (block_size + 1) + 1 + 13, screen.bounds.h - block_size - 1, block_size, block_size));
+    }
+    */
+
+    screen.watermark();
   }
 
 

--- a/examples/timer-test/timer-test.cpp
+++ b/examples/timer-test/timer-test.cpp
@@ -44,7 +44,6 @@ void init() {
 
 int tick_count = 0;
 void render(uint32_t time_ms) {
-  char text_buffer[60];
   screen.pen = Pen(20, 30, 40);
   screen.clear();
   

--- a/examples/timer-test/timer-test.cpp
+++ b/examples/timer-test/timer-test.cpp
@@ -57,8 +57,7 @@ void render(uint32_t time_ms) {
   // Since our timer callback is updating our `count` variable
   // we can just display it on the screen and watch it tick up!
   screen.pen = Pen(255, 255, 255);
-  sprintf(text_buffer, "Count: %d", count);
-  screen.text(text_buffer, minimal_font, Point(120, 100));
+  screen.text("Count: " + std::to_string(count), minimal_font, Point(120, 100));
 
   // `is_running()` is a handy shorthand for checking the timer state
   if(timer_count.is_running()) {

--- a/examples/tunnel/tunnel.cpp
+++ b/examples/tunnel/tunnel.cpp
@@ -46,8 +46,8 @@ void tunnel_test(uint32_t time_ms) {
 	for (int scanline = 0; scanline < screen.bounds.w; scanline++) {
 
 		float z = 3.0; // Distance from our imaginary wall plane
-		z += sin((time_ms + scanline) / 1000.0f);
-		y = sin((time_ms + scanline) / 200.0f);
+		z += sinf((time_ms + scanline) / 1000.0f);
+		y = sinf((time_ms + scanline) / 200.0f);
 
 		int offset = scanline;
 
@@ -80,8 +80,8 @@ void tunnel_test(uint32_t time_ms) {
 				(float(wall_y) / wall_height)
 			);
 
-			uv.x -= floor(uv.x);
-			uv.y -= floor(uv.y);
+			uv.x -= floorf(uv.x);
+			uv.y -= floorf(uv.y);
 
 
 			uint8_t *fragment_c = screen.sprites->ptr(Point(
@@ -133,8 +133,8 @@ void tunnel_test(uint32_t time_ms) {
 			uv.y = uv.y * weight;
 			uv.y += z * (1.0f - weight);
 
-			uv.x -= floor(uv.x);
-			uv.y -= floor(uv.y);
+			uv.x -= floorf(uv.x);
+			uv.y -= floorf(uv.y);
 
 			uint8_t *fragment_c = screen.sprites->ptr(Point(
 				texture_origin.x + (uv.x * texture_size),
@@ -182,8 +182,8 @@ void tunnel_test(uint32_t time_ms) {
 			uv.y = uv.y * weight;
 			uv.y += z * (1.0f - weight);
 
-			uv.x -= floor(uv.x);
-			uv.y -= floor(uv.y);
+			uv.x -= floorf(uv.x);
+			uv.y -= floorf(uv.y);
 
 			uint8_t *fragment_c = screen.sprites->ptr(Point(
 				texture_origin.x + (uv.x * texture_size),
@@ -208,8 +208,8 @@ void tunnel_test1(uint8_t time_ms) {
 		screen.alpha = 255;
 		int offset = scanline * 2;
 		//float time_offset = (time_ms + offset) / 100.0f;
-		float x = (sin(float(time_ms + offset) / 1000.0f) + 1.0f) / 2.0f;
-		float y = (sin(float(time_ms + offset + 1000) / 2000.0f) + 1.0f) / 2.0f;
+		float x = (sinf(float(time_ms + offset) / 1000.0f) + 1.0f) / 2.0f;
+		float y = (sinf(float(time_ms + offset + 1000) / 2000.0f) + 1.0f) / 2.0f;
 
 		float stripe_height = min_stripe_height + max_stripe_height * y;
 		float stripe_offset_top = (screen.bounds.h / 4) * x;
@@ -267,8 +267,8 @@ void render(uint32_t time_ms) {
 
 	screen.alpha = 255;
 
-	int x = 20 + (sin(time_ms / 1000.0f) * 10.0f);
-	int y = 40 + (sin(time_ms / 1500.0f) * 30.0f);
+	int x = 20 + (sinf(time_ms / 1000.0f) * 10.0f);
+	int y = 40 + (sinf(time_ms / 1500.0f) * 30.0f);
 
 	screen.blit(ss_ship, Rect(0, 0, 64, 32), Point(x, y));
 

--- a/examples/tween-test/tween-test.cpp
+++ b/examples/tween-test/tween-test.cpp
@@ -26,7 +26,6 @@ void init() {
 
 int tick_count = 0;
 void render(uint32_t time_ms) {
-  char text_buffer[60];
   screen.pen = Pen(20, 30, 40);
   screen.clear();
 
@@ -34,8 +33,7 @@ void render(uint32_t time_ms) {
   screen.circle(Point(160, 20+tween_bounce.value), 20);
 
   screen.pen = Pen(255, 255, 255);
-  sprintf(text_buffer, "Value: %f", tween_bounce.value);
-  screen.text(text_buffer, minimal_font, Point(175, 35+tween_bounce.value));
+  screen.text("Value: " + std::to_string(tween_bounce.value), minimal_font, Point(175, 35+tween_bounce.value));
 }
 
 void update(uint32_t time_ms) {

--- a/examples/voxel/voxel.cpp
+++ b/examples/voxel/voxel.cpp
@@ -112,8 +112,8 @@ void draw_world(Vec3 position, float angle, float lean, float horizon, float nea
  
   // convert angle into radians
   angle = deg2rad(angle);
-  float sina = sin(angle);
-  float cosa = cos(angle);
+  float sina = sinf(angle);
+  float cosa = cosf(angle);
 
   // starting z value
   float z = near;
@@ -309,8 +309,8 @@ void update(uint32_t time_ms) {
   }*/
 
   // move player location if joystick y axis is forward/backwards
-  position.x += sin(deg2rad(angle)) * joystick.y;
-  position.y += cos(deg2rad(angle)) * joystick.y;
+  position.x += sinf(deg2rad(angle)) * joystick.y;
+  position.y += cosf(deg2rad(angle)) * joystick.y;
   pitch = joystick.y * 10.0f;
 
   position.x = position.x < 0.0f ? 1023.0f : position.x;


### PR DESCRIPTION
Since inadvertent float-to-double promotion can have serious performance implications on 32Blit hardware, I have promoted the warning to an error and fixed the current `double-promotion` errors.