### PR TITLE
Fix buttons in flash-loader + a few other firmware/flash-loader bits

### DIFF
--- a/32blit-stm32/Inc/USBManager.h
+++ b/32blit-stm32/Inc/USBManager.h
@@ -4,6 +4,8 @@
 #include "usb_device.h"
 #include "i2c.h"
 
+extern USBD_HandleTypeDef hUsbDeviceHS;
+
 class USBManager
 {
 public:
@@ -71,6 +73,14 @@ public:
 	{
 		// On linux we seem to get many start/stops so use a timer to set mount status.
 		const uint32_t uMountUnmountTime = 500;
+
+		// can't be mounted if there's no usb connection
+		// maybe show some kind of warning if previously mounted?
+		if(hUsbDeviceHS.dev_state != USBD_STATE_CONFIGURED)
+		{
+			m_state = usbsMSCInititalising;
+			m_bHasHadSomeActivity = false;
+		}
 
 		switch(m_state)
 		{

--- a/32blit-stm32/Src/32blit.c
+++ b/32blit-stm32/Src/32blit.c
@@ -121,6 +121,9 @@ std::string battery_vbus_status() {
     case 0b11: // OTG
       return "OTG";
   }
+
+  // unreachable
+  return "";
 }
 
 std::string battery_charge_status() {
@@ -134,6 +137,9 @@ std::string battery_charge_status() {
     case 0b11: // Charge Done
       return "Done";
   }
+
+  // unreachable
+  return "";
 }
 
 void blit_tick() {

--- a/firmware/flash-loader/flash-loader.cpp
+++ b/firmware/flash-loader/flash-loader.cpp
@@ -220,15 +220,6 @@ void FlashLoader::RenderMassStorage(uint32_t time)
 		if(g_usbManager.HasHadActivity())
 			uActivityAnim = 255;
 	}
-
-
-	if(g_usbManager.GetState() == USBManager::usbsMSCUnmounted)
-	{
-		// Swicth back to CDC
-		g_usbManager.SetType(USBManager::usbtCDC);
-		FSInit();
-		m_state = stFlashFile;
-	}
 }
 
 // RenderSaveFile() Render file save progress %
@@ -292,6 +283,8 @@ void FlashLoader::Update(uint32_t time)
 		FSInit();
 		m_state = stFlashFile;
 	}
+
+	bool button_home = buttons.pressed & Button::HOME;
 	
 	if(m_state == stFlashFile)
 	{
@@ -306,8 +299,6 @@ void FlashLoader::Update(uint32_t time)
 
 		bool button_up = buttons.pressed & Button::DPAD_UP;
 		bool button_down = buttons.pressed & Button::DPAD_DOWN;
-
-		bool button_home = buttons.pressed & Button::HOME;
 
 		if(time - lastRepeat > 150 || button_up || button_down) {
 			button_up = buttons & Button::DPAD_UP;
@@ -361,6 +352,22 @@ void FlashLoader::Update(uint32_t time)
 		}
 
 		persist.selected_menu_item = m_uCurrentFile;
+	}
+	else if(m_state == stMassStorage)
+	{
+		bool switch_back = g_usbManager.GetState() == USBManager::usbsMSCUnmounted;
+
+		// allow switching back manually if it was never mounted
+		if(button_home && g_usbManager.GetState() == USBManager::usbsMSCInititalising)
+			switch_back = true;
+
+		if(switch_back)
+		{
+			// Switch back to CDC
+			g_usbManager.SetType(USBManager::usbtCDC);
+			FSInit();
+			m_state = stFlashFile;
+		}
 	}
 }
 

--- a/firmware/flash-loader/flash-loader.cpp
+++ b/firmware/flash-loader/flash-loader.cpp
@@ -259,26 +259,6 @@ void FlashLoader::RenderFlashCDC(uint32_t time)
 // RenderFlashFile() Render main ui for selecting files to flash
 void FlashLoader::RenderFlashFile(uint32_t time)
 {
-	static uint32_t lastRepeat = 0;
-
-	if(!m_bFsInit)
-		FSInit();
-
-	bool button_a = buttons.pressed & Button::A;
-	bool button_x = buttons.pressed & Button::X;
-	bool button_y = buttons.pressed & Button::Y;
-
-	bool button_up = buttons.pressed & Button::DPAD_UP;
-	bool button_down = buttons.pressed & Button::DPAD_DOWN;
-
-	bool button_home = buttons.pressed & Button::HOME;
-
-	if(time - lastRepeat > 150 || button_up || button_down) {
-		button_up = buttons & Button::DPAD_UP;
-		button_down = buttons & Button::DPAD_DOWN;
-		lastRepeat = time;
-	}
-
 	screen.pen = Pen(0,0,0);
 	screen.rectangle(Rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT));
 	screen.pen = Pen(255, 255, 255);
@@ -302,53 +282,6 @@ void FlashLoader::RenderFlashFile(uint32_t time)
 	{
 		screen.text("No Files Found.", minimal_font, ROW(0));
 	}
-
-	if(button_home)
-	{
-		// switch to mass media
-		g_usbManager.SetType(USBManager::usbtMSC);
-		m_state = stMassStorage;
-
-	}
-
-	if(button_up)
-	{
-		if(m_uCurrentFile > 0) {
-			m_uCurrentFile--;
-		} else {
-			m_uCurrentFile = m_uFileCount - 1;
-		}
-	}
-
-	if(button_down)
-	{
-		if(m_uCurrentFile < (m_uFileCount - 1)) {
-			m_uCurrentFile++;
-		} else {
-			m_uCurrentFile = 0;
-		}
-	}
-
-	if(button_a)
-	{
-		if(Flash(m_filemeta[m_uCurrentFile].sFilename)) {
-			blit_switch_execution();
-		}
-	}
-
-	if (button_x)
-	{
-		// Sort by filename
-		std::sort(&m_filemeta[0], &m_filemeta[m_uFileCount], [](auto a, auto b) { return strcmp(a.sFilename, b.sFilename) <= 0; });
-	}
-
-	if (button_y)
-	{
-		// Sort by filesize
-		std::sort(&m_filemeta[0], &m_filemeta[m_uFileCount], [](auto a, auto b) { return a.fstFilesize <= b.fstFilesize; });
-	}
-
-	persist.selected_menu_item = m_uCurrentFile;
 }
 
 
@@ -358,6 +291,76 @@ void FlashLoader::Update(uint32_t time)
 	{
 		FSInit();
 		m_state = stFlashFile;
+	}
+	
+	if(m_state == stFlashFile)
+	{
+		static uint32_t lastRepeat = 0;
+
+		if(!m_bFsInit)
+			FSInit();
+
+		bool button_a = buttons.pressed & Button::A;
+		bool button_x = buttons.pressed & Button::X;
+		bool button_y = buttons.pressed & Button::Y;
+
+		bool button_up = buttons.pressed & Button::DPAD_UP;
+		bool button_down = buttons.pressed & Button::DPAD_DOWN;
+
+		bool button_home = buttons.pressed & Button::HOME;
+
+		if(time - lastRepeat > 150 || button_up || button_down) {
+			button_up = buttons & Button::DPAD_UP;
+			button_down = buttons & Button::DPAD_DOWN;
+			lastRepeat = time;
+		}
+
+		if(button_home)
+		{
+			// switch to mass media
+			g_usbManager.SetType(USBManager::usbtMSC);
+			m_state = stMassStorage;
+
+		}
+
+		if(button_up)
+		{
+			if(m_uCurrentFile > 0) {
+				m_uCurrentFile--;
+			} else {
+				m_uCurrentFile = m_uFileCount - 1;
+			}
+		}
+
+		if(button_down)
+		{
+			if(m_uCurrentFile < (m_uFileCount - 1)) {
+				m_uCurrentFile++;
+			} else {
+				m_uCurrentFile = 0;
+			}
+		}
+
+		if(button_a)
+		{
+			if(Flash(m_filemeta[m_uCurrentFile].sFilename)) {
+				blit_switch_execution();
+			}
+		}
+
+		if (button_x)
+		{
+			// Sort by filename
+			std::sort(&m_filemeta[0], &m_filemeta[m_uFileCount], [](auto a, auto b) { return strcmp(a.sFilename, b.sFilename) <= 0; });
+		}
+
+		if (button_y)
+		{
+			// Sort by filesize
+			std::sort(&m_filemeta[0], &m_filemeta[m_uFileCount], [](auto a, auto b) { return a.fstFilesize <= b.fstFilesize; });
+		}
+
+		persist.selected_menu_item = m_uCurrentFile;
 	}
 }
 


### PR DESCRIPTION
I said that the button rework shouldn't break anything... It did.

This fixes flash-loader to check buttons in `update` instead of `render`, so that `buttons.changed` actually works. Also includes some changes to make it possible to get out of mass storage mode if USB is not connected... and a random warning fix (for a silly warning...)