### PR TITLE
Reset to firmware on abort/exit

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -101,6 +101,13 @@ void blit_debug(std::string message) {
   screen.text(message, minimal_font, Point(0, 0));
 }
 
+void blit_exit(bool is_error) {
+  if(is_error)
+    blit_reset_with_error(); // likely an abort
+  else
+    blit_switch_execution(0); // switch back to firmware
+}
+
 void enable_us_timer()
 {
   CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
@@ -372,6 +379,8 @@ void blit_init() {
     blit::api.debugf = blit_debugf;
     blit::api.now = HAL_GetTick;
     blit::api.random = HAL_GetRandom;
+    blit::api.exit = blit_exit;
+
     blit::api.set_screen_mode = display::set_screen_mode;
     blit::api.set_screen_palette = display::set_screen_palette;
     display::set_screen_mode(blit::lores);

--- a/32blit-stm32/startup_user.cpp
+++ b/32blit-stm32/startup_user.cpp
@@ -1,4 +1,5 @@
 #include "engine/engine.hpp"
+#include "engine/api_private.hpp"
 
 extern void init();
 extern void update(uint32_t time);
@@ -12,4 +13,8 @@ extern "C" void cpp_do_init() {
     blit::set_screen_mode(blit::ScreenMode::lores);
 
     init();
+}
+
+extern "C" void _exit(int code) {
+  blit::api.exit(code != 0);
 }

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -32,6 +32,7 @@ namespace blit {
     void (*set_screen_palette)  (const Pen *colours, int num_cols);
     uint32_t (*now)();
     uint32_t (*random)();
+    void (*exit)(bool is_error);
 
     // serial debug
     void (*debug)(std::string message);


### PR DESCRIPTION
Found this while rebasing all my branches yesterday, wasn't included with the initial error handling PR due to depending on user-only.

Intended to catch abort and do something more useful than hang in an infinite loop, `exit` working is an err... undocumented bonus feature. 