### PR TITLE
Tweak docs for installing tools

### DIFF
--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -1,9 +1,14 @@
 # Building & Running on Linux
 
 First install the required tools:
-
 ```
 sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev
+
+pip3 install 32blit
+```
+
+Optionally, for building the firmware as a .DFU file (usually not needed on Linux):
+```
 pip3 install construct bitstring
 ```
 

--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -64,6 +64,12 @@ for(auto x = 0; x < level_width * level_height; x++){
 level = new TileMap((uint8_t *)local_level_data, nullptr, Size(level_width, level_height), screen.sprites);
 ```
 
+# Visual Studio
+To use `assets.yml` with a Visual Studio project, you need to run the packer as a pre-build step. Make sure that the output path is in the project's include path.
+```
+python -m ttblit pack --force --config $(ProjectDir)\assets.yml --output $(ProjectDir)
+```
+
 # Old Tools
 
 ## Sprite Builder

--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -2,7 +2,12 @@
 
 The individual asset tools have been deprecated in favour of https://github.com/pimoroni/32blit-tools which installs `32blit` or `32blit.exe` command on Linux/Mac or Windows respectively.
 
-Head on over to https://github.com/pimoroni/32blit-tools for documentation covering the installation of the new tools.
+You can install these tools with `pip`:
+```
+pip3 install 32blit
+```
+
+Head on over to https://github.com/pimoroni/32blit-tools for further documentation covering the installation of the new tools.
 
 # Asset Pipeline
 

--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -83,7 +83,7 @@ Have a look into the script for further details regarding the formats.
 ### Prerequisites:
 
 ``` shell
-sudo python3 -m pip install construct bitarray bitstring pillow
+python3 -m pip install construct bitarray bitstring pillow
 ```
 
 ### Usage:

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -24,7 +24,7 @@ sudo add-apt-repository ppa:daft-freak/arm-gcc
 sudo apt update
 
 sudo apt install gcc gcc-arm-none-eabi gcc-mingw-w64 g++-mingw-w64 unzip cmake make python3 python3-pip
-pip3 install construct bitstring
+pip3 install 32blit construct bitstring
 ```
 
 ## Building & Running on 32Blit

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -17,6 +17,10 @@ Installing `python3` can be done with homebrew with a simple `brew install pytho
 
 ###  Installing pip3 dependecies
 
+```
+pip3 install 32blit
+```
+
 TODO: Document install of `construct` and `bitstring` for Python 3 (probably need a requirements.txt for the tools directory)
 
 ###  Verifying install


### PR DESCRIPTION
Adds installing the tools to the OS-specific pages (except Windows/VS, which doesn't currently cover installing Python). Also adds some basic instructions on how to use the packer when ~duplicating build confi~ using a VS project.