### PR TITLE
Add joystick history and range to hardware-test

### DIFF
--- a/examples/hardware-test/hardware-test.cpp
+++ b/examples/hardware-test/hardware-test.cpp
@@ -7,6 +7,8 @@ using namespace blit;
 #define SCREEN_WIDTH 160
 #define SCREEN_HEIGHT 120
 
+std::vector<Point> joystick_history;
+
 void init() {
     set_screen_mode(ScreenMode::lores);
 }
@@ -78,12 +80,31 @@ void render(uint32_t time) {
     screen.text("HOME", minimal_font, Point(85, 15));
 
 
+    screen.pen = Pen(255, 255, 255);
+    screen.alpha = 128;
+    screen.circle(Point(
+        (SCREEN_WIDTH / 2),
+        (SCREEN_HEIGHT / 2)),
+    30);
+    screen.alpha = 255;
+
     screen.pen = Pen(255, 0, 0);
 
-    screen.pixel(Point(
+    joystick_history.emplace_back(Point(
         (SCREEN_WIDTH / 2) + blit::joystick.x * 30,
         (SCREEN_HEIGHT / 2) + blit::joystick.y * 30
     ));
+
+    if(joystick_history.size() > 256){
+        int trim = joystick_history.size() - 256;
+        joystick_history.erase(joystick_history.begin(), joystick_history.begin() + trim);
+    }
+
+    screen.alpha = 128;
+    for (auto p : joystick_history) {
+        screen.pixel(p);
+    }
+    screen.alpha = 255;
 
 
     screen.pen = Pen(255, 255, 255);
@@ -104,16 +125,16 @@ void render(uint32_t time) {
         ));
     }
 
-    screen.text("Tilt:", minimal_font, Point(COL2, ROW1));
+    screen.text("Tilt:", minimal_font, Point(COL1, ROW1+33));
 
     snprintf(text_buf, 100, "X: %d", (int)(blit::tilt.x * 1024));
-    screen.text(text_buf, minimal_font, Point(COL2, ROW1+7));
+    screen.text(text_buf, minimal_font, Point(COL1, ROW1+40));
 
     snprintf(text_buf, 100, "Y: %d", (int)(blit::tilt.y * 1024));
-    screen.text(text_buf, minimal_font, Point(COL2, ROW1+14));
+    screen.text(text_buf, minimal_font, Point(COL1, ROW1+47));
 
     snprintf(text_buf, 100, "Z: %d", (int)(blit::tilt.z * 1024));
-    screen.text(text_buf, minimal_font, Point(COL2, ROW1+21));
+    screen.text(text_buf, minimal_font, Point(COL1, ROW1+54));
 
     blit::LED = Pen(
         (float)((sinf(blit::now() / 100.0f) + 1) / 2.0f),


### PR DESCRIPTION
Adds a circle to indicate the expected joystick range.

Adds history, allowing joystick motion to be visualised.

Known: Joystick should effectively outline the circle, but seems to fall about 1px short from the bottom edge. I think this is a visual bug (looking at the joystick X/Y numbers) with either the dot plotting or the circle.