### PR TITLE
Replace double-precision logs in packed sprite load

### DIFF
--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -11,6 +11,19 @@
 
 using namespace blit;
 
+#ifdef _MSC_VER
+#include <intrin.h>
+static int log2i(unsigned int x) {
+    unsigned long idx = 0;
+    _BitScanReverse(&idx, x);
+    return idx;
+}
+#else
+static int log2i(unsigned int x) {
+    return 8 * sizeof(unsigned int) - __builtin_clz(x) - 1;
+}
+#endif
+
 namespace blit {
 
 
@@ -477,7 +490,7 @@ namespace blit {
 
     bounds = Size(image->width, image->height);
 
-    uint8_t bit_depth = uint8_t(ceil(log(image->palette_entry_count) / log(2)));
+    uint8_t bit_depth = log2i(std::max(1, (int)image->palette_entry_count - 1)) + 1;
 
     uint8_t col = 0;
     uint8_t bit = 0;


### PR DESCRIPTION
Went a step further than the `log2f` patch, this one is two instructions (on ARM). Saves nearly 3k of flash. Also clamps the minimum bit size to 1, which fixes images with one colour.


(Wasn't sure where to put the helper function, so just threw it at the top of the file)