### PR TITLE
Drop the second HAL build

### DIFF
--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -166,42 +166,6 @@ target_compile_definitions(BlitHalSTM32Ext
     -DCDC_FIFO_BUFFERS=${CDC_FIFO_BUFFERS_EXT}
 )
 
-set(MCU_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT}")
-set(MCU_LINKER_SCRIPT "${MCU_LINKER_SCRIPT}" PARENT_SCOPE)
-set(MCU_LINKER_SCRIPT_EXT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT_EXT}" PARENT_SCOPE)
-
-set(USER_STARTUP ${CMAKE_CURRENT_SOURCE_DIR}/startup_user.s ${CMAKE_CURRENT_SOURCE_DIR}/startup_user.cpp PARENT_SCOPE)
-
-function(blit_executable_common NAME)
-	target_link_libraries(${NAME} BlitEngine)
-	set_property(TARGET ${NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-Map=${NAME}.map,--cref")
-	add_custom_command(TARGET ${NAME} POST_BUILD
-		COMMENT "Building ${NAME}.bin"
-		COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${NAME}> ${NAME}.hex
-		COMMAND ${CMAKE_OBJCOPY} -O binary -S $<TARGET_FILE:${NAME}> ${NAME}.bin
-		COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${NAME}>
-		COMMAND ${CMAKE_READELF} -S $<TARGET_FILE:${NAME}>
-	)
-endfunction()
-
-function(blit_executable NAME SOURCES)
-	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
-	add_executable(${NAME} ${USER_STARTUP} ${SOURCES} ${ARGN})
-
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.bin
-		DESTINATION bin
-	)
-
-	set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-specs=nano.specs -u _printf_float -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT}")
-	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")
-
-	blit_executable_common(${NAME})
-
-	if(32BLIT_TOOL)
-		add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${32BLIT_TOOL} PROG ${FLASH_PORT} ${NAME}.bin)
-	endif()
-endfunction()
-
 function(blit_executable_int_flash NAME SOURCES)
 	find_package(PythonInterp 3.6 REQUIRED)
 

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -149,23 +149,6 @@ target_compile_definitions(BlitHalSTM32
 target_compile_options(BlitHalSTM32 PUBLIC "$<$<CONFIG:RELEASE>:-Os>")
 set_target_properties(BlitHalSTM32 PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 
-# 2nd build for external flash
-add_library(BlitHalSTM32Ext OBJECT ${SOURCES})
-
-target_include_directories(BlitHalSTM32Ext
-	PRIVATE
-		${INCLUDE_DIRS}
-)
-
-target_compile_definitions(BlitHalSTM32Ext
-	PRIVATE
-		${DEFINITIONS}
-		-DAPPLICATION_VTOR=${APPLICATION_VTOR_EXT}
-		-DEXTERNAL_LOAD_ADDRESS=${EXTERNAL_LOAD_ADDRESS_EXT}
-		-DINITIALISE_QSPI=${INITIALISE_QSPI_EXT}
-    -DCDC_FIFO_BUFFERS=${CDC_FIFO_BUFFERS_EXT}
-)
-
 function(blit_executable_int_flash NAME SOURCES)
 	find_package(PythonInterp 3.6 REQUIRED)
 

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -1,0 +1,33 @@
+set(MCU_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT}")
+
+set(USER_STARTUP ${CMAKE_CURRENT_LIST_DIR}/startup_user.s ${CMAKE_CURRENT_LIST_DIR}/startup_user.cpp)
+
+function(blit_executable_common NAME)
+	target_link_libraries(${NAME} BlitEngine)
+	set_property(TARGET ${NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-Map=${NAME}.map,--cref")
+	add_custom_command(TARGET ${NAME} POST_BUILD
+		COMMENT "Building ${NAME}.bin"
+		COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${NAME}> ${NAME}.hex
+		COMMAND ${CMAKE_OBJCOPY} -O binary -S $<TARGET_FILE:${NAME}> ${NAME}.bin
+		COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${NAME}>
+		COMMAND ${CMAKE_READELF} -S $<TARGET_FILE:${NAME}>
+	)
+endfunction()
+
+function(blit_executable NAME SOURCES)
+	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
+	add_executable(${NAME} ${USER_STARTUP} ${SOURCES} ${ARGN})
+
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.bin
+		DESTINATION bin
+	)
+
+	set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-specs=nano.specs -u _printf_float -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT}")
+	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")
+
+	blit_executable_common(${NAME})
+
+	if(32BLIT_TOOL)
+		add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${32BLIT_TOOL} PROG ${FLASH_PORT} ${NAME}.bin)
+	endif()
+endfunction()

--- a/32blit.cmake
+++ b/32blit.cmake
@@ -55,7 +55,7 @@ if (NOT DEFINED BLIT_ONCE)
 			message(WARNING "32Blit tool not found")
 		endif()
 
-		add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/32blit-stm32 32blit-stm32)
+		include(${CMAKE_CURRENT_LIST_DIR}/32blit-stm32/executable.cmake)
 	else()
 		add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/32blit-sdl 32blit-sdl)
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ include(32blit.cmake)
 add_subdirectory(examples)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
+    add_subdirectory(32blit-stm32)
     add_subdirectory(firmware)
 endif()
 


### PR DESCRIPTION
And avoid building it entirely in external projects. Unneeded since we're not linking it into games any more.