### PR TITLE
Enable LTO for 32blit-stm32

### DIFF
--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND SOURCES
+	startup_stm32h750xx.s
 	Src/main.c
 	Src/stm32h7xx_it.c
 	Src/stm32h7xx_hal_msp.c
@@ -81,7 +82,6 @@ list(APPEND SOURCES
 	Src/rng.c
 	Src/32blit.c
 	Src/CDCLogging.c
-	startup_stm32h750xx.s
 	Src/CDCDataStream.cpp 
 	Src/CDCCommandStream.cpp 
 	Src/CDCCommandHandler.cpp 
@@ -148,6 +148,7 @@ target_compile_definitions(BlitHalSTM32
 )
 
 target_compile_options(BlitHalSTM32 PUBLIC "$<$<CONFIG:RELEASE>:-Os>")
+set_target_properties(BlitHalSTM32 PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 
 # 2nd build for external flash
 add_library(BlitHalSTM32Ext OBJECT ${SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
+cmake_policy(SET CMP0069 NEW)
 project(32blit)
 include(32blit.cmake)
 add_subdirectory(examples)


### PR DESCRIPTION
Makes the firmware build ~9.6k smaller. I was getting quite close to the limit when adding USB host code...

(The startup file is moved to the top of the source list as otherwise GCC optimises out all of the interrupt handlers...)