### PR TITLE
Switch to official Emscripten Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 jobs:
   include:
     - name: "Emscripten"
-      env: CACHE_NAME=emscripten1
+      env: CACHE_NAME=emscripten2
       cache:
         directories:
           - $HOME/.emscripten_ports
@@ -22,7 +22,7 @@ jobs:
       services:
         - docker
       before_install:
-        - docker run -dit --name emscripten -v $(pwd):/src -v $HOME/.emscripten_ports:/emsdk_portable/.data/ports -v $HOME/.emscripten_cache:/emsdk_portable/.data/cache trzeci/emscripten:1.39.10-fastcomp bash
+        - docker run -dit --name emscripten -v $(pwd):/src -v $HOME/.emscripten_ports:/emsdk/upstream/emscripten/ports -v $HOME/.emscripten_cache:/emsdk/upstream/emscripten/cache emscripten/emsdk:2.0.4 bash
       install:
         - docker exec -it emscripten apt update
         - docker exec -it emscripten apt -y install python3-setuptools


### PR DESCRIPTION
... and update to the latest release. Includes switching to the "upstream" backend, which seems to build a bit faster (~2 mins on travis). Also should include the workaround for audio.

Bonus: flight and the `perspective` effect in tilemap-test now work (#97/#340). (The nans/infs are still there, they just don't cause exceptions any more...)