### PR TITLE
Reset button state before launching app

### DIFF
--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -783,6 +783,10 @@ void blit_switch_execution(void)
   #else
   persist.reset_target = prtFirmware;
   #endif
+
+  // Reset button state, this prevents the user app immediately seeing the last button transition used to launch the game
+  buttons = 0;
+
   // Stop the ADC DMA
   HAL_ADC_Stop_DMA(&hadc1);
   HAL_ADC_Stop_DMA(&hadc3);


### PR DESCRIPTION
Found a weird bug where Particle would start in lores, even though init set hires mode. This was because the button state was (correctly) carrying over in the shared-memory API from the firmware to the user code and immediately triggering the resolution switch.

This ensures user code gets a fresh button state.