### PR TITLE
Use a newer toolchain for Travis STM32 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,15 @@ jobs:
         - RELEASE_FILE=${TRAVIS_BUILD_DIR}${REPO}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}-STM32
       addons:
         apt:
-          gcc-arm-none-eabi
-          libnewlib-arm-none-eabi
-          libstdc++-arm-none-eabi-newlib
-          python3-pip
-          python3-setuptools
-          zip
+          sources:
+            sourceline: "ppa:daft-freak/arm-gcc"
+          packages:
+            gcc-arm-none-eabi
+            libnewlib-arm-none-eabi
+            libstdc++-arm-none-eabi-newlib
+            python3-pip
+            python3-setuptools
+            zip
       install:
         - python3 -m pip install 32blit bitstring construct
       after_success:

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -19,6 +19,10 @@ After that, proceed to the Microsoft Store to download Ubuntu for WSL.
 The following requirements enable cross-compile to 32Blit via ARM GCC and to Windows via MinGW:
 
 ```shell
+# Ubuntu 18.04's gcc-arm-none-eabi is too old, this repo backports the one from 19.10
+sudo add-apt-repository ppa:daft-freak/arm-gcc
+sudo apt update
+
 sudo apt install gcc gcc-arm-none-eabi gcc-mingw-w64 g++-mingw-w64 unzip cmake make python3 python3-pip
 pip3 install construct bitstring
 ```


### PR DESCRIPTION
Uses a PPA containing GCC/newlib backported from Ubuntu 19.10. I'm not planning on changing anything in there so it should be stable. Also adds the PPA to the WSL instructions.

The main reason for this is that Ubuntu 18.04 has GCC 6.3 and GCC 7 is required for most of C++17. 
https://gcc.gnu.org/projects/cxx-status.html#cxx17
https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2017