### PR TITLE
Flash game listing and metadata handling

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -142,3 +142,7 @@ endfunction()
 function(blit_executable_int_flash NAME SOURCES)
 	blit_executable(${NAME} ${SOURCES} ${ARGN})
 endfunction()
+
+function(blit_metadata TARGET FILE)
+	# do nothing
+endfunction()

--- a/32blit-stm32/Inc/executable.hpp
+++ b/32blit-stm32/Inc/executable.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+
+constexpr uint32_t blit_game_magic = 0x54494C42; // "BLIT"
+
+using BlitRenderFunction = void(*)(uint32_t);
+using BlitTickFunction = bool(*)(uint32_t);
+using BlitInitFunction = void(*)();
+
+// should match the layout in startup_user.s
+struct BlitGameHeader {
+  uint32_t magic;
+
+  BlitRenderFunction render;
+  BlitTickFunction tick;
+  BlitInitFunction init;
+
+  uint32_t start;
+  uint32_t end;
+};

--- a/32blit-stm32/Inc/executable.hpp
+++ b/32blit-stm32/Inc/executable.hpp
@@ -15,6 +15,6 @@ struct BlitGameHeader {
   BlitTickFunction tick;
   BlitInitFunction init;
 
-  uint32_t start;
   uint32_t end;
+  uint32_t start;
 };

--- a/32blit-stm32/STM32H750VBTx.ld
+++ b/32blit-stm32/STM32H750VBTx.ld
@@ -69,6 +69,7 @@ SECTIONS
   /* The startup code goes first into FLASH */
   .isr_vector :
   {
+    flash_start = .;
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -144,16 +144,18 @@ int main(void)
   MX_JPEG_Init();
   /* USER CODE BEGIN 2 */
 
-  blit_init();
   //NVIC_SetPriority(SysTick_IRQn, 0x0);
 
 #if (INITIALISE_QSPI==1)
   qspi_init();
+#endif
+
+  blit_init();
+
+#if (INITIALISE_QSPI==1)
   if((persist.reset_target == prtGame) && HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port,  BUTTON_MENU_Pin) && !persist.reset_error)
     blit_switch_execution(persist.last_game_offset);
 #endif
-
-
 
   // add CDC handler to reset device on receiving "_RST" and "SWIT"
 	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'_', 'R', 'S', 'T'>::value, &g_resetHandler);

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -31,3 +31,15 @@ function(blit_executable NAME SOURCES)
 		add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${32BLIT_TOOL} PROG ${FLASH_PORT} ${NAME}.bin)
 	endif()
 endfunction()
+
+function(blit_metadata TARGET FILE)
+	find_package(PythonInterp 3.6 REQUIRED)
+
+	add_custom_command(
+		TARGET ${TARGET} POST_BUILD
+		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.bin
+	)
+
+	# force relink on change so that the post-build commands are rerun
+	set_property(TARGET ${TARGET} APPEND PROPERTY LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+endfunction()

--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -112,6 +112,7 @@ g_pfnVectors:
   .word  _ZN4blit4tickEm
   .word  do_init
   .word flash_start
+  .word _flash_end
 
 /*
 .weak      render

--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -111,6 +111,7 @@ g_pfnVectors:
   .word  _Z6renderm
   .word  _ZN4blit4tickEm
   .word  do_init
+  .word flash_start
 
 /*
 .weak      render

--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -111,8 +111,8 @@ g_pfnVectors:
   .word  _Z6renderm
   .word  _ZN4blit4tickEm
   .word  do_init
-  .word flash_start
   .word _flash_end
+  .word flash_start // temp
 
 /*
 .weak      render

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project (firmware)
 include (../32blit.cmake)
 
-blit_executable_int_flash(firmware firmware.cpp)
+blit_executable_int_flash(firmware firmware.cpp metadata.cpp)
 
 
 target_compile_definitions(firmware

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -6,6 +6,7 @@
 #include "USBManager.h"
 #include "file.hpp"
 #include "executable.hpp"
+#include "metadata.hpp"
 
 #include <cstring>
 #include <stdio.h>
@@ -45,116 +46,6 @@ State		state = stFlashFile;
 
 FIL file;
 
-// metadata stuff
-struct BlitGameMetadata {
-  uint16_t length = 0;
-  std::string title, description, version;
-
-  Surface *icon = nullptr, *splash = nullptr;
-};
-
-void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadata, bool unpack_images) {
-  metadata.length = metadata_len;
-
-  // parse strings
-  uint16_t offset = 0;
-
-  auto len = strlen(data);
-  metadata.title = std::string(data, len);
-  offset += len + 1;
-
-  len = strlen(data + offset);
-  metadata.description = std::string(data + offset, len);
-  offset += len + 1;
-
-  len = strlen(data + offset);
-  metadata.version = std::string(data + offset, len);
-  offset += len + 1;
-
-  if(unpack_images && metadata.icon) {
-    delete[] metadata.icon->data;
-    delete[] metadata.icon->palette;
-    delete metadata.icon;
-    metadata.icon = nullptr;
-  }
-
-  if(unpack_images && metadata.splash) {
-    delete[] metadata.splash->data;
-    delete[] metadata.splash->palette;
-    delete metadata.splash;
-    metadata.splash = nullptr;
-  }
-
-  if(offset != metadata_len && unpack_images) {
-    // icon/splash
-    // not really sprite sheets, but that's where the load helper is...
-    auto image = reinterpret_cast<packed_image *>(data + offset);
-    metadata.icon = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
-    offset += sizeof(packed_image) + image->byte_count + image->palette_entry_count * 4;
-
-    image = reinterpret_cast<packed_image *>(data + offset);
-    metadata.splash = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
-  }
-}
-
-bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata, bool unpack_images = false) {
-
-  BlitGameHeader header;
-
-  if(qspi_read_buffer(offset, reinterpret_cast<uint8_t *>(&header), sizeof(header)) != QSPI_OK)
-    return false;
-
-  offset += header.end - 0x90000000;
-
-  uint8_t buf[10];
-  if(qspi_read_buffer(offset, buf, 10) != QSPI_OK)
-    return false;
-
-  if(memcmp(buf, "BLITMETA", 8) != 0)
-    return false;
-
-  auto metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
-  auto metadata_buf = new uint8_t[metadata_len];
-  if(qspi_read_buffer(offset + 10, metadata_buf, metadata_len) != QSPI_OK) {
-    delete[] metadata_buf;
-    return false;
-  }
-
-  parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
-
-  delete[] metadata_buf;
-  return true;
-}
-
-bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata, bool unpack_images = false) {
-  FIL fh;
-  f_open(&fh, filename.c_str(), FA_READ);
-
-  BlitGameHeader header;
-  UINT bytes_read;
-  f_read(&fh, &header, sizeof(header), &bytes_read);
-
-  if(header.magic == blit_game_magic) {
-    uint8_t buf[10];
-    f_lseek(&fh, (header.end - 0x90000000));
-    auto res = f_read(&fh, buf, 10, &bytes_read);
-
-    if(bytes_read == 10 && memcmp(buf, "BLITMETA", 8) == 0) {
-      auto metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
-      auto metadata_buf = new uint8_t[metadata_len];
-      f_read(&fh, metadata_buf, metadata_len, &bytes_read);
-
-      parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
-      delete[] metadata_buf;
-
-      f_close(&fh);
-      return true;
-    }
-  }
-
-  f_close(&fh);
-  return false;
-}
 
 BlitGameMetadata selected_game_metadata;
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -48,9 +48,11 @@ FIL file;
 // metadata stuff
 struct BlitGameMetadata {
   std::string title, description, version;
+
+  Surface *icon = nullptr, *splash = nullptr;
 };
 
-void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadata) {
+void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadata, bool unpack_images) {
 
   // parse strings
   uint16_t offset = 0;
@@ -67,12 +69,33 @@ void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadat
   metadata.version = std::string(data + offset, len);
   offset += len + 1;
 
-  if(offset != metadata_len) {
+  if(unpack_images && metadata.icon) {
+    delete[] metadata.icon->data;
+    delete[] metadata.icon->palette;
+    delete metadata.icon;
+    metadata.icon = nullptr;
+  }
+
+  if(unpack_images && metadata.splash) {
+    delete[] metadata.splash->data;
+    delete[] metadata.splash->palette;
+    delete metadata.splash;
+    metadata.splash = nullptr;
+  }
+
+  if(offset != metadata_len && unpack_images) {
     // icon/splash
+    // not really sprite sheets, but that's where the load helper is...
+    auto image = reinterpret_cast<packed_image *>(data + offset);
+    metadata.icon = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
+    offset += sizeof(packed_image) + image->byte_count + image->palette_entry_count * 4;
+
+    image = reinterpret_cast<packed_image *>(data + offset);
+    metadata.splash = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
   }
 }
 
-bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata) {
+bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata, bool unpack_images = false) {
 
   BlitGameHeader header;
 
@@ -95,13 +118,13 @@ bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata) {
     return false;
   }
 
-  parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata);
+  parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
 
   delete[] metadata_buf;
   return true;
 }
 
-bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata) {
+bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata, bool unpack_images = false) {
   FIL fh;
   f_open(&fh, filename.c_str(), FA_READ);
 
@@ -119,7 +142,7 @@ bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata
       auto metadata_buf = new uint8_t[metadata_len];
       f_read(&fh, metadata_buf, metadata_len, &bytes_read);
 
-      parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata);
+      parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
       delete[] metadata_buf;
 
       f_close(&fh);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -26,6 +26,7 @@ extern USBManager g_usbManager;
 
 struct FlashGame {
   uint32_t offset;
+  uint32_t size;
   // TODO: metadata?
 };
 
@@ -98,17 +99,20 @@ void load_file_list() {
 
 void scan_flash() {
   for(uint32_t offset = 0; offset < qspi_flash_size; offset += qspi_flash_sector_size) {
-    uint8_t header_buf[4];
+    uint8_t header_buf[40];
 
-    if(qspi_read_buffer(offset, header_buf, 4) != QSPI_OK)
+    if(qspi_read_buffer(offset, header_buf, 40) != QSPI_OK)
       break;
 
     auto magic = reinterpret_cast<uint32_t *>(header_buf)[0];
     if(magic != 0x54494C42)
       continue;
 
+    auto end = reinterpret_cast<uint32_t *>(header_buf)[5];
+
     FlashGame game;
     game.offset = offset;
+    game.size = end - 0x90000000;
     flashed_games.push_back(game);
 
     // TODO: when we have a header with metadata, we'll be able to skip to the end

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -47,12 +47,14 @@ FIL file;
 
 // metadata stuff
 struct BlitGameMetadata {
+  uint16_t length = 0;
   std::string title, description, version;
 
   Surface *icon = nullptr, *splash = nullptr;
 };
 
 void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadata, bool unpack_images) {
+  metadata.length = metadata_len;
 
   // parse strings
   uint16_t offset = 0;
@@ -234,13 +236,15 @@ void scan_flash() {
 
     GameInfo game;
     game.offset = offset;
-    game.size = header.end - 0x90000000; // TODO: include metadata size
+    game.size = header.end - 0x90000000;
     game.title = "game @" + std::to_string(game.offset / qspi_flash_sector_size);
 
     // check for valid metadata
     BlitGameMetadata meta;
-    if(parse_flash_metadata(offset, meta))
+    if(parse_flash_metadata(offset, meta)) {
       game.title = meta.title;
+      game.size += meta.length + 10;
+    }
 
     games.push_back(game);
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -222,6 +222,9 @@ void render(uint32_t time) {
   if(selected_game_metadata.splash)
     screen.blit(selected_game_metadata.splash, Rect(Point(0, 0), selected_game_metadata.splash->bounds), Point(172, 20));
 
+  screen.pen = Pen(235, 245, 255);
+  screen.text(selected_game_metadata.title, minimal_font, Point(172, 124));
+
   Rect desc_rect(172, 138, 128, 72);
 
   screen.pen = Pen(80, 100, 120);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -39,7 +39,7 @@ struct GameInfo {
 
 struct DirectoryInfo {
   std::string name;
-  int x;
+  int x, w;
 };
 
 std::vector<GameInfo> game_list;
@@ -104,21 +104,22 @@ void load_directory_list(std::string directory) {
   for(auto &folder : ::list_files(directory)) {
     if(folder.flags & blit::FileFlags::directory) {
       if(folder.name.compare("System Volume Information") == 0) continue;
-      directory_list.push_back({folder.name, 0});
+      directory_list.push_back({folder.name, 0, 0});
     }
   }
 
   directory_list.sort([](const auto &a, const auto &b) { return a.name > b.name; });
 
-  directory_list.push_front({"/", 0});
-  directory_list.push_front({"FLASH", 0});
+  directory_list.push_front({"/", 0, 0});
+  directory_list.push_front({"FLASH", 0, 0});
 
   // measure positions
   int x = 0;
   for(auto &dir : directory_list) {
     dir.x = x;
+    dir.w = screen.measure_text(dir.name, minimal_font).w;
 
-    x += screen.measure_text(dir.name, minimal_font, true).w + 10;
+    x += dir.w + 10;
   }
 }
 
@@ -277,8 +278,8 @@ void render(uint32_t time) {
       else
         screen.pen = Pen(80, 100, 120);
 
-      int x = 120 + directory.x - directory_list_scroll_offset;
-      screen.text(directory.name, minimal_font, Rect(x, 5, 100 - 20, text_align_height), true, TextAlign::center_v);
+      int x = 120 + 95 + directory.x - directory_list_scroll_offset;
+      screen.text(directory.name, minimal_font, Rect(x, 5, 190, text_align_height), true, TextAlign::center_v);
     }
 
     screen.clip = Rect(Point(0, 0), screen.bounds);
@@ -451,7 +452,7 @@ void update(uint32_t time)
     // scroll list towards selected item  
     file_list_scroll_offset.y += ((persist.selected_menu_item * 10) - file_list_scroll_offset.y) / 5.0f;
 
-    directory_list_scroll_offset += (current_directory->x - directory_list_scroll_offset) / 5.0f;
+    directory_list_scroll_offset += (current_directory->x + current_directory->w / 2 - directory_list_scroll_offset) / 5.0f;
 
     // load metadata for selected item
     if(persist.selected_menu_item != old_menu_item)

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -309,11 +309,13 @@ void render(uint32_t time) {
     screen.pen = Pen(235, 245, 255);
     screen.text(selected_game_metadata.title, minimal_font, Point(172, 124));
 
-    Rect desc_rect(172, 138, 128, 72);
+    Rect desc_rect(172, 138, 128, 64);
 
     screen.pen = Pen(80, 100, 120);
     std::string wrapped_desc = screen.wrap_text(selected_game_metadata.description, desc_rect.w, minimal_font);
     screen.text(wrapped_desc, minimal_font, desc_rect);
+
+    screen.text(selected_game_metadata.author, minimal_font, Point(172, 208));
 
     int num_blocks = calc_num_blocks(game_list[persist.selected_menu_item].size);
     char buf[20];

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -289,30 +289,30 @@ void render(uint32_t time) {
       screen.text(file.title, minimal_font, Rect(file_list_scroll_offset.x, y, 100 - 20, text_align_height), true, TextAlign::center_v);
       y += ROW_HEIGHT;
     }
+
+    // game info
+    if(selected_game_metadata.splash)
+      screen.blit(selected_game_metadata.splash, Rect(Point(0, 0), selected_game_metadata.splash->bounds), Point(172, 20));
+
+    screen.pen = Pen(235, 245, 255);
+    screen.text(selected_game_metadata.title, minimal_font, Point(172, 124));
+
+    Rect desc_rect(172, 138, 128, 72);
+
+    screen.pen = Pen(80, 100, 120);
+    std::string wrapped_desc = screen.wrap_text(selected_game_metadata.description, desc_rect.w, minimal_font);
+    screen.text(wrapped_desc, minimal_font, desc_rect);
+
+    int num_blocks = calc_num_blocks(games[persist.selected_menu_item].size);
+    char buf[20];
+    snprintf(buf, 20, "%i block%s", num_blocks, num_blocks == 1 ? "" : "s");
+    screen.text(buf, minimal_font, Point(172, 216));
+
   }
   else {
     screen.pen = Pen(235, 245, 255);
     screen.text("No Files Found.", minimal_font, Point(20, screen.bounds.h / 2), true, TextAlign::center_v);
   }
-
-  // game info
-
-  if(selected_game_metadata.splash)
-    screen.blit(selected_game_metadata.splash, Rect(Point(0, 0), selected_game_metadata.splash->bounds), Point(172, 20));
-
-  screen.pen = Pen(235, 245, 255);
-  screen.text(selected_game_metadata.title, minimal_font, Point(172, 124));
-
-  Rect desc_rect(172, 138, 128, 72);
-
-  screen.pen = Pen(80, 100, 120);
-  std::string wrapped_desc = screen.wrap_text(selected_game_metadata.description, desc_rect.w, minimal_font);
-  screen.text(wrapped_desc, minimal_font, desc_rect);
-
-  int num_blocks = calc_num_blocks(games[persist.selected_menu_item].size);
-  char buf[20];
-  snprintf(buf, 20, "%i block%s", num_blocks, num_blocks == 1 ? "" : "s");
-  screen.text(buf, minimal_font, Point(172, 216));
 
   // overlays
   if(state == stMassStorage)

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -110,7 +110,8 @@ void load_directory_list(std::string directory) {
 
   directory_list.sort([](const auto &a, const auto &b) { return a.name > b.name; });
 
-  directory_list.push_back({"FLASH", 0});
+  directory_list.push_front({"/", 0});
+  directory_list.push_front({"FLASH", 0});
 
   // measure positions
   int x = 0;
@@ -135,7 +136,7 @@ void load_file_list(std::string directory) {
 
       GameInfo game;
       game.title = file.name.substr(0, file.name.length() - 4);
-      game.filename = directory + "/" + file.name;
+      game.filename = directory == "/" ? file.name : directory + "/" + file.name;
       game.size = file.size;
       
       // check for metadata

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -243,7 +243,7 @@ void init() {
     load_file_list(current_directory->name);
 
   auto total_items = game_list.size();
-  if(persist.selected_menu_item > total_items)
+  if(persist.selected_menu_item >= total_items)
     persist.selected_menu_item = total_items - 1;
 
   load_current_game_metadata();

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -146,10 +146,17 @@ void scan_flash() {
 
 void load_current_game_metadata() {
   auto &game = games[persist.selected_menu_item];
+  bool loaded;
   if(game.filename.empty())
-    parse_flash_metadata(game.offset, selected_game_metadata, true);
+    loaded = parse_flash_metadata(game.offset, selected_game_metadata, true);
   else
-    parse_file_metadata(game.filename, selected_game_metadata, true);
+    loaded = parse_file_metadata(game.filename, selected_game_metadata, true);
+
+  // no valid metadata, reset
+  if(!loaded) {
+    selected_game_metadata.free_surfaces();
+    selected_game_metadata = BlitGameMetadata();
+  }
 }
 
 void mass_storage_overlay(uint32_t time)

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -117,7 +117,7 @@ void load_directory_list(std::string directory) {
   int x = 0;
   for(auto &dir : directory_list) {
     dir.x = x;
-    dir.w = screen.measure_text(dir.name, minimal_font).w;
+    dir.w = screen.measure_text(dir.name == "/" ? "ROOT" : dir.name, minimal_font).w;
 
     x += dir.w + 10;
   }
@@ -279,7 +279,7 @@ void render(uint32_t time) {
         screen.pen = Pen(80, 100, 120);
 
       int x = 120 + 95 + directory.x - directory_list_scroll_offset;
-      screen.text(directory.name, minimal_font, Rect(x, 5, 190, text_align_height), true, TextAlign::center_v);
+      screen.text(directory.name == "/" ? "ROOT" : directory.name, minimal_font, Rect(x, 5, 190, text_align_height), true, TextAlign::center_v);
     }
 
     screen.clip = Rect(Point(0, 0), screen.bounds);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -176,12 +176,15 @@ void scan_flash() {
 void load_current_game_metadata() {
   auto &games = current_directory.compare("FLASH") == 0 ? flash_games : sd_games;
 
-  auto &game = games[persist.selected_menu_item];
-  bool loaded;
-  if(game.filename.empty())
-    loaded = parse_flash_metadata(game.offset, selected_game_metadata, true);
-  else
-    loaded = parse_file_metadata(game.filename, selected_game_metadata, true);
+  bool loaded = false;
+  if(!games.empty()) {
+    auto &game = games[persist.selected_menu_item];
+
+    if(game.filename.empty())
+      loaded = parse_flash_metadata(game.offset, selected_game_metadata, true);
+    else
+      loaded = parse_file_metadata(game.filename, selected_game_metadata, true);
+  }
 
   // no valid metadata, reset
   if(!loaded) {

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -777,7 +777,21 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
                   if(bEOS)
                   {
                     f_close(&file);
-                    load_file_list(current_directory->name);
+
+                    // switch to dir
+                    auto name_str = std::string_view(m_sFilename);
+                    auto slash = name_str.find_last_of('/');
+                    auto dir = slash == std::string::npos ? "/" : name_str.substr(0, name_str.find_last_of('/'));
+
+                    for(current_directory = directory_list.begin(); current_directory != directory_list.end(); ++current_directory) {
+                      if(current_directory->name == dir) break;
+                    }
+
+                    if(current_directory == directory_list.end()) // couldn't find it
+                      current_directory = directory_list.begin();
+                    else
+                      load_file_list(current_directory->name);
+
                     state = stFlashFile;
                     if(result != srError)
                       result = srFinish;

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -329,6 +329,17 @@ void render(uint32_t time) {
     screen.text("No Files Found.", minimal_font, Point(20, screen.bounds.h / 2), true, TextAlign::center_v);
   }
 
+  // game info
+
+  if(selected_game_metadata.splash)
+    screen.blit(selected_game_metadata.splash, Rect(Point(0, 0), selected_game_metadata.splash->bounds), Point(172, 20));
+
+  Rect desc_rect(172, 138, 128, 72);
+
+  screen.pen = Pen(80, 100, 120);
+  std::string wrapped_desc = screen.wrap_text(selected_game_metadata.description, desc_rect.w, minimal_font);
+  screen.text(wrapped_desc, minimal_font, desc_rect);
+
   if(state == stMassStorage)
     mass_storage_overlay(time);
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -144,6 +144,14 @@ void scan_flash() {
   }
 }
 
+void load_current_game_metadata() {
+  auto &game = games[persist.selected_menu_item];
+  if(game.filename.empty())
+    parse_flash_metadata(game.offset, selected_game_metadata, true);
+  else
+    parse_file_metadata(game.filename, selected_game_metadata, true);
+}
+
 void mass_storage_overlay(uint32_t time)
 {
   static uint8_t uActivityAnim = 0;
@@ -180,6 +188,8 @@ void init() {
   auto total_items = games.size();
   if(persist.selected_menu_item > total_items)
     persist.selected_menu_item = total_items - 1;
+
+  load_current_game_metadata();
 
   // register PROG
   g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'P', 'R', 'O', 'G'>::value, &flashLoader);
@@ -344,14 +354,8 @@ void update(uint32_t time)
     file_list_scroll_offset.y += ((persist.selected_menu_item * 10) - file_list_scroll_offset.y) / 5.0f;
 
     // load metadata for selected item
-    if(persist.selected_menu_item != old_menu_item) {
-
-      auto &game = games[persist.selected_menu_item];
-      if(game.filename.empty())
-        parse_flash_metadata(game.offset, selected_game_metadata, true);
-      else
-        parse_file_metadata(game.filename, selected_game_metadata, true);
-    }
+    if(persist.selected_menu_item != old_menu_item)
+      load_current_game_metadata();
 
     if(button_a)
     {

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -36,7 +36,6 @@ struct GameInfo {
 
 std::vector<GameInfo> games;
 
-int32_t max_width_size = 0;
 SortBy file_sort = SortBy::name;
 
 uint8_t buffer[PAGE_SIZE];
@@ -86,8 +85,6 @@ void sort_file_list() {
 void load_file_list() {
   games.erase(std::remove_if(games.begin(), games.end(), [](auto &game){return !game.filename.empty();}), games.end());
 
-  max_width_size = 0;
-
   for(auto &file : ::list_files("/")) {
     if(file.flags & blit::FileFlags::directory)
       continue;
@@ -107,8 +104,6 @@ void load_file_list() {
         game.title = meta.title;
 
       games.push_back(game);
-
-      max_width_size = std::max(max_width_size, screen.measure_text(std::to_string(file.size), minimal_font).w);
     }
   }
 
@@ -214,8 +209,6 @@ void render(uint32_t time) {
         screen.pen = Pen(80, 100, 120);
 
       screen.text(file.title, minimal_font, Rect(file_list_scroll_offset.x, y, 100 - 20, text_align_height), true, TextAlign::center_v);
-      screen.line(Point(size_x - 4, y), Point(size_x - 4, y + ROW_HEIGHT));
-      screen.text(std::to_string(file.size), minimal_font, Rect(size_x, y, max_width_size, text_align_height), true, TextAlign::center_right);
       y += ROW_HEIGHT;
     }
   }
@@ -235,6 +228,12 @@ void render(uint32_t time) {
   std::string wrapped_desc = screen.wrap_text(selected_game_metadata.description, desc_rect.w, minimal_font);
   screen.text(wrapped_desc, minimal_font, desc_rect);
 
+  int num_blocks = (games[persist.selected_menu_item].size - 1) / qspi_flash_sector_size + 1;
+  char buf[20];
+  snprintf(buf, 20, "%i block%s", num_blocks, num_blocks == 1 ? "" : "s");
+  screen.text(buf, minimal_font, Point(172, 216));
+
+  // overlays
   if(state == stMassStorage)
     mass_storage_overlay(time);
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -154,6 +154,8 @@ bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata
   return false;
 }
 
+BlitGameMetadata selected_game_metadata;
+
 // error dialog
 int selected_dialog_option = 0;
 
@@ -404,6 +406,8 @@ void update(uint32_t time)
 
     auto total_items = games.size();
 
+    auto old_menu_item = persist.selected_menu_item;
+
     if(button_up)
     {
       if(persist.selected_menu_item > 0) {
@@ -424,6 +428,16 @@ void update(uint32_t time)
 
     // scroll list towards selected item  
     file_list_scroll_offset.y += ((persist.selected_menu_item * 10) - file_list_scroll_offset.y) / 5.0f;
+
+    // load metadata for selected item
+    if(persist.selected_menu_item != old_menu_item) {
+
+      auto &game = games[persist.selected_menu_item];
+      if(game.filename.empty())
+        parse_flash_metadata(game.offset, selected_game_metadata, true);
+      else
+        parse_file_metadata(game.filename, selected_game_metadata, true);
+    }
 
     if(button_a)
     {

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -119,7 +119,9 @@ void mass_storage_overlay(uint32_t time)
 }
 
 void init() {
-  blit::set_screen_mode(ScreenMode::hires);
+  set_screen_mode(ScreenMode::hires);
+  screen.clear();
+
   load_file_list();
 
   // register PROG

--- a/firmware/firmware.hpp
+++ b/firmware/firmware.hpp
@@ -69,4 +69,5 @@ private:
 
   uint32_t m_uParseIndex = 0;
   uint32_t m_uFilelen = 0;
+  uint32_t flash_start_offset = 0;
 };

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -1,0 +1,113 @@
+#include <cstring>
+
+#include "graphics/sprite.hpp"
+
+#include "metadata.hpp"
+#include "executable.hpp"
+#include "ff.h"
+#include "quadspi.h"
+
+using namespace blit;
+
+void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadata, bool unpack_images) {
+  metadata.length = metadata_len;
+
+  // parse strings
+  uint16_t offset = 0;
+
+  auto len = strlen(data);
+  metadata.title = std::string(data, len);
+  offset += len + 1;
+
+  len = strlen(data + offset);
+  metadata.description = std::string(data + offset, len);
+  offset += len + 1;
+
+  len = strlen(data + offset);
+  metadata.version = std::string(data + offset, len);
+  offset += len + 1;
+
+  if(unpack_images && metadata.icon) {
+    delete[] metadata.icon->data;
+    delete[] metadata.icon->palette;
+    delete metadata.icon;
+    metadata.icon = nullptr;
+  }
+
+  if(unpack_images && metadata.splash) {
+    delete[] metadata.splash->data;
+    delete[] metadata.splash->palette;
+    delete metadata.splash;
+    metadata.splash = nullptr;
+  }
+
+  if(offset != metadata_len && unpack_images) {
+    // icon/splash
+    // not really sprite sheets, but that's where the load helper is...
+    auto image = reinterpret_cast<packed_image *>(data + offset);
+    metadata.icon = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
+    offset += sizeof(packed_image) + image->byte_count + image->palette_entry_count * 4;
+
+    image = reinterpret_cast<packed_image *>(data + offset);
+    metadata.splash = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
+  }
+}
+
+bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata, bool unpack_images) {
+
+  BlitGameHeader header;
+
+  if(qspi_read_buffer(offset, reinterpret_cast<uint8_t *>(&header), sizeof(header)) != QSPI_OK)
+    return false;
+
+  offset += header.end - 0x90000000;
+
+  uint8_t buf[10];
+  if(qspi_read_buffer(offset, buf, 10) != QSPI_OK)
+    return false;
+
+  if(memcmp(buf, "BLITMETA", 8) != 0)
+    return false;
+
+  auto metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
+  auto metadata_buf = new uint8_t[metadata_len];
+  if(qspi_read_buffer(offset + 10, metadata_buf, metadata_len) != QSPI_OK) {
+    delete[] metadata_buf;
+    return false;
+  }
+
+  parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
+
+  delete[] metadata_buf;
+  return true;
+}
+
+bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata, bool unpack_images) {
+  FIL fh;
+  f_open(&fh, filename.c_str(), FA_READ);
+
+  BlitGameHeader header;
+  UINT bytes_read;
+  f_read(&fh, &header, sizeof(header), &bytes_read);
+
+  if(header.magic == blit_game_magic) {
+    uint8_t buf[10];
+    f_lseek(&fh, (header.end - 0x90000000));
+    auto res = f_read(&fh, buf, 10, &bytes_read);
+
+    if(bytes_read == 10 && memcmp(buf, "BLITMETA", 8) == 0) {
+      auto metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
+      auto metadata_buf = new uint8_t[metadata_len];
+      f_read(&fh, metadata_buf, metadata_len, &bytes_read);
+
+      parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
+      delete[] metadata_buf;
+
+      f_close(&fh);
+      return true;
+    }
+  }
+
+  f_close(&fh);
+  return false;
+}

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -12,20 +12,21 @@ using namespace blit;
 void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadata, bool unpack_images) {
   metadata.length = metadata_len;
 
-  // parse strings
-  uint16_t offset = 0;
+  struct RawMetadata {
+    uint32_t crc32;
+    char datetime[16];
+    char title[25];
+    char description[129];
+    char version[17];
+    char author[17];
+  };
 
-  auto len = strlen(data);
-  metadata.title = std::string(data, len);
-  offset += len + 1;
+  auto raw_meta = reinterpret_cast<RawMetadata *>(data);
+  metadata.title = raw_meta->title;
+  metadata.description = raw_meta->description;
+  metadata.version = raw_meta->version;
 
-  len = strlen(data + offset);
-  metadata.description = std::string(data + offset, len);
-  offset += len + 1;
-
-  len = strlen(data + offset);
-  metadata.version = std::string(data + offset, len);
-  offset += len + 1;
+  uint16_t offset = sizeof(RawMetadata);
 
   if(unpack_images && metadata.icon)
     metadata.free_surfaces();

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -27,19 +27,8 @@ void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadat
   metadata.version = std::string(data + offset, len);
   offset += len + 1;
 
-  if(unpack_images && metadata.icon) {
-    delete[] metadata.icon->data;
-    delete[] metadata.icon->palette;
-    delete metadata.icon;
-    metadata.icon = nullptr;
-  }
-
-  if(unpack_images && metadata.splash) {
-    delete[] metadata.splash->data;
-    delete[] metadata.splash->palette;
-    delete metadata.splash;
-    metadata.splash = nullptr;
-  }
+  if(unpack_images && metadata.icon)
+    metadata.free_surfaces();
 
   if(offset != metadata_len && unpack_images) {
     // icon/splash

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -70,15 +70,13 @@ bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata, bool unpa
     return false;
 
   auto metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
-  auto metadata_buf = new uint8_t[metadata_len];
+  uint8_t metadata_buf[0xFFFF];
   if(qspi_read_buffer(offset + 10, metadata_buf, metadata_len) != QSPI_OK) {
-    delete[] metadata_buf;
     return false;
   }
 
   parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
 
-  delete[] metadata_buf;
   return true;
 }
 
@@ -97,11 +95,11 @@ bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata
 
     if(bytes_read == 10 && memcmp(buf, "BLITMETA", 8) == 0) {
       auto metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
-      auto metadata_buf = new uint8_t[metadata_len];
+
+      uint8_t metadata_buf[0xFFFF];
       f_read(&fh, metadata_buf, metadata_len, &bytes_read);
 
       parse_metadata(reinterpret_cast<char *>(metadata_buf), metadata_len, metadata, unpack_images);
-      delete[] metadata_buf;
 
       f_close(&fh);
       return true;

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -52,6 +52,10 @@ bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata, bool unpa
 
   offset += header.end - 0x90000000;
 
+  // out of bounds
+  if(offset >= 0x2000000)
+    return false;
+
   uint8_t buf[10];
   if(qspi_read_buffer(offset, buf, 10) != QSPI_OK)
     return false;

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -9,17 +9,17 @@
 
 using namespace blit;
 
+struct RawMetadata {
+  uint32_t crc32;
+  char datetime[16];
+  char title[25];
+  char description[129];
+  char version[17];
+  char author[17];
+};
+
 void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadata, bool unpack_images) {
   metadata.length = metadata_len;
-
-  struct RawMetadata {
-    uint32_t crc32;
-    char datetime[16];
-    char title[25];
-    char description[129];
-    char version[17];
-    char author[17];
-  };
 
   auto raw_meta = reinterpret_cast<RawMetadata *>(data);
   metadata.title = raw_meta->title;
@@ -88,7 +88,8 @@ bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata
     auto res = f_read(&fh, buf, 10, &bytes_read);
 
     if(bytes_read == 10 && memcmp(buf, "BLITMETA", 8) == 0) {
-      auto metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
+      // don't bother reading the whole thing if we don't want the images
+      auto metadata_len = unpack_images ? *reinterpret_cast<uint16_t *>(buf + 8) : sizeof(RawMetadata);
 
       uint8_t metadata_buf[0xFFFF];
       f_read(&fh, metadata_buf, metadata_len, &bytes_read);

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -22,9 +22,11 @@ void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadat
   metadata.length = metadata_len;
 
   auto raw_meta = reinterpret_cast<RawMetadata *>(data);
+
   metadata.title = raw_meta->title;
   metadata.description = raw_meta->description;
   metadata.version = raw_meta->version;
+  metadata.author = raw_meta->author;
 
   uint16_t offset = sizeof(RawMetadata);
 

--- a/firmware/metadata.hpp
+++ b/firmware/metadata.hpp
@@ -9,6 +9,22 @@ struct BlitGameMetadata {
   std::string title, description, version;
 
   blit::Surface *icon = nullptr, *splash = nullptr;
+
+  void free_surfaces() {
+    if(icon) {
+      delete[] icon->data;
+      delete[] icon->palette;
+      delete icon;
+      icon = nullptr;
+    }
+
+    if(splash) {
+      delete[] splash->data;
+      delete[] splash->palette;
+      delete splash;
+      splash = nullptr;
+    }
+  }
 };
 
 bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata, bool unpack_images = false);

--- a/firmware/metadata.hpp
+++ b/firmware/metadata.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+#include "graphics/surface.hpp"
+
+struct BlitGameMetadata {
+  uint16_t length = 0;
+  std::string title, description, version;
+
+  blit::Surface *icon = nullptr, *splash = nullptr;
+};
+
+bool parse_flash_metadata(uint32_t offset, BlitGameMetadata &metadata, bool unpack_images = false);
+bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata, bool unpack_images = false);

--- a/firmware/metadata.hpp
+++ b/firmware/metadata.hpp
@@ -6,7 +6,7 @@
 
 struct BlitGameMetadata {
   uint16_t length = 0;
-  std::string title, description, version;
+  std::string title, description, version, author;
 
   blit::Surface *icon = nullptr, *splash = nullptr;
 


### PR DESCRIPTION
Changes for listing games in flash and using the game metadata. Also some cleanup stuff. Has a few unfinished bits:

- ~Doesn't unload metadata when a game has none~
- A block is a 64k flash sector, could be anywhere down to 4k with subsector erases
- The CMake function for metadata only detects changes on the yaml, not the images
- ~There's a TODO in there for skipping to the end of a game while scanning flash~
- ~After you flash a game from the SD, it has two identical entries in the list~
- No RGB splash handling (tool doesn't generate them (yet?))