### PR TITLE
Refine LIS3DH/MSA301 Normal/Beta auto-detection, fix accel polarity

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -268,11 +268,19 @@ void blit_i2c_tick() {
       accel_y.add(((int8_t)i2c_buffer[3] << 6) | (i2c_buffer[2] >> 2));
       accel_z.add(((int8_t)i2c_buffer[5] << 6) | (i2c_buffer[4] >> 2));
 
-      blit::tilt = Vec3(
-        -accel_x.average(),
-        -accel_y.average(),
-        -accel_z.average()
-      );
+      if(is_beta_unit){
+        blit::tilt = Vec3(
+          accel_x.average(),
+          accel_y.average(),
+          -accel_z.average()
+        );
+      } else {
+        blit::tilt = Vec3(
+          -accel_x.average(),
+          -accel_y.average(),
+          -accel_z.average()
+        );
+      }
 
       blit::tilt.normalize();
       i2c_state = SEND_BAT;


### PR DESCRIPTION
Saved a few bytes here, used a few bytes there, all in all a net positive! Or negative. Depending on which way you tilt your blit.