### PR TITLE
Use TIM2 for sys button debounce, long press

### DIFF
--- a/32blit-stm32/Inc/stm32h7xx_it.h
+++ b/32blit-stm32/Inc/stm32h7xx_it.h
@@ -63,6 +63,7 @@ void DMA1_Stream1_IRQHandler(void);
 //void DMA1_Stream2_IRQHandler(void);
 void ADC_IRQHandler(void);
 void ADC3_IRQHandler(void);
+void TIM2_IRQHandler(void);
 void TIM3_IRQHandler(void);
 void TIM4_IRQHandler(void);
 //void TIM6_DAC_IRQHandler(void);

--- a/32blit-stm32/Inc/tim.h
+++ b/32blit-stm32/Inc/tim.h
@@ -30,6 +30,7 @@
 
 /* USER CODE END Includes */
 
+extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim4;
 
@@ -39,6 +40,7 @@ extern TIM_HandleTypeDef htim15;
 
 /* USER CODE END Private defines */
 
+void MX_TIM2_Init(void);
 void MX_TIM3_Init(void);
 void MX_TIM4_Init(void);
 

--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -46,6 +46,7 @@ FRESULT SD_Error = FR_INVALID_PARAMETER;
 FRESULT SD_FileOpenError = FR_INVALID_PARAMETER;
 
 bool needs_render = true;
+bool exit_game = false;
 uint32_t flip_cycle_count = 0;
 float volume_log_base = 2.0f;
 
@@ -55,8 +56,6 @@ uint8_t battery_fault;
 float battery;
 
 const uint32_t long_press_exit_time = 1000;
-
-uint32_t home_button_pressed_time = 0;
 
 __attribute__((section(".persist"))) Persist persist;
 
@@ -100,6 +99,15 @@ uint32_t GetMaxUsTimer(void)
 }
 
 void blit_tick() {
+  if(exit_game) {
+    #if EXTERNAL_LOAD_ADDRESS == 0x90000000
+      // Already in firmware menu
+    #else
+    blit::LED.r = 0;
+    blit_switch_execution();
+    #endif
+  }
+
   if(display::needs_render) {
     blit::render(blit::now());
     display::enable_vblank_interrupt();
@@ -110,15 +118,6 @@ void blit_tick() {
   blit_update_vibration();
 
   blit::tick(blit::now());
-
-  if(home_button_pressed_time > 0 && HAL_GetTick() - home_button_pressed_time > long_press_exit_time) {
-      #if EXTERNAL_LOAD_ADDRESS == 0x90000000
-        // Already in firmware menu
-      #else
-        blit_switch_execution();
-      #endif
-      home_button_pressed_time = 0;
-  }
 }
 
 bool blit_sd_detected() {
@@ -145,15 +144,11 @@ void blit_update_volume() {
 }
 
 void blit_init() {
-    // Ensure releasing a held down button that hasn't been pressed
-    // doesn't launch the menu right away
-    home_button_pressed_time = 0;
-
     // enable backup sram
     __HAL_RCC_RTC_ENABLE();
     __HAL_RCC_BKPRAM_CLK_ENABLE();
     HAL_PWR_EnableBkUpAccess(); 
-    HAL_PWREx_EnableBkUpReg(); 
+    HAL_PWREx_EnableBkUpReg();
 
     // need to wit for sram, I tried a few things I found on the net to wait
     // based on PWR flags but none seemed to work, a simple delay does work!
@@ -178,7 +173,6 @@ void blit_init() {
     HAL_ADC_Start_DMA(&hadc1, (uint32_t *)adc1data, ADC_BUFFER_SIZE);
     HAL_ADC_Start_DMA(&hadc3, (uint32_t *)adc3data, ADC_BUFFER_SIZE);
 
-    
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
     DWT->CYCCNT = 0;
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
@@ -329,13 +323,13 @@ void blit_menu_update(uint32_t time) {
 }
 
 void blit_menu_render(uint32_t time) {
-#if EXTERNAL_LOAD_ADDRESS == 0x90000000  // TODO We probably need a nicer way of detecting that we're compiling a firmware build (-DFIRMWARE maybe?)
+  #if EXTERNAL_LOAD_ADDRESS == 0x90000000  // TODO We probably need a nicer way of detecting that we're compiling a firmware build (-DFIRMWARE maybe?)
   // Don't attempt to render firmware game selection menu behind system menu
   // At the moment `render` handles input in the firmware, so this results
   // in all kinds of fun an exciting weirdness.
-#else
+  #else
   ::render(time);
-#endif
+  #endif
   int screen_width = 160;
   int screen_height = 120;
   if (display::mode == blit::ScreenMode::hires) {
@@ -480,16 +474,42 @@ void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc) {
   }
 }
 
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
+  if(htim == &htim2) {
+    bool pressed = !HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port, BUTTON_MENU_Pin);
+    if(pressed) {
+      exit_game = true;
+    }
+    HAL_TIM_Base_Stop(&htim2);
+    HAL_TIM_Base_Stop_IT(&htim2);
+  }
+}
+
 void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-  if(!HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port, BUTTON_MENU_Pin)) {
-    home_button_pressed_time = HAL_GetTick();
+  bool pressed = !HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port, BUTTON_MENU_Pin);
+  if(pressed) {
+    /*
+    The timer will generate a spurious interrupt as soon as it's enabled- apparently to load the compare value.
+    We disable interrupts and clear this early interrupt flag before re-enabling them so that the *real*
+    interrupt can fire. 
+    */
+    HAL_NVIC_DisableIRQ(TIM2_IRQn);
+    __HAL_TIM_SetCounter(&htim2, 0);
+    __HAL_TIM_SetCompare(&htim2, TIM_CHANNEL_1, long_press_exit_time * 10); // press-to-reset-time
+    HAL_TIM_Base_Start(&htim2);
+    HAL_TIM_Base_Start_IT(&htim2);
+    __HAL_TIM_CLEAR_FLAG(&htim2, TIM_SR_UIF);
+    HAL_NVIC_EnableIRQ(TIM2_IRQn);
+
   } else {
-    if(home_button_pressed_time > 0 && HAL_GetTick() - home_button_pressed_time > 20) {
+    if(__HAL_TIM_GetCounter(&htim2) > 200){ // 20ms debounce time
       // TODO is it a good idea to swap out the render/update functions potentially in the middle of a loop?
       // We were more or less doing this before by handling the menu update between render/update so perhaps it's mostly fine.
       blit_menu();
+      HAL_TIM_Base_Stop(&htim2);
+      HAL_TIM_Base_Stop_IT(&htim2);
+      __HAL_TIM_SetCounter(&htim2, 0);
     }
-    home_button_pressed_time = 0;
   }
 }
 
@@ -662,11 +682,11 @@ pFunction JumpToApplication;
 
 void blit_switch_execution(void)
 {
-#if EXTERNAL_LOAD_ADDRESS == 0x90000000
+  #if EXTERNAL_LOAD_ADDRESS == 0x90000000
   persist.reset_target = prtGame;
-#else
+  #else
   persist.reset_target = prtFirmware;
-#endif
+  #endif
   // Stop the ADC DMA
   HAL_ADC_Stop_DMA(&hadc1);
   HAL_ADC_Stop_DMA(&hadc3);
@@ -674,6 +694,9 @@ void blit_switch_execution(void)
   // Stop the audio
   HAL_TIM_Base_Stop_IT(&htim6);
   HAL_DAC_Stop(&hdac1, DAC_CHANNEL_2);
+
+  // Stop system button timer
+  HAL_TIM_Base_Stop_IT(&htim2);
 
   // stop USB
   USBD_Stop(&hUsbDeviceHS);
@@ -687,6 +710,7 @@ void blit_switch_execution(void)
   HAL_NVIC_DisableIRQ(TIM6_DAC_IRQn);
   HAL_NVIC_DisableIRQ(OTG_HS_IRQn);
   HAL_NVIC_DisableIRQ(EXTI9_5_IRQn);
+  HAL_NVIC_DisableIRQ(TIM2_IRQn);
 
 	volatile uint32_t uAddr = EXTERNAL_LOAD_ADDRESS;
 	// enable qspi memory mapping if needed

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -122,6 +122,7 @@ int main(void)
   //MX_GPIO_Init();
 
   MX_DMA_Init();
+  MX_TIM2_Init();
   MX_TIM4_Init();
   MX_TIM3_Init();
   //MX_DAC1_Init();

--- a/32blit-stm32/Src/stm32h7xx_it.c
+++ b/32blit-stm32/Src/stm32h7xx_it.c
@@ -67,6 +67,7 @@ extern ADC_HandleTypeDef hadc1;
 extern ADC_HandleTypeDef hadc3;
 extern PCD_HandleTypeDef hpcd_USB_OTG_HS;
 extern DMA_HandleTypeDef hdma_dac1_ch2;
+extern TIM_HandleTypeDef htim2;
 
 /* USER CODE BEGIN EV */
 
@@ -291,6 +292,20 @@ void DMAMUX1_OVR_IRQHandler(void)
   /* USER CODE BEGIN DMAMUX1_OVR_IRQn 1 */
 
   /* USER CODE END DMAMUX1_OVR_IRQn 1 */
+}
+
+/**
+  * @brief This function handles TIM2 global interrupt.
+  */
+void TIM2_IRQHandler(void)
+{
+  /* USER CODE BEGIN TIM2_IRQn 0 */
+
+  /* USER CODE END TIM2_IRQn 0 */
+  HAL_TIM_IRQHandler(&htim2);
+  /* USER CODE BEGIN TIM2_IRQn 1 */
+
+  /* USER CODE END TIM2_IRQn 1 */
 }
 
 /**

--- a/32blit-stm32/Src/tim.c
+++ b/32blit-stm32/Src/tim.c
@@ -26,10 +26,43 @@
 
 /* USER CODE END 0 */
 
+TIM_HandleTypeDef htim2;
 TIM_HandleTypeDef htim3;
 TIM_HandleTypeDef htim4;
 
 TIM_HandleTypeDef htim15;
+
+/* TIM2 init function */
+void MX_TIM2_Init(void)
+{
+  TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+  TIM_MasterConfigTypeDef sMasterConfig = {0};
+
+  htim2.Instance = TIM2;
+  htim2.Init.Prescaler = 24000;
+  htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
+  htim2.Init.Period = 10000;
+  htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim2.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+
+  if (HAL_TIM_Base_Init(&htim2) != HAL_OK)
+  {
+    Error_Handler();
+  }
+
+  sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+  if (HAL_TIM_ConfigClockSource(&htim2, &sClockSourceConfig) != HAL_OK)
+  {
+    Error_Handler();
+  }
+  sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+  if (HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig) != HAL_OK)
+  {
+    Error_Handler();
+  }
+
+}
 
 /* TIM3 init function */
 void MX_TIM3_Init(void)
@@ -184,7 +217,23 @@ void MX_TIM15_Init(void)
 void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* tim_baseHandle)
 {
 
-  if(tim_baseHandle->Instance==TIM3)
+  if(tim_baseHandle->Instance==TIM2)
+  {
+  /* USER CODE BEGIN TIM2_MspInit 0 */
+
+  /* USER CODE END TIM2_MspInit 0 */
+    /* TIM2 clock enable */
+    __HAL_RCC_TIM2_CLK_ENABLE();
+
+    /* TIM2 interrupt Init */
+    __HAL_TIM_CLEAR_FLAG(tim_baseHandle, TIM_SR_UIF);
+    HAL_NVIC_SetPriority(TIM2_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(TIM2_IRQn);
+  /* USER CODE BEGIN TIM2_MspInit 1 */
+
+  /* USER CODE END TIM2_MspInit 1 */
+  }
+  else if(tim_baseHandle->Instance==TIM3)
   {
   /* USER CODE BEGIN TIM3_MspInit 0 */
 


### PR DESCRIPTION
This change uses Timer 2 to enhance the clunky button debounce and long press code so we don't need to mess around comparing a time value to `HAL_GetTick()`.