### PR TITLE
Assets/memory as files

### DIFF
--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -34,7 +34,7 @@ namespace blit {
     // check for buffer
     auto it = buf_files.find(file);
 
-    if (it != buf_files.end()) {
+    if (mode == OpenMode::read && it != buf_files.end()) {
       buf = it->second.ptr;
       buf_len = it->second.length;
       return true;

--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -14,7 +14,21 @@ namespace blit {
   static std::map<std::string, BufferFile> buf_files;
 
   std::vector<FileInfo> list_files(std::string path) {
-    return api.list_files(path);
+    auto ret = api.list_files(path);
+
+    for(auto &buf_file : buf_files) {
+      auto slash_pos = buf_file.first.find_last_of('/');
+      if(slash_pos == std::string::npos)
+        slash_pos = 0;
+      
+      if(buf_file.first.substr(0, slash_pos) == path) {
+        FileInfo info = {};
+        info.name = buf_file.first.substr(slash_pos == 0 ? 0 : slash_pos + 1);
+        ret.push_back(info);
+      }
+    }
+
+    return ret;
   }
 
   bool file_exists(std::string path) {

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -45,6 +45,8 @@ namespace blit {
       if (this != &other) {
         close();
         std::swap(fh, other.fh);
+        std::swap(buf, other.buf);
+        std::swap(buf_len, other.buf_len);
       }
       return *this;
     }
@@ -56,10 +58,21 @@ namespace blit {
     uint32_t get_length();
 
     bool is_open() const {
-      return fh != nullptr;
+      return buf != nullptr || fh != nullptr;
     }
 
+    // for buffers pretending to be files
+    const uint8_t *get_ptr() const {
+      return buf;
+    }
+
+    static void add_buffer_file(std::string path, const uint8_t *ptr, uint32_t len);
+
   private:
-     void *fh = nullptr;
+      void *fh = nullptr;
+
+      // buffer "files"
+      const uint8_t *buf = nullptr;
+      uint32_t buf_len;
   };
 }


### PR DESCRIPTION
Adds a way to use embedded assets (or any memory) as if they were files. Useful for porting things that expect data to be in files.

One minor issue is that:
```
File::add_buffer_file("some/dir/file.thing", ...);
directory_exists("some/dir");
```

will return false.