### PR TITLE
Fix opening files for writing through the constructor

### DIFF
--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -29,7 +29,7 @@ namespace blit {
   class File final {
   public:
     File() = default;
-    File(std::string filename, int mode = OpenMode::read) {open(filename, OpenMode::read);}
+    File(std::string filename, int mode = OpenMode::read) {open(filename, mode);}
     File(const File &) = delete;
     File(File &&other) noexcept {
       *this = std::move(other);


### PR DESCRIPTION
`blit::File f("blah", blit::OpenMode::write)` now doesn't ignore you and open the file for reading instead... (Oops, again.)