### PR TITLE
Fix sprite unpacking to RGBA

### DIFF
--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -524,7 +524,8 @@ namespace blit {
     }else{
       Pen *pdest = (Pen *)data;
 
-      for (uint8_t b = *bytes; bytes < ((uint8_t *)image) + image->byte_count; b = *++bytes) {
+      for (; bytes < ((uint8_t *)image) +  sizeof(packed_image) + (image->palette_entry_count * 4) + image->byte_count; ++bytes) {
+        uint8_t b = *bytes;
         for (auto j = 0; j < 8; j++) {
           col <<= 1;
           col |= ((0b10000000 >> j) & b) ? 1 : 0;


### PR DESCRIPTION
The else branch in `load_from_packed` had the same issues that were fixed in #282.