### PR TITLE
"Fix" ~1000 warnings

### DIFF
--- a/32blit-stm32/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_adc.h
+++ b/32blit-stm32/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_adc.h
@@ -23,6 +23,8 @@
 
 #ifdef __cplusplus
 extern "C" {
+ 
+#define register // removed in C++17, has no effect at > -O0 anyway
 #endif
 
 /* Includes ------------------------------------------------------------------*/


### PR DESCRIPTION
`#define` out `register` when compiling `stm32h7xx_ll_adc.h` as C++. This file gets included indirectly by anything using the HAL, which causes a total of over 1000 warnings. This is a little annoying.

This should be entirely safe as GCC only obeys `register` when not optimising (or some other cases that don't apply here, see: https://gcc.gnu.org/onlinedocs/gcc/Hints-implementation.html)