### PR TITLE
Deploy Emscripten examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ jobs:
       script:
         - docker exec -it emscripten emcmake cmake -B build.em -G "Unix Makefiles"
         - docker exec -it emscripten make -C build.em
+      before_deploy:
+        - cp build.em/examples/*/*.{js,wasm} site/examples
+      deploy:
+        provider: pages:git
+        local_dir: site
+        edge: true
     
     - name: "Linux"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ jobs:
   include:
     - name: "Emscripten"
       env: CACHE_NAME=emscripten2
+      addons:
+        apt:
+          doxygen
+          graphviz
       cache:
         directories:
           - $HOME/.emscripten_ports
@@ -31,6 +35,8 @@ jobs:
         - docker exec -it emscripten emcmake cmake -B build.em -G "Unix Makefiles"
         - docker exec -it emscripten make -C build.em
       before_deploy:
+        - cd 32blit && doxygen doxygen.conf && cd ..
+        - cp -r 32blit/documentation/html/* site
         - cp build.em/examples/*/*.{js,wasm} site/examples
       deploy:
         provider: pages:git

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -7,7 +7,7 @@
 
 Renderer::Renderer(SDL_Window *window, int width, int height) : sys_width(width), sys_height(height) {
 	//SDL_SetHint(SDL_HINT_RENDER_DRIVER, "openGL");
-	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+	renderer = SDL_CreateRenderer(window, -1, 0);
 	if (renderer == nullptr) {
 		fprintf(stderr, "could not create renderer: %s\n", SDL_GetError());
 	}

--- a/32blit/doxygen.conf
+++ b/32blit/doxygen.conf
@@ -171,7 +171,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = ./
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/32blit/doxygen.conf
+++ b/32blit/doxygen.conf
@@ -790,7 +790,8 @@ WARN_LOGFILE           = doxygen.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = engine \
+INPUT                  = audio \
+                         engine \
                          graphics \
                          math \
                          types

--- a/site/examples/index.html
+++ b/site/examples/index.html
@@ -44,10 +44,10 @@
         <iframe id="example-frame" src="shell.html?app=logo"></iframe>
         <script type="text/javascript">
             const examples = [
-                "audio-test", "doom-fire", "fizzlefade", "flight", "geometry", "hardware-test", "logo", 
-                "matrix-test","palette-cycle", "palette-swap", "particle", "platformer", "raycaster", 
-                "rotozoom", "scrolly-tile", "serial-debug", "shmup", "sprite-test", "text", "tilemap_test",
-                "tilt", "timer-test", "tunnel"
+                "audio-test", "audio-wave", "doom-fire", "fizzlefade", "flight", "geometry", "hardware-test", "logo", 
+                "matrix-test", "palette-cycle", "palette-swap", "particle", "platformer", "profiler-test", "raycaster", 
+                "rotozoom", "scrolly-tile", "serial-debug", "shmup", "sprite-test", "text", "tilemap-test",
+                "tilt", "timer-test", "tunnel", "tween-test", "voxel"
             ];
 
             const listEl = document.getElementById("example-list");

--- a/site/examples/index.html
+++ b/site/examples/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>32blit examples</title>
+        <style>
+        body {
+            font-family: sans-serif;
+            margin: 0;
+            padding: 0;
+        }
+
+        #example-list {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: stretch;
+            margin: 1em auto;
+            max-width: 1280px;
+
+        }
+
+        #example-list button {
+            border: none;
+            background: #222;
+            color: #f7f7f7;
+
+            padding: 1em;
+            margin: 0.2em;
+            flex: 1 0;
+            white-space: nowrap;
+        }
+
+        iframe {
+            border: 0;
+            margin: auto;
+            display: block;
+            width: 640px;
+            height: 480px;
+        }
+        </style>
+    </head>
+    <body>
+        <section id="example-list"></section>
+        <iframe id="example-frame" src="shell.html?app=logo"></iframe>
+        <script type="text/javascript">
+            const examples = [
+                "audio-test", "doom-fire", "fizzlefade", "flight", "geometry", "hardware-test", "logo", 
+                "matrix-test","palette-cycle", "palette-swap", "particle", "platformer", "raycaster", 
+                "rotozoom", "scrolly-tile", "serial-debug", "shmup", "sprite-test", "text", "tilemap_test",
+                "tilt", "timer-test", "tunnel"
+            ];
+
+            const listEl = document.getElementById("example-list");
+            const frameEl = document.getElementById("example-frame");
+
+            frameEl.addEventListener("load", e => {
+                // hack to give iframe keyboard
+                const frame = e.target;
+                const canvas = frame.contentDocument.getElementById("canvas");
+                canvas.addEventListener("mousedown", () => frame.contentWindow.focus());
+            });
+
+            for(const example of examples)
+            {
+                const el = document.createElement("button");
+                el.innerText = example;
+                el.addEventListener("click", e => {
+                    frameEl.src = `shell.html?app=${example}`
+                    frameEl.contentWindow.focus();
+                });
+
+                listEl.appendChild(el);
+            }
+        </script>
+    </body>
+</html>

--- a/site/examples/shell.html
+++ b/site/examples/shell.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Emscripten-Generated Code</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+
+      canvas {
+        width: 100vw;
+        height: 100vh;
+        image-rendering: crisp-edges;
+        image-rendering: pixelated;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+    <script type='text/javascript'>
+      var Module = {
+        print: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          console.log(text);
+        },
+        printErr: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          console.error(text);
+        },
+        canvas: document.getElementById('canvas')
+      };
+
+      // add main js
+      const appName = new URLSearchParams(document.location.search.substring(1)).get("app");
+      const scriptEl = document.createElement("script");
+      scriptEl.src = appName + ".js";
+
+      document.body.appendChild(scriptEl);
+    </script>
+  </body>
+</html>
+
+


### PR DESCRIPTION
Pushes the Emscripten compiled examples to pages, also includes the API docs as they're currently the content of https://pimoroni.github.io/32blit-beta/ (also it was easy). May want to add `on: tags` at some point.

(The accelerated renderer commit is here mostly because WebGL is currently refusing to work in my Firefox...)