### PR TITLE
Small file fix and optimisation

### DIFF
--- a/32blit-sdl/File.cpp
+++ b/32blit-sdl/File.cpp
@@ -146,21 +146,21 @@ std::vector<blit::FileInfo> list_files(std::string path) {
 
 bool file_exists(std::string path) {
 #ifdef WIN32
-	DWORD attribs = GetFileAttributesA(path.c_str());
+	DWORD attribs = GetFileAttributesA((basePath + path).c_str());
 	return (attribs != INVALID_FILE_ATTRIBUTES && !(attribs & FILE_ATTRIBUTE_DIRECTORY));
 #else
   struct stat stat_buf;
-  return (stat(path.c_str(), &stat_buf) == 0 && S_ISREG(stat_buf.st_mode));
+  return (stat((basePath + path).c_str(), &stat_buf) == 0 && S_ISREG(stat_buf.st_mode));
 #endif
 }
 
 bool directory_exists(std::string path) {
 #ifdef WIN32
-	DWORD attribs = GetFileAttributesA(path.c_str());
+	DWORD attribs = GetFileAttributesA((basePath + path).c_str());
 	return (attribs != INVALID_FILE_ATTRIBUTES && (attribs & FILE_ATTRIBUTE_DIRECTORY));
 #else
   struct stat stat_buf;
-  return (stat(path.c_str(), &stat_buf) == 0 && S_ISDIR(stat_buf.st_mode));
+  return (stat((basePath + path).c_str(), &stat_buf) == 0 && S_ISDIR(stat_buf.st_mode));
 #endif
 }
 

--- a/32blit-sdl/File.cpp
+++ b/32blit-sdl/File.cpp
@@ -23,7 +23,7 @@ void setup_base_path()
   SDL_free(basePathPtr);
 }
 
-void *open_file(std::string name, int mode) {
+void *open_file(const std::string &name, int mode) {
   const char *str_mode;
 
   if(mode == blit::OpenMode::read)
@@ -77,7 +77,7 @@ uint32_t get_file_length(void *fh)
   return SDL_RWtell(file);
 }
 
-std::vector<blit::FileInfo> list_files(std::string path) {
+std::vector<blit::FileInfo> list_files(const std::string &path) {
   std::vector<blit::FileInfo> ret;
 
 #ifdef WIN32
@@ -144,7 +144,7 @@ std::vector<blit::FileInfo> list_files(std::string path) {
   return ret;
 }
 
-bool file_exists(std::string path) {
+bool file_exists(const std::string &path) {
 #ifdef WIN32
 	DWORD attribs = GetFileAttributesA((basePath + path).c_str());
 	return (attribs != INVALID_FILE_ATTRIBUTES && !(attribs & FILE_ATTRIBUTE_DIRECTORY));
@@ -154,7 +154,7 @@ bool file_exists(std::string path) {
 #endif
 }
 
-bool directory_exists(std::string path) {
+bool directory_exists(const std::string &path) {
 #ifdef WIN32
 	DWORD attribs = GetFileAttributesA((basePath + path).c_str());
 	return (attribs != INVALID_FILE_ATTRIBUTES && (attribs & FILE_ATTRIBUTE_DIRECTORY));
@@ -164,7 +164,7 @@ bool directory_exists(std::string path) {
 #endif
 }
 
-bool create_directory(std::string path) {
+bool create_directory(const std::string &path) {
 #ifdef WIN32
   return _mkdir((basePath + path).c_str()) == 0 || errno == EEXIST;
 #else
@@ -172,10 +172,10 @@ bool create_directory(std::string path) {
 #endif
 }
 
-bool rename_file(std::string old_name, std::string new_name) {
+bool rename_file(const std::string &old_name, const std::string &new_name) {
   return rename((basePath + old_name).c_str(), (basePath + new_name).c_str()) == 0;
 }
 
-bool remove_file(std::string path) {
+bool remove_file(const std::string &path) {
   return remove((basePath + path).c_str()) == 0;
 }

--- a/32blit-sdl/File.hpp
+++ b/32blit-sdl/File.hpp
@@ -7,14 +7,14 @@
 #include "engine/file.hpp"
 
 void setup_base_path();
-void *open_file(std::string file, int mode);
+void *open_file(const std::string &file, int mode);
 int32_t read_file(void *fh, uint32_t offset, uint32_t length, char *buffer);
 int32_t write_file(void *fh, uint32_t offset, uint32_t length, const char *buffer);
 int32_t close_file(void *fh);
 uint32_t get_file_length(void *fh);
-std::vector<blit::FileInfo> list_files(std::string path);
-bool file_exists(std::string path);
-bool directory_exists(std::string path);
-bool create_directory(std::string path);
-bool rename_file(std::string old_name, std::string new_name);
-bool remove_file(std::string path);
+std::vector<blit::FileInfo> list_files(const std::string &path);
+bool file_exists(const std::string &path);
+bool directory_exists(const std::string &path);
+bool create_directory(const std::string &path);
+bool rename_file(const std::string &old_name, const std::string &new_name);
+bool remove_file(const std::string &path);

--- a/32blit-stm32/Inc/file.hpp
+++ b/32blit-stm32/Inc/file.hpp
@@ -6,14 +6,14 @@
 
 #include "engine/file.hpp"
 
-void *open_file(std::string file, int mode);
+void *open_file(const std::string &file, int mode);
 int32_t read_file(void *fh, uint32_t offset, uint32_t length, char *buffer);
 int32_t write_file(void *fh, uint32_t offset, uint32_t length, const char *buffer);
 int32_t close_file(void *fh);
 uint32_t get_file_length(void *fh);
-std::vector<blit::FileInfo> list_files(std::string path);
-bool file_exists(std::string path);
-bool directory_exists(std::string path);
-bool create_directory(std::string path);
-bool rename_file(std::string old_name, std::string new_name);
-bool remove_file(std::string path);
+std::vector<blit::FileInfo> list_files(const std::string &path);
+bool file_exists(const std::string &path);
+bool directory_exists(const std::string &path);
+bool create_directory(const std::string &path);
+bool rename_file(const std::string &old_name, const std::string &new_name);
+bool remove_file(const std::string &path);

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -5,7 +5,7 @@
 
 #include "file.hpp"
 
-void *open_file(std::string file, int mode) {
+void *open_file(const std::string &file, int mode) {
   FIL *f = new FIL();
 
   BYTE ff_mode = 0;
@@ -78,7 +78,7 @@ uint32_t get_file_length(void *fh)
   return f_size((FIL *)fh);
 }
 
-std::vector<blit::FileInfo> list_files(std::string path) {
+std::vector<blit::FileInfo> list_files(const std::string &path) {
   std::vector<blit::FileInfo> ret;
 
   auto dir = new DIR();
@@ -106,30 +106,32 @@ std::vector<blit::FileInfo> list_files(std::string path) {
   return ret;
 }
 
-bool file_exists(std::string path) {
+bool file_exists(const std::string &path) {
   FILINFO info;
   return f_stat(path.c_str(), &info) == FR_OK && !(info.fattrib & AM_DIR);
 }
 
-bool directory_exists(std::string path) {
+bool directory_exists(const std::string &path) {
   FILINFO info;
   return f_stat(path.c_str(), &info) == FR_OK && (info.fattrib & AM_DIR);
 }
 
-bool create_directory(std::string path) {
+bool create_directory(const std::string &path) {
+  FRESULT r;
+
   // strip trailing slash
   if(path.back() == '/')
-    path = path.substr(0, path.length() - 1);
-
-  FRESULT r = f_mkdir(path.c_str());
+     r = f_mkdir(path.substr(0, path.length() - 1).c_str());
+  else
+    r = f_mkdir(path.c_str());
 
   return r == FR_OK || r == FR_EXIST;
 }
 
-bool rename_file(std::string old_name, std::string new_name) {
+bool rename_file(const std::string &old_name, const std::string &new_name) {
   return f_rename(old_name.c_str(), new_name.c_str()) == FR_OK;
 }
 
-bool remove_file(std::string path) {
+bool remove_file(const std::string &path) {
   return f_unlink(path.c_str()) == FR_OK;
 }

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -35,17 +35,17 @@ namespace blit {
     int  (*debugf)(const char * psFormatString, va_list args);
 
     // files
-    void *(*open_file)(std::string file, int mode);
+    void *(*open_file)(const std::string &file, int mode);
     int32_t (*read_file)(void *fh, uint32_t offset, uint32_t length, char* buffer);
     int32_t (*write_file)(void *fh, uint32_t offset, uint32_t length, const char* buffer);
     int32_t (*close_file)(void *fh);
     uint32_t (*get_file_length)(void *fh);
-    std::vector<FileInfo> (*list_files) (std::string path);
-    bool (*file_exists) (std::string path);
-    bool (*directory_exists) (std::string path);
-    bool (*create_directory) (std::string path);
-    bool (*rename_file) (std::string old_name, std::string new_name);
-    bool (*remove_file) (std::string path);
+    std::vector<FileInfo> (*list_files) (const std::string &path);
+    bool (*file_exists) (const std::string &path);
+    bool (*directory_exists) (const std::string &path);
+    bool (*create_directory) (const std::string &path);
+    bool (*rename_file) (const std::string &old_name, const std::string &new_name);
+    bool (*remove_file) (const std::string &path);
 
     // profiler
     void (*enable_us_timer)();

--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -13,7 +13,7 @@ namespace blit {
 
   static std::map<std::string, BufferFile> buf_files;
 
-  std::vector<FileInfo> list_files(std::string path) {
+  std::vector<FileInfo> list_files(const std::string &path) {
     auto ret = api.list_files(path);
 
     for(auto &buf_file : buf_files) {
@@ -31,26 +31,26 @@ namespace blit {
     return ret;
   }
 
-  bool file_exists(std::string path) {
+  bool file_exists(const std::string &path) {
     return api.file_exists(path) || buf_files.find(path) != buf_files.end();
   }
-  bool directory_exists(std::string path) {
+  bool directory_exists(const std::string &path) {
     return api.directory_exists(path);
   }
 
-  bool create_directory(std::string path) {
+  bool create_directory(const std::string &path) {
     return api.create_directory(path);
   }
 
-  bool rename_file(std::string old_name, std::string new_name) {
+  bool rename_file(const std::string &old_name, const std::string &new_name) {
     return api.rename_file(old_name, new_name);
   }
 
-  bool remove_file(std::string path) {
+  bool remove_file(const std::string &path) {
     return api.remove_file(path);
   }
 
-  bool File::open(std::string file, int mode) {
+  bool File::open(const std::string &file, int mode) {
     close();
 
     // check for buffer

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -21,19 +21,19 @@ namespace blit {
     uint32_t size;
   };
 
-  std::vector<FileInfo> list_files(std::string path);
-  bool file_exists(std::string path);
-  bool directory_exists(std::string path);
+  std::vector<FileInfo> list_files(const std::string &path);
+  bool file_exists(const std::string &path);
+  bool directory_exists(const std::string &path);
 
-  bool create_directory(std::string path);
+  bool create_directory(const std::string &path);
 
-  bool rename_file(std::string old_name, std::string new_name);
-  bool remove_file(std::string path);
+  bool rename_file(const std::string &old_name, const std::string &new_name);
+  bool remove_file(const std::string &path);
   
   class File final {
   public:
     File() = default;
-    File(std::string filename, int mode = OpenMode::read) {open(filename, mode);}
+    File(const std::string &filename, int mode = OpenMode::read) {open(filename, mode);}
     File(const File &) = delete;
     File(File &&other) noexcept {
       *this = std::move(other);
@@ -55,7 +55,7 @@ namespace blit {
       return *this;
     }
 
-    bool open(std::string file, int mode = OpenMode::read);
+    bool open(const std::string &file, int mode = OpenMode::read);
     int32_t read(uint32_t offset, uint32_t length, char *buffer);
     int32_t write(uint32_t offset, uint32_t length, const char *buffer);
     void close();


### PR DESCRIPTION
Fixes `file/directory_exists` on SDL (ignored base path) and passes all the file names/paths by const reference to avoid some copies.