### PR TITLE
Fix battery voltage ADC reading

### DIFF
--- a/32blit-stm32/Src/adc.c
+++ b/32blit-stm32/Src/adc.c
@@ -125,7 +125,7 @@ void MX_ADC3_Init(void)
   */
   sConfig.Channel = ADC_CHANNEL_11;
   sConfig.Rank = ADC_REGULAR_RANK_1;
-  sConfig.SamplingTime = ADC_SAMPLETIME_32CYCLES_5;
+  sConfig.SamplingTime = ADC_SAMPLETIME_810CYCLES_5;
   sConfig.SingleDiff = ADC_SINGLE_ENDED;
   sConfig.OffsetNumber = ADC_OFFSET_NONE;
   sConfig.Offset = 0;

--- a/32blit-stm32/Src/gpio.cpp
+++ b/32blit-stm32/Src/gpio.cpp
@@ -90,8 +90,12 @@ namespace gpio {
     // user hack headers
     init_pin(GPIOC, USER_LEFT1_Pin, GPIO_MODE_ANALOG, GPIO_NOPULL); // left analog
     init_pin(GPIOC, USER_LEFT2_Pin, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL); // left digital
-    // missing a user right 1 here? analog?
+    init_pin(GPIOC, USER_RIGHT1_Pin, GPIO_MODE_ANALOG, GPIO_NOPULL); // right analog
     init_pin(GPIOC, USER_RIGHT2_Pin, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL); // right digital
+
+    // battery sense
+    init_pin(GPIOC, BATTERY_SENSE_Pin, GPIO_MODE_ANALOG, GPIO_NOPULL); // battery sense
+
     
     // "gpio" pin on extension header
     init_pin(GPIOC, EXTENSION_GPIO_Pin, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL); // left digital


### PR DESCRIPTION
Battery voltage has been broken for a while, probably in the migration from normal to interrupt-driven ADC.

I've added GPIO config for the relevant ADC channels, albeit they seemed to work without it. It's best to be explicit.

I've switched from 32.5 cycle integration time to 810.5. With 256 sample oversampling this means each of the four ADC3 readings takes 0.43ms, but since it's asyncronous that's largely irrelevant.

It seems - at an educated guess - the longer integration time is required to successfully read a voltage through the 1MOhm resistor divider pair.

This should fix:
1. Battery meter should be stable, instead of flickering around like a flag in a thunderstorm
2. Battery voltage should give sensible output

Note: Battery meter is still nonsense, since it does not adjust for the nonlinear discharge curve