### PR TITLE
Define a symbol for the end of (used) flash

### DIFF
--- a/32blit-stm32/STM32H750VBTx.ld
+++ b/32blit-stm32/STM32H750VBTx.ld
@@ -139,6 +139,10 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
   } >DTCMRAM AT> FLASH
 
+  .flash_end :
+  {
+    _flash_end = .;
+  } > FLASH
 
   /* Uninitialized data section */
   . = ALIGN(4);


### PR DESCRIPTION
Useful for appending data post-build. (Like I did with my emulator)