### PR TITLE
Small blend/fill fixes

### DIFF
--- a/32blit/graphics/blend.cpp
+++ b/32blit/graphics/blend.cpp
@@ -110,7 +110,7 @@ namespace blit {
     // if destination is not double-word aligned copy at most three bytes until it is
     uint8_t* de = d + c * 3;
     while (uintptr_t(d) & 0b11) {
-      *d = s32 & 0xff000000; d++;
+      *d = s32 & 0xff; d++;
       // rotate the aligned rgbr/gbrg/brgb quad
       s32 >>= 8; s32 |= uint8_t(s32 & 0xff) << 24;
     }

--- a/32blit/graphics/blend.cpp
+++ b/32blit/graphics/blend.cpp
@@ -223,7 +223,7 @@ namespace blit {
         d += 4;
       }       
 
-      s += src->palette ? 1 : 4;
+      s += (src->palette ? 1 : 4) * src_step;
     } while (--cnt);
   }
 
@@ -247,7 +247,7 @@ namespace blit {
         d += 3;
       }       
 
-      s += src->palette ? 1 : 4;
+      s += (src->palette ? 1 : 4) * src_step;
     } while (--cnt);
   }
 


### PR DESCRIPTION
Fixes the left edge of this circle https://daft-freak.github.io/32blit-beta/examples/shell.html?app=tween-test. Also hflipped blits I think (at least shmup looks less broken).