### PR TITLE
Add -fno-exceptions to the toolchain

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -36,7 +36,7 @@ set(CDC_FIFO_BUFFERS_EXT 4)
 set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Werror=double-promotion -Wno-unused-variable -Wno-write-strings")
 
 set(CMAKE_C_FLAGS_INIT "${COMMON_FLAGS}")
-set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS}")
+set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS} -fno-exceptions")
 set(CMAKE_C_FLAGS_DEBUG_INIT "-g -Og")
 set(CMAKE_CXX_FLAGS_DEBUG_INIT "-g -Og")
 #set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nano.specs -T ${MCU_LINKER_SCRIPT} -Wl,--gc-sections")


### PR DESCRIPTION
Decreases code size, also libstdc++_nano is already compiled with this.