### PR TITLE
Fix using the second half of the flash

### DIFF
--- a/32blit-stm32/Src/quadspi.c
+++ b/32blit-stm32/Src/quadspi.c
@@ -293,7 +293,7 @@ HAL_StatusTypeDef qspi_sector_erase(uint32_t BlockAddress)
     s_command.Instruction       = SECTOR_ERASE_CMD;
     s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
     s_command.AddressMode       = QSPI_ADDRESS_1_LINE;
-    s_command.AddressSize       = QSPI_ADDRESS_24_BITS;
+    s_command.AddressSize       = QSPI_ADDRESS_32_BITS;
     s_command.Address           = BlockAddress;
     s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
     s_command.DataMode          = QSPI_DATA_NONE;
@@ -329,7 +329,7 @@ HAL_StatusTypeDef qspi_write_buffer(size_t offset, const uint8_t* buffer, size_t
     s_command.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
     s_command.AddressMode = QSPI_ADDRESS_1_LINE;
     s_command.DataMode    = QSPI_DATA_4_LINES;
-    s_command.AddressSize = QSPI_ADDRESS_24_BITS;
+    s_command.AddressSize = QSPI_ADDRESS_32_BITS;
 
     s_command.Address     = offset;
     s_command.NbData      = length;
@@ -360,7 +360,7 @@ HAL_StatusTypeDef qspi_read_buffer(size_t address, const uint8_t* buffer, size_t
     s_command.DummyCycles = DUMMY_CLOCK_CYCLES_READ_QUAD;
     s_command.AddressMode = QSPI_ADDRESS_1_LINE;
     s_command.DataMode    = QSPI_DATA_4_LINES;
-    s_command.AddressSize = QSPI_ADDRESS_24_BITS;
+    s_command.AddressSize = QSPI_ADDRESS_32_BITS;
 
     s_command.Address     = address;
     s_command.NbData      = length;
@@ -408,7 +408,7 @@ HAL_StatusTypeDef qspi_enable_memorymapped_mode(void)
 
     s_command.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
     s_command.AddressMode       = QSPI_ADDRESS_1_LINE;
-    s_command.AddressSize       = QSPI_ADDRESS_24_BITS;
+    s_command.AddressSize       = QSPI_ADDRESS_32_BITS;
     s_command.DataMode          = QSPI_DATA_4_LINES;
     s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
     s_command.DummyCycles       = 6;
@@ -430,6 +430,28 @@ HAL_StatusTypeDef qspi_enable_memorymapped_mode(void)
     return QSPI_OK;
 }
 
+static HAL_StatusTypeDef qspi_enable_4byte_addr(QSPI_HandleTypeDef *hqspi)
+{
+    QSPI_CommandTypeDef s_command = {0};
+
+    s_command.Instruction = ENTER_4_BYTE_ADDR_MODE_CMD;
+    s_command.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    s_command.AddressMode = QSPI_ADDRESS_NONE;
+    s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    s_command.DataMode = QSPI_DATA_NONE;
+    s_command.DummyCycles = 0;
+    s_command.DdrMode = QSPI_DDR_MODE_DISABLE;
+    s_command.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    s_command.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+
+    if (HAL_QSPI_Command(hqspi, &s_command, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
+    {
+        Error_Handler();
+    }
+
+    return QSPI_OK;
+}
+
 // for some godforsaken reason if this is optimised in any way when returning from the function
 // it jumps off into the normal SPI code!
 #pragma GCC push_options
@@ -437,6 +459,7 @@ HAL_StatusTypeDef qspi_enable_memorymapped_mode(void)
 int qspi_init(void) {
   qspi_reset(&hqspi);
   qspi_enable_quad(&hqspi);
+  qspi_enable_4byte_addr(&hqspi);
   return(0);
 }
 #pragma GCC pop_options


### PR DESCRIPTION
Switches to 32bit addresses as 24 is one too short. Tested with a modified bin flashed to the very end of the flash. (And a WIP "installed" list).