### PR TITLE
Remove USB GPIO deinit

### DIFF
--- a/32blit-stm32/Src/usbd_conf.c
+++ b/32blit-stm32/Src/usbd_conf.c
@@ -93,14 +93,6 @@ void HAL_PCD_MspDeInit(PCD_HandleTypeDef* pcdHandle)
   /* USER CODE END USB_OTG_HS_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_USB_OTG_HS_CLK_DISABLE();
-  
-    /**USB_OTG_HS GPIO Configuration    
-    PB12     ------> USB_OTG_HS_ID
-    PB13     ------> USB_OTG_HS_VBUS
-    PB14     ------> USB_OTG_HS_DM
-    PB15     ------> USB_OTG_HS_DP 
-    */
-    HAL_GPIO_DeInit(GPIOB, GPIO_PIN_12|GPIO_PIN_13|GPIO_PIN_14|GPIO_PIN_15);
 
     /* Peripheral interrupt Deinit*/
     HAL_NVIC_DisableIRQ(OTG_HS_IRQn);


### PR DESCRIPTION
Since the GPIO init was moved to `gpio.cpp` disabling and then re enabling USB would de-init the pins, but not re-init them. Not sure how this isn't causing issues with the CDC <-> MSC switch.