### PR TITLE
Support SDL2_image in WSL/MinGw + docs

### DIFF
--- a/docs/32Blit-Firmware.md
+++ b/docs/32Blit-Firmware.md
@@ -1,8 +1,20 @@
-# 32Blit Firmware
+# 32Blit Firmware <!-- omit in toc -->
 
 This repository includes firmware for the 32Blit that lets you manage games on SD card, and copy or flash games via USB serial.
 
-In order to use it, you will need to:
+- [Prerequisites](#prerequisites)
+- [Building & Flashing The 32Blit Firmware](#building--flashing-the-32blit-firmware)
+  - [Building The Firmware](#building-the-firmware)
+  - [Flashing The Firmware To Your 32Blit](#flashing-the-firmware-to-your-32blit)
+    - [Prepare the device](#prepare-the-device)
+    - [Linux and macOS](#linux-and-macos)
+    - [Windows](#windows)
+- [Troubleshooting](#troubleshooting)
+  - [Finding The Right DFU Device](#finding-the-right-dfu-device)
+
+# Prerequisites
+
+In order to use the 32blit firmware, you will need to:
 
 1. Build and install the 32Blit firmware (if you don't have it already)
 2. [Build the flash loader](32Blit-Loader.md) tool in `tools/src`
@@ -65,8 +77,8 @@ If this fails you can run the `DfusSeDemo` application and pick your 32Blit (it 
 
 In the "Upload Action" section hit "Choose" and select the `firmware.dfu` file you built earlier. (It should be in `build.stm32/firmware/firmware.dfu`) and finally hit "Upgrade" to flash the file.
 
-## Troubleshooting
+# Troubleshooting
 
-### Finding The Right DFU Device
+## Finding The Right DFU Device
 
 If you have more than one device in DFU mode connected to your computer then find the 32blit using `lsusb` and add `-d vid:pid` to the dfu-util command. Replace `vid:pid` with the 4 character ID strings to target the correct device.

--- a/docs/32Blit-Loader.md
+++ b/docs/32Blit-Loader.md
@@ -1,6 +1,12 @@
-# 32Blit Loader Tool
+# 32Blit Loader Tool <!-- omit in toc -->
 
 The 32Blit loader is a tool for saving 32Blit games to your SD card over USB, or flashing them directly to the 32Blit's external flash for quick and easy testing.
+
+- [Building The 32Blit Loader Tool](#building-the-32blit-loader-tool)
+  - [macOS & Linux](#macos--linux)
+  - [Windows - Visual Studio](#windows---visual-studio)
+  - [Windows - WSL](#windows---wsl)
+- [Usage](#usage)
 
 ## Building The 32Blit Loader Tool
 

--- a/docs/32blit.md
+++ b/docs/32blit.md
@@ -1,6 +1,17 @@
-# Building & Running On 32Blit
+# Building & Running On 32Blit <!-- omit in toc -->
 
 These instructions assume a basic familiarity with the Linux command-line and with compiling software from source.
+
+- [Prerequisites](#prerequisites)
+  - [Examples](#examples)
+    - [Building An Example](#building-an-example)
+    - [Uploading An Example](#uploading-an-example)
+  - [Your Own Projects](#your-own-projects)
+- [Troubleshooting](#troubleshooting)
+    - [Flasher Can't Find 32Blit Port](#flasher-cant-find-32blit-port)
+    - [CMake Errors](#cmake-errors)
+
+# Prerequisites
 
 Make sure you've prepared your 32Blit by following the instructions in:
 
@@ -71,6 +82,6 @@ If `make example.flash` fails to find the correct port, re-run `cmake` with `-DF
 
 Port-detection does not work if your device is in DFU mode. Either reset it to get it out, or it it's stuck in DFU mode (or just boots into a black screen), you may need to reflash the firmware.
 
-### Cmake Errors
+### CMake Errors
 
 If you see `cannot create target because another target with the same name already exists` you've probably run `cmake ..` in the wrong directory (the project directory rather than the build directory), you should remove all but your project files and `cmake ..` again from the build directory.

--- a/docs/ChromeOS.md
+++ b/docs/ChromeOS.md
@@ -1,4 +1,12 @@
+# Chrome OS <!-- omit in toc -->
+
+These instructions cover building 32blit on a Chrome OS Linux VM.
+
 Chrome OS (Chromebook) uses a Linux virtual machine to run Linux software. Once the virtual machine is set up you can follow the the [General Readme](../README.md) and the [Linux](Linux.md) instructions.
+
+- [Installing the Linux Beta](#installing-the-linux-beta)
+- [Sharing folders with the Linux virtual machine](#sharing-folders-with-the-linux-virtual-machine)
+- [Flashing the firmware (DFU mode) and USB access](#flashing-the-firmware-dfu-mode-and-usb-access)
 
 # Installing the Linux Beta
 

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -1,6 +1,16 @@
-# Building & Running on Linux
+# Building & Running on Linux <!-- omit in toc -->
+
+These instructions cover building 32blit on Linux.
+
+- [Prerequisites](#prerequisites)
+  - [Building & Running on 32Blit](#building--running-on-32blit)
+  - [Building & Running Locally](#building--running-locally)
+    - [Build Everything](#build-everything)
+
+# Prerequisites
 
 First install the required tools:
+
 ```
 sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev
 
@@ -8,6 +18,7 @@ pip3 install 32blit
 ```
 
 Optionally, for building the firmware as a .DFU file (usually not needed on Linux):
+
 ```
 pip3 install construct bitstring
 ```

--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -1,13 +1,23 @@
-# Tools
+# Tools <!-- omit in toc -->
 
 The individual asset tools have been deprecated in favour of https://github.com/pimoroni/32blit-tools which installs `32blit` or `32blit.exe` command on Linux/Mac or Windows respectively.
 
 You can install these tools with `pip`:
+
 ```
 pip3 install 32blit
 ```
 
 Head on over to https://github.com/pimoroni/32blit-tools for further documentation covering the installation of the new tools.
+
+- [Asset Pipeline](#asset-pipeline)
+- [Visual Studio](#visual-studio)
+- [Old Tools](#old-tools)
+  - [Sprite Builder](#sprite-builder)
+    - [Prerequisites](#prerequisites)
+    - [Usage](#usage)
+      - [Packed](#packed)
+      - [Raw](#raw)
 
 # Asset Pipeline
 
@@ -93,13 +103,13 @@ The script outputs to a C++ byte-array and includes a header with information ab
 
 Have a look into the script for further details regarding the formats.
 
-### Prerequisites:
+### Prerequisites
 
 ``` shell
 python3 -m pip install construct bitarray bitstring pillow
 ```
 
-### Usage:
+### Usage
 
 Currently `sprite-builder` knows two types of conversion:
 

--- a/docs/VSCode.md
+++ b/docs/VSCode.md
@@ -1,7 +1,22 @@
-# Setting up Visual Studio Code
+# Setting up Visual Studio Code <!-- omit in toc -->
+
+These instructions cover setting up Visual Studio Code to build the CMake project.
+
+A working knowledge of using and configuring Visual Studio Code is assumed.
+
+- [Requirements](#requirements)
+- [Windows specific setup](#windows-specific-setup)
+- [Mac specific setup](#mac-specific-setup)
+- [Initial setup for local builds](#initial-setup-for-local-builds)
+- [IntelliSense](#intellisense)
+- [CMake Arguments](#cmake-arguments)
+- [Debugger configuration](#debugger-configuration)
+- [Building for 32Blit](#building-for-32blit)
 
 ## Requirements
+
 You'll need to install:
+
  - [Visual Studio Code](https://code.visualstudio.com/)
  - The [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
  - The [CMake Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)

--- a/docs/Windows-VisualStudio.md
+++ b/docs/Windows-VisualStudio.md
@@ -1,8 +1,14 @@
-# Visual Studio 2019
+# Visual Studio 2019 <!-- omit in toc -->
 
 You can use Visual Studio 2019 to examine the samples (compile them and run them in an SDL window) or to build your own apps for the 32blit API.
 
 See [Building & Running On 32Blit](32blit.md) if you want to compile examples/projects to run on 32Blit.
+
+- [Requirements](#requirements)
+- [Option 1: Use the solution file](#option-1-use-the-solution-file)
+  - [Get started with your own game](#get-started-with-your-own-game)
+- [Option 2: Use Visual Studio's built-in CMake support](#option-2-use-visual-studios-built-in-cmake-support)
+- [Troubleshooting](#troubleshooting)
 
 ## Requirements
 

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -52,14 +52,14 @@ You will need to cross-compile SDL2 for MinGW and install both it, and SDL2-imag
 
 ### Installing SDL2 & SDL2_image
 
-This will install the SDL2 development headers and libraries into `/usr/local/cross-tools/x86_64-w64-mingw32/`.
+This will install the SDL2 64bit mingw development headers and libraries into `/opt/local/x86_64-w64-mingw32/`.
 
-If you use a different directory then you will have to supply the SDL2 dir to the `cmake` command below using `-DSDL2_DIR`. For example: `cmake .. -DCMAKE_TOOLCHAIN_FILE=../mingw.toolchain -DSDL2_DIR=/usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2`
+Note: the `lib/cmake/SDL2/sdl2-config.cmake` shipped with these libraries expects them to be in `/opt/local`, if you change the install path you will have to modify this file.
 
-First, make sure the `cross-tools` directory (or your chosen alternative) exists:
+First, make sure the `/opt/local/` directory exists:
 
 ```shell
-sudo mkdir -p /usr/local/cross-tools/
+sudo mkdir -p /opt/local/
 ```
 
 #### SDL2
@@ -69,7 +69,7 @@ Grab and install the SDL2 mingw development package:
 ```shell
 wget https://libsdl.org/release/SDL2-devel-2.0.10-mingw.tar.gz
 tar xzf SDL2-devel-2.0.10-mingw.tar.gz
-sudo cp -r SDL2-2.0.10/x86_64-w64-mingw32 /usr/local/cross-tools/
+sudo cp -r SDL2-2.0.10/x86_64-w64-mingw32 /opt/local/
 ```
 
 #### SDL2_image
@@ -79,7 +79,7 @@ Grab and install the SDL2_image mingw development package:
 ```shell
 wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz
 tar xzf SDL2_image-devel-2.0.5-mingw.tar.gz
-sudo cp -r SDL2_image-2.0.5/x86_64-w64-mingw32 /usr/local/cross-tools/
+sudo cp -r SDL2_image-2.0.5/x86_64-w64-mingw32 /opt/local/
 ```
 
 ### Building

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -1,8 +1,8 @@
 # Building & Running on Win32 (WSL and MinGW) <!-- omit in toc -->
 
-These instructions cover setting up Windows Subsystem for Linux so that you can cross-compile Windows-compatible binaries with MinGW.
+These instructions cover setting up Windows Subsystem for Linux so that you can cross-compile Windows-compatible binaries with MinGW. This approach is included for completeness but not recommended, since MinGW binaries are statically linked and much larger than the Visual Studio output.
 
-They assume a basic knowledge of the Linux command-line, installing tools and compiling code from source.
+A basic knowledge of the Linux command-line, installing tools and compiling code from source is assumed.
 
 If you're more familiar with Visual Studio then you should [follow the instructions in Windows-VisualStudio.md](Windows-VisualStudio.md)
 

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -11,8 +11,9 @@ If you're more familiar with Visual Studio then you should [follow the instructi
   - [Installing requirements inside WSL](#installing-requirements-inside-wsl)
 - [Building & Running on 32Blit](#building--running-on-32blit)
 - [Building & Running Locally](#building--running-locally)
-  - [Building & Installing SDL2](#building--installing-sdl2)
-  - [Installing SLD2-Image](#installing-sld2-image)
+  - [Installing SDL2 & SDL2_image](#installing-sdl2--sdl2_image)
+    - [SDL2](#sdl2)
+    - [SDL2_image](#sdl2_image)
   - [Building](#building)
     - [Single Example](#single-example)
     - [Build Everything](#build-everything)
@@ -49,38 +50,36 @@ You can use WSL on Windows to cross-compile your project (or any 32Blit example)
 
 You will need to cross-compile SDL2 for MinGW and install both it, and SDL2-image.
 
-### Building & Installing SDL2
+### Installing SDL2 & SDL2_image
 
-Grab the SDL2 source code and unzip it with the following commands:
+This will install the SDL2 development headers and libraries into `/usr/local/cross-tools/x86_64-w64-mingw32/`.
 
-```shell
-wget https://www.libsdl.org/release/SDL2-2.0.10.zip
-unzip SDL2-2.0.10.zip
-cd SDL2-2.0.10
-```
+If you use a different directory then you will have to supply the SDL2 dir to the `cmake` command below using `-DSDL2_DIR`. For example: `cmake .. -DCMAKE_TOOLCHAIN_FILE=../mingw.toolchain -DSDL2_DIR=/usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2`
 
-Then build and install it:
+First, make sure the `cross-tools` directory (or your chosen alternative) exists:
 
 ```shell
-mkdir build.mingw
-cd build.mingw
-../configure --target=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --build=x86_64--linux --prefix=/usr/local/cross-tools/x86_64-w64-mingw32/
-make
-sudo make install
+sudo mkdir -p /usr/local/cross-tools/
 ```
 
-This will install the SDL2 development headers and libraries into `/usr/local/cross-tools/x86_64-w64-mingw32/` if you use a different directory then you will have to supply the SDL2 dir to the `cmake` command below using `-DSDL2_DIR=/usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2`
+#### SDL2
 
-### Installing SLD2-Image
+Grab and install the SDL2 mingw development package:
 
-SDL2 Image can be a little trickier to build from source, so we'll grab the pre-compiled mingw packages and install them alongside SDL2 in `/usr/local/cross-tools/x86_64-w64-mingw32/`:
+```shell
+wget https://libsdl.org/release/SDL2-devel-2.0.10-mingw.tar.gz
+tar xzf SDL2-devel-2.0.10-mingw.tar.gz
+sudo cp -r SDL2-2.0.10/x86_64-w64-mingw32 /usr/local/cross-tools/
+```
+
+#### SDL2_image
+
+Grab and install the SDL2_image mingw development package:
 
 ```shell
 wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz
 tar xzf SDL2_image-devel-2.0.5-mingw.tar.gz
-sudo cp -r bin /usr/local/cross-tools/x86_64-w64-mingw32/
-sudo cp -r lib /usr/local/cross-tools/x86_64-w64-mingw32/
-sudo cp -r include /usr/local/cross-tools/x86_64-w64-mingw32/
+sudo cp -r SDL2_image-2.0.5/x86_64-w64-mingw32 /usr/local/cross-tools/
 ```
 
 ### Building

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -1,10 +1,22 @@
-# Building & Running on Win32 (WSL and MinGW)
+# Building & Running on Win32 (WSL and MinGW) <!-- omit in toc -->
 
 These instructions cover setting up Windows Subsystem for Linux so that you can cross-compile Windows-compatible binaries with MinGW.
 
 They assume a basic knowledge of the Linux command-line, installing tools and compiling code from source.
 
 If you're more familiar with Visual Studio then you should [follow the instructions in Windows-VisualStudio.md](Windows-VisualStudio.md)
+
+- [Setting Up](#setting-up)
+  - [Windows Subsystem for Linux (WSL)](#windows-subsystem-for-linux-wsl)
+  - [Installing requirements inside WSL](#installing-requirements-inside-wsl)
+- [Building & Running on 32Blit](#building--running-on-32blit)
+- [Building & Running Locally](#building--running-locally)
+  - [Building & Installing SDL2](#building--installing-sdl2)
+  - [Installing SLD2-Image](#installing-sld2-image)
+  - [Building](#building)
+    - [Single Example](#single-example)
+    - [Build Everything](#build-everything)
+  - [Troubleshooting](#troubleshooting)
 
 ## Setting Up
 
@@ -35,7 +47,9 @@ If you want to run code on 32Blit, you should now refer to [Building & Running O
 
 You can use WSL on Windows to cross-compile your project (or any 32Blit example) into a Windows .exe for testing locally.
 
-First you'll need to cross-compile SDL2 for MinGW and install it.
+You will need to cross-compile SDL2 for MinGW and install both it, and SDL2-image.
+
+### Building & Installing SDL2
 
 Grab the SDL2 source code and unzip it with the following commands:
 
@@ -57,6 +71,20 @@ sudo make install
 
 This will install the SDL2 development headers and libraries into `/usr/local/cross-tools/x86_64-w64-mingw32/` if you use a different directory then you will have to supply the SDL2 dir to the `cmake` command below using `-DSDL2_DIR=/usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2`
 
+### Installing SLD2-Image
+
+SDL2 Image can be a little trickier to build from source, so we'll grab the pre-compiled mingw packages and install them alongside SDL2 in `/usr/local/cross-tools/x86_64-w64-mingw32/`:
+
+```shell
+wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz
+tar xzf SDL2_image-devel-2.0.5-mingw.tar.gz
+sudo cp -r bin /usr/local/cross-tools/x86_64-w64-mingw32/
+sudo cp -r lib /usr/local/cross-tools/x86_64-w64-mingw32/
+sudo cp -r include /usr/local/cross-tools/x86_64-w64-mingw32/
+```
+
+### Building
+
 Finally, set up the 32Blit Makefile from the root of the repository with the following commands:
 
 ```shell
@@ -64,6 +92,8 @@ mkdir build.mingw
 cd build.mingw
 cmake .. -DCMAKE_TOOLCHAIN_FILE=../mingw.toolchain
 ```
+
+#### Single Example
 
 Now to make any example, type:
 
@@ -87,7 +117,7 @@ WSL will launch the example in Windows, using the required `SDL2.dll` that will 
 
 Don't forget to include `SDL2.dll` this if you want to redistribute a game/example.
 
-### Build Everything
+#### Build Everything
 
 Alternatively you can build everything by just typing:
 

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -1,4 +1,19 @@
-# Building & Running on macOS
+# Building & Running on macOS <!-- omit in toc -->
+
+These instructions cover building 32blit on macOS.
+
+- [Prerequisites](#prerequisites)
+- [Python3](#python3)
+  - [Installing python3](#installing-python3)
+  - [Installing pip3 dependecies](#installing-pip3-dependecies)
+  - [Verifying install](#verifying-install)
+- [Installing `gcc-arm-none-eabi`](#installing-gcc-arm-none-eabi)
+- [Building & Running on 32Blit](#building--running-on-32blit)
+- [Building & Running Locally](#building--running-locally)
+  - [Build Everything](#build-everything)
+- [Troubleshooting](#troubleshooting)
+
+## Prerequisites
 
 You will need build tools and CMake. Assuming you have [homebrew](https://docs.brew.sh/Installation) installed:
 
@@ -24,6 +39,7 @@ pip3 install 32blit
 TODO: Document install of `construct` and `bitstring` for Python 3 (probably need a requirements.txt for the tools directory)
 
 ###  Verifying install
+
 ``` shell
 python3 --version
 ```

--- a/mingw.toolchain
+++ b/mingw.toolchain
@@ -14,3 +14,7 @@ set(CMAKE_CXX_FLAGS_INIT "-static-libstdc++ -static-libgcc -Wl,-Bstatic -lstdc++
 if(EXISTS "${SDL2_PREFIX}/bin/SDL2.dll")
 	set(SDL2_DLL "${SDL2_PREFIX}/bin/SDL2.dll")
 endif()
+
+if(EXISTS "${SDL2_PREFIX}/bin/SDL2_image.dll")
+	set(SDL2_IMAGE_DLL "${SDL2_PREFIX}/bin/SDL2_image.dll")
+endif()

--- a/mingw.toolchain
+++ b/mingw.toolchain
@@ -1,5 +1,5 @@
 if(NOT DEFINED SDL2_DIR)
-	set(SDL2_DIR /usr/local/cross-tools/x86_64-w64-mingw32/lib/cmake/SDL2)
+	set(SDL2_DIR /opt/local/x86_64-w64-mingw32/lib/cmake/SDL2)
 endif()
 list(APPEND CMAKE_MODULE_PATH ${SDL2_DIR})
 include(sdl2-config REQUIRED)


### PR DESCRIPTION
Instructions for installing SDL2_image.dll and other dev files for MinGW WSL build. Plus support for copying SDL2_image.dll added to the cmake toolchain file.

Perhaps the SDL2 compile instructions should be substituted for a precompiled binary package and a bootstrap script to do all of this automagically.