### PR TITLE
Increase width of circles by one

### DIFF
--- a/32blit/graphics/primitive.cpp
+++ b/32blit/graphics/primitive.cpp
@@ -115,16 +115,16 @@ namespace blit {
 
       err += y; y++; err += y;
 
-      h_span(Point(c.x - x, c.y + lastY), x * 2);
+      h_span(Point(c.x - x, c.y + lastY), x * 2 + 1);
       if (lastY != 0) {
-        h_span(Point(c.x - x, c.y - lastY), x * 2);
+        h_span(Point(c.x - x, c.y - lastY), x * 2 + 1);
       }
 
       if (err >= 0) {
         if (x != lastY) {
-          h_span(Point(c.x - lastY, c.y + x), lastY * 2);
+          h_span(Point(c.x - lastY, c.y + x), lastY * 2 + 1);
           if (x != 0) {
-            h_span(Point(c.x - lastY, c.y - x), lastY * 2);
+            h_span(Point(c.x - lastY, c.y - x), lastY * 2 + 1);
           }
 
           err -= x; x--; err -= x;


### PR DESCRIPTION
This makes the width match the height (and also matches what the original unfilled algorithm would do). It does mean that the circle size is actually r * 2 + 1 though...

Result:
![circles](https://user-images.githubusercontent.com/3074891/94169554-e0465580-fe86-11ea-8f46-59501e0bb1f9.png)

Should fix #31
