### PR TITLE
Remove clip param to Surface::text

### DIFF
--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -143,8 +143,8 @@ namespace blit {
     void triangle(Point p1, Point p2, Point p3);
     void polygon(std::vector<Point> p);
 
-    void text(std::string_view message, const Font &font, const Rect &r, bool variable = true, TextAlign align = TextAlign::top_left, Rect clip = Rect(0, 0, 1000, 1000));
-    void text(std::string_view message, const Font &font, const Point &p, bool variable = true, TextAlign align = TextAlign::top_left, Rect clip = Rect(0, 0, 1000, 1000));
+    void text(std::string_view message, const Font &font, const Rect &r, bool variable = true, TextAlign align = TextAlign::top_left);
+    void text(std::string_view message, const Font &font, const Point &p, bool variable = true, TextAlign align = TextAlign::top_left);
     Size measure_text(std::string_view message, const Font &font, bool variable = true);
     std::string wrap_text(std::string_view message, int32_t width, const Font &font, bool variable = true, bool words = true);
 

--- a/32blit/graphics/text.cpp
+++ b/32blit/graphics/text.cpp
@@ -18,8 +18,8 @@ namespace blit {
    * \param p
    * \param variable
    */
-  void Surface::text(std::string_view message, const Font &font, const Point &p, bool variable, TextAlign align, Rect clip) {
-    text(message, font, Rect(p.x, p.y, 0, 0), variable, align, clip);
+  void Surface::text(std::string_view message, const Font &font, const Point &p, bool variable, TextAlign align) {
+    text(message, font, Rect(p.x, p.y, 0, 0), variable, align);
   }
 
   /**
@@ -30,16 +30,8 @@ namespace blit {
    * \param r
    * \param variable
    */
-  void Surface::text(std::string_view message, const Font &font, const Rect &r, bool variable, TextAlign align, Rect clip) {
+  void Surface::text(std::string_view message, const Font &font, const Rect &r, bool variable, TextAlign align) {
     Point c(r.x, r.y); // caret position
-
-    // default clip rect to rect if passed in
-    if(r.w > 0 && clip.w == 1000)
-      clip = r;
-
-    // clamp clip rect to screen
-    clip.w = std::min(clip.w, bounds.w - clip.x);
-    clip.h = std::min(clip.h, bounds.h - clip.y);
 
     if(!clip.intersects(r))
       return;

--- a/examples/text/text.cpp
+++ b/examples/text/text.cpp
@@ -34,6 +34,7 @@ void init() {
 }
 
 void render(uint32_t time) {
+	screen.clip = Rect(Point(0, 0), screen.bounds);
 	screen.pen = Pen(0, 0, 0);
 	screen.clear();
 
@@ -72,7 +73,8 @@ void render(uint32_t time) {
     text = screen.wrap_text(text, text_rect.w, minimal_font, variable_width);
 
     screen.pen = Pen(0xFF, 0xFF, 0xFF);
-    screen.text(text, minimal_font, text_rect, variable_width, TextAlign::center_center, clip);
+    screen.clip = clip;
+    screen.text(text, minimal_font, text_rect, variable_width, TextAlign::center_center);
 }
 
 void update(uint32_t time) {


### PR DESCRIPTION
Use the surface clip rect instead. Removes the default clipping from the `Rect` version of `text` but makes it more consistent with the rest of the API. (Somehow missed the surface clip when adding this...)