### PR TITLE
Retrieve battery status and fault in single transaction

### DIFF
--- a/32blit-stm32/Inc/i2c-bq24295.h
+++ b/32blit-stm32/Inc/i2c-bq24295.h
@@ -19,14 +19,22 @@
 #define BQ24295_SYS_FAULT_REGISTER    0x09
 #define BQ24295_ID_REGISTER           0x0A
 
+#define BQ24295_BFAULT_WATCHDOG       0b10000000
+#define BQ24295_BFAULT_OTG            0b01000000
+#define BQ24295_BFAULT_CHARGE         0b00110000
+#define BQ24295_BFAULT_BAT            0b00001000
+#define BQ24295_BFAULT_NTC            0b00000011
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 extern bool bq24295_init(I2C_HandleTypeDef *i2c_port);
+extern uint16_t bq24295_get_statusfault(I2C_HandleTypeDef *i2c_port);
 extern uint8_t bq24295_get_status(I2C_HandleTypeDef *i2c_port);
 extern uint8_t bq24295_get_fault(I2C_HandleTypeDef *i2c_port);
 extern void bq24295_enable_shipping_mode(I2C_HandleTypeDef *i2c_port);
+extern void bq24295_disable_battery_fault_int(I2C_HandleTypeDef *i2c_port);
 
 #ifdef __cplusplus
 }

--- a/32blit-stm32/Src/i2c-bq24295.c
+++ b/32blit-stm32/Src/i2c-bq24295.c
@@ -2,6 +2,7 @@
 
 static void _i2c_send_8(I2C_HandleTypeDef *i2c_port, uint8_t address, uint8_t reg, uint8_t data);
 static uint8_t _i2c_recv_8(I2C_HandleTypeDef *i2c_port, uint8_t address, uint8_t reg);
+static uint16_t _i2c_recv_16(I2C_HandleTypeDef *i2c_port, uint16_t address, uint8_t reg );
 
 bool bq24295_init(I2C_HandleTypeDef *i2c_port) {
     uint8_t chip_id = _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_ID_REGISTER);
@@ -21,12 +22,26 @@ bool bq24295_init(I2C_HandleTypeDef *i2c_port) {
     return false;
 }
 
+uint16_t bq24295_get_statusfault(I2C_HandleTypeDef *i2c_port) {
+    return _i2c_recv_16(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_SYS_STATUS_REGISTER);
+}
+
 uint8_t bq24295_get_status(I2C_HandleTypeDef *i2c_port) {
     return _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_SYS_STATUS_REGISTER);
 }
 
 uint8_t bq24295_get_fault(I2C_HandleTypeDef *i2c_port) {
     return _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_SYS_FAULT_REGISTER);
+}
+
+void bq24295_disable_battery_fault_int(I2C_HandleTypeDef *i2c_port){
+    uint8_t op_timer = _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_TIMER_REGISTER);
+    op_timer &= 0b11001111; // Set WATCHDOG to 0b00
+    _i2c_send_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_TIMER_REGISTER, op_timer);
+
+    uint8_t op_control = _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_OP_CONTROL_REGISTER);
+    op_control &= ~0b00000011; // Set INT_MASK BAT_FAULT bit to 0
+    _i2c_send_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_OP_CONTROL_REGISTER, op_control);
 }
 
 void bq24295_enable_shipping_mode(I2C_HandleTypeDef *i2c_port){
@@ -52,4 +67,14 @@ static void _i2c_send_8(I2C_HandleTypeDef *i2c_port, uint8_t address, uint8_t re
     data_buffer[0] = reg;
     data_buffer[1] = data;
     HAL_I2C_Master_Transmit(i2c_port, address, &data_buffer[0], 2, HAL_TIMEOUT);
+}
+
+static uint16_t _i2c_recv_16(I2C_HandleTypeDef *i2c_port, uint16_t address, uint8_t reg ){
+  uint8_t receive_buffer[2];
+
+  HAL_I2C_Master_Transmit(i2c_port, address, &reg, 1, HAL_TIMEOUT); //set register pointer
+  HAL_Delay(1);
+  HAL_I2C_Master_Receive(i2c_port, address, &receive_buffer[0], 2, HAL_TIMEOUT); //read two bytes from register
+
+  return (uint16_t)(receive_buffer[0] << 8) + receive_buffer [1]; //combine MSB LSB
 }

--- a/32blit/engine/input.hpp
+++ b/32blit/engine/input.hpp
@@ -18,7 +18,7 @@ namespace blit {
     HOME = 512,
     JOYSTICK = 1024
   };
-  
+
   extern bool pressed(uint32_t button);
- 
+
 }

--- a/examples/hardware-test/hardware-test.cpp
+++ b/examples/hardware-test/hardware-test.cpp
@@ -4,10 +4,6 @@
 
 using namespace blit;
 
-extern uint8_t battery_status;
-extern uint8_t battery_fault;
-extern float battery;
-
 #define SCREEN_WIDTH 160
 #define SCREEN_HEIGHT 120
 

--- a/examples/hardware-test/hardware-test.cpp
+++ b/examples/hardware-test/hardware-test.cpp
@@ -4,6 +4,10 @@
 
 using namespace blit;
 
+extern uint8_t battery_status;
+extern uint8_t battery_fault;
+extern float battery;
+
 #define SCREEN_WIDTH 160
 #define SCREEN_HEIGHT 120
 


### PR DESCRIPTION
This change combines the status/fault register retrival into a single transaction of the two bytes. Not only is it less overhead, but puts us in a good position to pull this data using interrupt-driven i2c transactions.