### PR TITLE
Clamp joystick range

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -804,6 +804,10 @@ void blit_process_input() {
   }
   blit::joystick.y = -joystick_y / 7168.0f;
 
+  if(blit::joystick.length() > 1.0){
+    blit::joystick.normalize();
+  }
+
   blit::hack_left = (adc3data[0] >> 1) / 32768.0f;
   blit::hack_right = (adc3data[1] >> 1)  / 32768.0f;
 


### PR DESCRIPTION
Joystick was hitting cardinal directions fine, but diagonals overflowed the circular range.

This change normalises the joystick if its vector length exceeds 1. Clamping it to a circle of r=1.