### PR TITLE
400KHz i2c with slight rise/fall slew

### DIFF
--- a/32blit-stm32/Src/i2c.c
+++ b/32blit-stm32/Src/i2c.c
@@ -31,7 +31,7 @@ void MX_I2C4_Init(void)
 {
 
   hi2c4.Instance = I2C4;
-  hi2c4.Init.Timing = 0x307075B1;
+  hi2c4.Init.Timing = 0x20401943;
   hi2c4.Init.OwnAddress1 = 0;
   hi2c4.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
   hi2c4.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;


### PR DESCRIPTION
The i2c timing value is frustratingly cryptic, but this is an attempt at using STM32 Cube MX to switch the bus into 400KHz mode with a rise/fall time of 10us.

Since we're running in interrupt-driven i2c anyway this will probably have no immediate benefit, but in my experience the number of i2c devices that require 100KHz mode is slim to none and none of them are soldered onto our PCB so we're good.

(If you're a future hacker of 32Blit trying to use our i2c trackball, this probably broke compatibility)