### PR TITLE
Avoid initialising the API struct

### DIFF
--- a/32blit/engine/api.cpp
+++ b/32blit/engine/api.cpp
@@ -1,11 +1,16 @@
 #include "api.hpp"
 #include "api_private.hpp"
 
+#ifdef TARGET_32BLIT_HW
+extern char __api_start;
+#endif
+
 namespace blit {
 #ifdef TARGET_32BLIT_HW
-  __attribute__((section(".api"))) API api;
+  API &api = *(API *)&__api_start;
 #else
-  API api;
+  API real_api;
+  API &api = real_api;
 #endif
 
   uint32_t &buttons = api.buttons;

--- a/32blit/engine/api.cpp
+++ b/32blit/engine/api.cpp
@@ -13,6 +13,8 @@ namespace blit {
   API &api = real_api;
 #endif
 
+  static_assert(sizeof(API) < 2048);
+
   uint32_t &buttons = api.buttons;
   float &hack_left = api.hack_left;
   float &hack_right = api.hack_right;

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -55,5 +55,5 @@ namespace blit {
   };
   #pragma pack(pop)
 
-  extern API api;
+  extern API &api;
 }


### PR DESCRIPTION
Possibly fixes the OpenOCD flashing problem.