### PR TITLE
Update voxel CMakeLists to 3.8

### DIFF
--- a/examples/audio-test/CMakeLists.txt
+++ b/examples/audio-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
-project (tilt)
+cmake_minimum_required(VERSION 3.8)
+project (audio-test)
 include (../../32blit.cmake)
 blit_executable (audio-test audio-test.cpp)

--- a/examples/audio-wave/CMakeLists.txt
+++ b/examples/audio-wave/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8)
 project (audio-wave)
 include (../../32blit.cmake)
 blit_executable (audio-wave audio-wave.cpp)

--- a/examples/voxel/CMakeLists.txt
+++ b/examples/voxel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8)
 project (voxel)
 include (../../32blit.cmake)
 blit_executable (voxel voxel.cpp)


### PR DESCRIPTION
This one was missed since it hadn't been bumped to 3.1. Pointed out by @lenardg.