### PR TITLE
Fix multi-block SD card writes

### DIFF
--- a/32blit-stm32/Src/fatfs_sd.c
+++ b/32blit-stm32/Src/fatfs_sd.c
@@ -193,6 +193,8 @@ static bool SD_TxDataBlock(const uint8_t *buff, BYTE token)
 		/* recv buffer clear */
 		while (SPI_RxByte() == 0);
 	}
+	else
+		return TRUE;
 
 	/* transmit 0x05 accepted */
 	if ((resp & 0x1F) == 0x05) return TRUE;


### PR DESCRIPTION
it would fail after writing all the data as `resp` is uninitialised when sending a stop token.

(More bugs in the SD card code, yay)