### PR TITLE
Correct noise waveform for #351

### DIFF
--- a/32blit/audio/audio.cpp
+++ b/32blit/audio/audio.cpp
@@ -67,7 +67,7 @@ namespace blit {
       if(channel.waveform_offset & 0b10000) {
         // if the waveform offset overflows then generate a new
         // random noise sample
-        channel.noise = (rand() & 0x0fff) - 0x07ff;
+        channel.noise = (blit::random() & 0xffff) - 0x7fff;
       }
 
       channel.waveform_offset &= 0xffff;
@@ -78,7 +78,6 @@ namespace blit {
         int32_t channel_sample = 0;
 
         if(channel.waveforms & Waveform::NOISE) {
-          channel_sample += (channel.noise - 0x7fff) >> 2;
           channel_sample += channel.noise;
           waveform_count++;
         }


### PR DESCRIPTION
Title says all, really.

The noise waveform was severely offset and not scaled to the full range of the channel, it looked typoriffic so it was presumably either that or a merge fail somewhere. Either way it's *technically* correct now and doesn't seem to break the ocean noise in Scrolly Tile.

Also switched to using `blit::random()` instead of `rand()` so it should be... uh... more random?

We should probably look into using a LFSR for noise predictability across platforms, perhaps?