### PR TITLE
WIP: PIC for games

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,7 +68,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install ${{matrix.apt-packages}}
-        pip3 install 32blit
+        pip3 install 32blit pyelftools
 
     # macOS deps
     - name: Install deps

--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,4 @@ _deps
 
 stdlib/no-pic
 stdlib/pic
+stdlib/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+
+stdlib/no-pic
+stdlib/pic

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -161,6 +161,7 @@ function(blit_executable_int_flash NAME SOURCES)
 	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")
 
 	blit_executable_common(${NAME})
+	target_link_libraries(${NAME} ${NOPIC_STDLIBS})
 
 	target_include_directories(${NAME} PRIVATE ${HAL_INCLUDE_DIRS})
 	target_compile_definitions(${NAME} PRIVATE ${HAL_DEFINITIONS})

--- a/32blit-stm32/Inc/executable.hpp
+++ b/32blit-stm32/Inc/executable.hpp
@@ -5,7 +5,7 @@ constexpr uint32_t blit_game_magic = 0x54494C42; // "BLIT"
 
 using BlitRenderFunction = void(*)(uint32_t);
 using BlitTickFunction = bool(*)(uint32_t);
-using BlitInitFunction = bool(*)();
+using BlitInitFunction = bool(*)(uint32_t);
 
 // should match the layout in startup_user.s
 struct BlitGameHeader {

--- a/32blit-stm32/STM32H750VBTx.ld
+++ b/32blit-stm32/STM32H750VBTx.ld
@@ -75,6 +75,14 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
+  .got :
+  {
+    . = ALIGN(4);
+    _gotstart = .;
+    *(.got*)
+    _gotend = .;
+  } > FLASH
+
   /* The program code and other data goes into FLASH */
   .text :
   {

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -916,8 +916,8 @@ void blit_switch_execution(uint32_t address)
 
     if(game_header->magic == blit_game_magic) {
       // load function pointers
-      auto init = (BlitInitFunction)((uint8_t *)game_header->init);
-      if(!init()) {
+      auto init = (BlitInitFunction)((uint8_t *)game_header->init + address);
+      if(!init(address)) {
         // this would just be a return, but qspi is already mapped by this point
         persist.reset_target = prtFirmware;
         SCB_CleanDCache();
@@ -927,8 +927,8 @@ void blit_switch_execution(uint32_t address)
   
       persist.last_game_offset = address;
 
-      blit::render = user_render = (BlitRenderFunction) ((uint8_t *)game_header->render);
-      do_tick = user_tick = (BlitTickFunction) ((uint8_t *)game_header->tick);
+      blit::render = user_render = (BlitRenderFunction) ((uint8_t *)game_header->render + address);
+      do_tick = user_tick = (BlitTickFunction) ((uint8_t *)game_header->tick + address);
       return;
     }
     // anything flashed at a non-zero offset should have a valid header

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -49,7 +49,7 @@ function(blit_metadata TARGET FILE)
 
 	add_custom_command(
 		TARGET ${TARGET} POST_BUILD
-		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.bin
+		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.reloc.bin
 	)
 
 	# force relink on change so that the post-build commands are rerun

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -29,6 +29,7 @@ function(blit_executable NAME SOURCES)
 	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")
 
 	blit_executable_common(${NAME})
+	target_link_libraries(${NAME} ${PIC_STDLIBS})
 
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.reloc.bin"

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -24,11 +24,16 @@ function(blit_executable NAME SOURCES)
 
 	set_target_properties(${NAME} PROPERTIES
 		COMPILE_FLAGS "-fPIC -mno-pic-data-is-text-relative -mno-single-pic-base"
-		LINK_FLAGS "-specs=nano.specs -u _printf_float -fPIC -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT}"
+		LINK_FLAGS "-specs=nano.specs -u _printf_float -fPIC -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT} -Wl,--emit-relocs"
 	)
 	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")
 
 	blit_executable_common(${NAME})
+
+	add_custom_command(TARGET ${NAME} POST_BUILD
+		COMMENT "Building ${NAME}.reloc.bin"
+		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_RELOC_TOOL} $<TARGET_FILE:${NAME}> ${NAME}.bin ${NAME}.reloc.bin
+	)
 
 	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${PYTHON_EXECUTABLE} -m ttblit flash --port=${FLASH_PORT} flash --file=${CMAKE_CURRENT_BINARY_DIR}/${NAME}.bin)
 endfunction()

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -22,7 +22,10 @@ function(blit_executable NAME SOURCES)
 		DESTINATION bin
 	)
 
-	set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-specs=nano.specs -u _printf_float -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT}")
+	set_target_properties(${NAME} PROPERTIES
+		COMPILE_FLAGS "-fPIC -mno-pic-data-is-text-relative -mno-single-pic-base"
+		LINK_FLAGS "-specs=nano.specs -u _printf_float -fPIC -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT}"
+	)
 	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")
 
 	blit_executable_common(${NAME})

--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -116,6 +116,8 @@ g_pfnVectors:
   .word flash_start // temp
   .word _gotstart
   .word _gotend
+  .word __preinit_array_start
+  .word __fini_array_end
 
 /*
 .weak      render

--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -55,7 +55,8 @@
   .weak  do_init
   .type  do_init, %function
 do_init:
-
+  push {r4, lr}
+  mov r4, r0
 
 // Copy the data segment initializers from flash to SRAM
   movs  r1, #0
@@ -63,6 +64,7 @@ do_init:
 
 CopyDataInit:
   ldr  r3, =_sidata
+  add r3, r4
   ldr  r3, [r3, r1]
   str  r3, [r0, r1]
   adds  r1, r1, #4
@@ -87,12 +89,11 @@ LoopFillZerobss:
   cmp  r2, r3
   bcc  FillZerobss
 
-  push {lr}
 // Call static constructors
   bl __libc_init_array
 // Call the application's entry point.
   bl cpp_do_init
-  pop {pc}
+  pop {r4, pc}
 
 /*****************************************************************************
 *

--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -114,6 +114,8 @@ g_pfnVectors:
   .word  do_init
   .word _flash_end
   .word flash_start // temp
+  .word _gotstart
+  .word _gotend
 
 /*
 .weak      render

--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -114,10 +114,6 @@ g_pfnVectors:
   .word  do_init
   .word _flash_end
   .word flash_start // temp
-  .word _gotstart
-  .word _gotend
-  .word __preinit_array_start
-  .word __fini_array_end
 
 /*
 .weak      render

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -11,6 +11,7 @@ set(CMAKE_AR arm-none-eabi-gcc-ar CACHE PATH "Path to ar")
 set(CMAKE_OBJCOPY arm-none-eabi-objcopy CACHE PATH "Path to objcopy")
 set(CMAKE_LINKER arm-none-eabi-ld CACHE PATH "Path to linker")
 set(CMAKE_DFU "${CMAKE_CURRENT_LIST_DIR}/tools/dfu" CACHE PATH "Path to DFU builder")
+set(CMAKE_RELOC_TOOL "${CMAKE_CURRENT_LIST_DIR}/tools/gather-relocs" CACHE PATH "Path to reloc tool")
 
 set(MCU_LINKER_SCRIPT STM32H750VBTx.ld)
 set(MCU_LINKER_FLAGS_INT -Wl,--defsym=FLASH_TARGET_INT=1)

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -46,7 +46,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nosys.specs -Wl,--gc-sections,--no-wchar
 
 # stdlibs
 set(STDLIB_PATH ${CMAKE_CURRENT_LIST_DIR}/stdlib)
-set(STDLIB_URL https://cupboard.daftgames.net/32blit/stdlibs.zip)
+set(STDLIB_URL https://get.pimoroni.com/stdlibs.zip)
 set(STDLIB_HASH "SHA256=867eb82d2329c962a5aa389f3b5a4a2efd6d75e5c7d464c92ed7b595f76eb90f")
 
 if(NOT EXISTS ${STDLIB_PATH}/stdlibs.zip)

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -44,6 +44,9 @@ set(CMAKE_CXX_FLAGS_DEBUG_INIT "-g -Og")
 
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nosys.specs -Wl,--gc-sections,--no-wchar-size-warning")
 
+set(PIC_STDLIBS "-nodefaultlibs -L ${CMAKE_CURRENT_LIST_DIR}/stdlib/pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
+set(NONPIC_STDLIBS "-nodefaultlibs -L ${CMAKE_CURRENT_LIST_DIR}/stdlib/no-pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
+
 add_definitions(-DTARGET_32BLIT_HW)
 set(32BLIT_HW 1)
 set(32BLIT_PATH ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "Path to 32blit.cmake")

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -44,8 +44,21 @@ set(CMAKE_CXX_FLAGS_DEBUG_INIT "-g -Og")
 
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nosys.specs -Wl,--gc-sections,--no-wchar-size-warning")
 
-set(PIC_STDLIBS "-nodefaultlibs -L ${CMAKE_CURRENT_LIST_DIR}/stdlib/pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
-set(NONPIC_STDLIBS "-nodefaultlibs -L ${CMAKE_CURRENT_LIST_DIR}/stdlib/no-pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
+# stdlibs
+set(STDLIB_PATH ${CMAKE_CURRENT_LIST_DIR}/stdlib)
+set(STDLIB_URL https://cupboard.daftgames.net/32blit/stdlibs.zip)
+set(STDLIB_HASH "SHA256=867eb82d2329c962a5aa389f3b5a4a2efd6d75e5c7d464c92ed7b595f76eb90f")
+
+if(NOT EXISTS ${STDLIB_PATH}/stdlibs.zip)
+    file(DOWNLOAD ${STDLIB_URL} ${STDLIB_PATH}/stdlibs.zip EXPECTED_HASH ${STDLIB_HASH} SHOW_PROGRESS)
+
+    # CMake 3.18
+    #file(ARCHIVE_EXTRACT INPUT ${STDLIB_PATH}/stdlibs.zip DESTINATION ${STDLIB_PATH})
+    execute_process(COMMAND unzip -u ${STDLIB_PATH}/stdlibs.zip -d ${STDLIB_PATH})
+endif()
+
+set(PIC_STDLIBS "-nodefaultlibs -L ${STDLIB_PATH}/pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
+set(NONPIC_STDLIBS "-nodefaultlibs -L ${STDLIB_PATH}/no-pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
 
 add_definitions(-DTARGET_32BLIT_HW)
 set(32BLIT_HW 1)

--- a/32blit/CMakeLists.txt
+++ b/32blit/CMakeLists.txt
@@ -55,3 +55,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
     -wd4244 # conversions
   )
 endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
+	set_target_properties(BlitEngine PROPERTIES COMPILE_FLAGS "-fPIC -mno-pic-data-is-text-relative -mno-single-pic-base")
+endif()

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -559,13 +559,25 @@ void update(uint32_t time) {
 // returns address to flash file to
 uint32_t get_flash_offset_for_file(BlitGameHeader &bin_header) {
 
-  // temporary load address for working on multiple app support without PIC being ready
-  // in future this will probably be more of a "find free space" function
   if(bin_header.magic == blit_game_magic) {
     auto expected_addr = bin_header.start;
 
-    // this should be sector aligned to not break things later...
-    return expected_addr - qspi_flash_address;
+    if(current_directory->name != "FLASH")
+      scan_flash();
+
+    if(game_list.empty())
+      return 0;
+
+    auto last_game_end = game_list.back().offset + game_list.back().size;
+
+    // round
+    last_game_end = calc_num_blocks(last_game_end) * qspi_flash_sector_size;
+
+    // TODO: handle full
+    if(last_game_end >= qspi_flash_size)
+      return 0;
+
+    return last_game_end;
   }
 
   return 0;

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -614,6 +614,7 @@ uint32_t flash_from_sd_to_qspi_flash(const char *filename)
   char buf[4];
   f_read(&file, buf, 4, &bytes_read);
   std::set<uint32_t> relocation_offsets;
+  bool has_relocs = false;
 
   if(memcmp(buf, "RELO", 4) == 0) {
     uint32_t num_relocs;
@@ -627,6 +628,7 @@ uint32_t flash_from_sd_to_qspi_flash(const char *filename)
     }
 
     bytes_total -= num_relocs * 4 + 8; // size of relocation data
+    has_relocs = true;
   } else {
     f_lseek(&file, 0);
   }
@@ -640,7 +642,7 @@ uint32_t flash_from_sd_to_qspi_flash(const char *filename)
   }
   f_lseek(&file, off);
 
-  uint32_t flash_offset = get_flash_offset_for_file(header);
+  uint32_t flash_offset = has_relocs ? get_flash_offset_for_file(header) : 0;
 
   // erase the sectors needed to write the image
   erase_qspi_flash(flash_offset / qspi_flash_sector_size, bytes_total);

--- a/firmware/firmware.hpp
+++ b/firmware/firmware.hpp
@@ -124,7 +124,7 @@ public:
   virtual bool StreamInit(CDCFourCC uCommand);
 
 private:
-  enum ParseState {stFilename, stLength, stData};
+  enum ParseState {stFilename, stLength, stRelocs, stData};
 
   ParseState m_parseState = stFilename;
 
@@ -134,4 +134,7 @@ private:
   uint32_t m_uParseIndex = 0;
   uint32_t m_uFilelen = 0;
   uint32_t flash_start_offset = 0;
+
+  uint32_t num_relocs = 0, cur_reloc = 0;
+  std::vector<uint32_t> relocation_offsets;
 };

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -22,6 +22,7 @@ void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadat
   metadata.length = metadata_len;
 
   auto raw_meta = reinterpret_cast<RawMetadata *>(data);
+  metadata.crc32 = raw_meta->crc32;
 
   metadata.title = raw_meta->title;
   metadata.description = raw_meta->description;

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -83,9 +83,23 @@ bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata
   UINT bytes_read;
   f_read(&fh, &header, sizeof(header), &bytes_read);
 
+  // skip relocation data
+  int off = 0;
+  if(header.magic == 0x4F4C4552 /* RELO */) {
+    f_lseek(&fh, 4);
+    uint32_t num_relocs;
+    f_read(&fh, (void *)&num_relocs, 4, &bytes_read);
+
+    off = num_relocs * 4 + 8;
+    f_lseek(&fh, off);
+
+    // re-read header
+    f_read(&fh, &header, sizeof(header), &bytes_read);
+  }
+
   if(header.magic == blit_game_magic) {
     uint8_t buf[10];
-    f_lseek(&fh, (header.end - 0x90000000));
+    f_lseek(&fh, (header.end - 0x90000000) + off);
     auto res = f_read(&fh, buf, 10, &bytes_read);
 
     if(bytes_read == 10 && memcmp(buf, "BLITMETA", 8) == 0) {

--- a/firmware/metadata.hpp
+++ b/firmware/metadata.hpp
@@ -6,6 +6,7 @@
 
 struct BlitGameMetadata {
   uint16_t length = 0;
+  uint32_t crc32 = 0;
   std::string title, description, version, author;
 
   blit::Surface *icon = nullptr, *splash = nullptr;

--- a/stdlib/build-libstdc++
+++ b/stdlib/build-libstdc++
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+GCC_VERSION=gcc-7.3.0
+NEWLIB_VERSION=newlib-3.1.0.20181231
+NEWLIB_INCLUDES=$PWD/build/$NEWLIB_VERSION/newlib/libc/include
+JOBS=$(nproc --all)
+OUT_DIR_NOPIC=$PWD/no-pic
+OUT_DIR_PIC=$PWD/pic
+
+mkdir -p $OUT_DIR_NOPIC
+mkdir -p $OUT_DIR_PIC
+
+LIBSTDCXX_FLAGS="--disable-decimal-float \
+	--disable-libffi \
+	--disable-libgomp \
+	--disable-libmudflap \
+	--disable-libquadmath \
+	--disable-libssp \
+	--disable-libstdcxx-pch \
+	--disable-nls \
+	--disable-shared \
+	--disable-threads \
+	--disable-tls \
+	--disable-plugin \
+	--disable-libstdcxx-verbose \
+	--with-gnu-as \
+	--with-gnu-ld \
+	--with-newlib \
+	--with-headers \
+	--enable-languages=c,c++ \
+    --with-cpu=cortex-m7 \
+    --with-mode=thumb \
+    --with-float=hard"
+
+mkdir -p build
+cd build
+
+wget -nc ftp://ftp.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/$GCC_VERSION/$GCC_VERSION.tar.xz
+tar --skip-old-files -xaf $GCC_VERSION.tar.xz
+
+cd $GCC_VERSION
+mkdir -p build
+cd build
+../configure --target=arm-none-eabi \
+    $LIBSTDCXX_FLAGS \
+    CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -fno-exceptions -isystem $NEWLIB_INCLUDES" \
+    CXXFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -fno-exceptions -isystem $NEWLIB_INCLUDES"
+
+make -j $JOBS
+
+cp arm-none-eabi/libgcc/libgcc.a $OUT_DIR_NOPIC
+cp arm-none-eabi/libstdc++-v3/src/.libs/libstdc++.a $OUT_DIR_NOPIC/libstdc++_nano.a
+cp arm-none-eabi/libstdc++-v3/libsupc++/.libs/libsupc++.a $OUT_DIR_NOPIC/libsupc++_nano.a
+
+cd ..
+
+mkdir -p build-pic
+cd build-pic
+../configure --target=arm-none-eabi \
+    $LIBSTDCXX_FLAGS \
+    CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -fno-exceptions -fPIC -mno-pic-data-is-text-relative -mno-single-pic-base -isystem $NEWLIB_INCLUDES" \
+    CXXFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -fno-exceptions -fPIC -mno-pic-data-is-text-relative -mno-single-pic-base -isystem $NEWLIB_INCLUDES"
+
+make -j $JOBS
+
+cp arm-none-eabi/libgcc/libgcc.a $OUT_DIR_PIC
+cp arm-none-eabi/libstdc++-v3/src/.libs/libstdc++.a $OUT_DIR_PIC/libstdc++_nano.a
+cp arm-none-eabi/libstdc++-v3/libsupc++/.libs/libsupc++.a $OUT_DIR_PIC/libsupc++_nano.a
+

--- a/stdlib/build-newlib
+++ b/stdlib/build-newlib
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+NEWLIB_VERSION=newlib-3.1.0.20181231
+JOBS=$(nproc --all)
+OUT_DIR_NOPIC=$PWD/no-pic
+OUT_DIR_PIC=$PWD/pic
+
+mkdir -p $OUT_DIR_NOPIC
+mkdir -p $OUT_DIR_PIC
+
+NEWLIB_FLAGS="--disable-newlib-supplied-syscalls \
+	--disable-nls \
+	--enable-newlib-reent-small \
+	--disable-newlib-fvwrite-in-streamio \
+	--disable-newlib-fseek-optimization \
+	--disable-newlib-wide-orient \
+	--enable-newlib-nano-malloc \
+	--disable-newlib-unbuf-stream-opt \
+	--enable-lite-exit \
+	--enable-newlib-global-atexit \
+	--enable-newlib-nano-formatted-io"
+
+mkdir -p build
+cd build
+
+wget -nc ftp://sourceware.org/pub/newlib/$NEWLIB_VERSION.tar.gz
+tar --skip-old-files -xaf $NEWLIB_VERSION.tar.gz
+cd $NEWLIB_VERSION
+
+mkdir -p build
+cd build
+../configure --target=arm-none-eabi \
+    $NEWLIB_FLAGS \
+    CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -fshort-wchar"
+
+make -j $JOBS
+
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/newlib/libc.a $OUT_DIR_NOPIC/libc_nano.a
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/newlib/libg.a $OUT_DIR_NOPIC/libg_nano.a
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/newlib/libm.a $OUT_DIR_NOPIC/
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/libgloss/libnosys/libnosys.a $OUT_DIR_NOPIC
+
+cd ..
+
+# PIC
+mkdir -p build-pic
+cd build-pic
+../configure --target=arm-none-eabi \
+    $NEWLIB_FLAGS \
+    CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections -fshort-wchar -fPIC -mno-pic-data-is-text-relative -mno-single-pic-base"
+
+make -j $JOBS
+
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/newlib/libc.a $OUT_DIR_PIC/libc_nano.a
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/newlib/libg.a $OUT_DIR_PIC/libg_nano.a
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/newlib/libm.a $OUT_DIR_PIC/
+cp arm-none-eabi/thumb/v7e-m/fpv5/hard/libgloss/libnosys/libnosys.a $OUT_DIR_PIC

--- a/tools/gather-relocs
+++ b/tools/gather-relocs
@@ -11,8 +11,30 @@ elf_filename = sys.argv[1]
 bin_filename = sys.argv[2]
 out_filename = sys.argv[3]
 
+def get_flash_addr_offsets(section):
+    section_data = section.data()
+    section_addrs = struct.unpack(f'<{len(section_data) // 4}I', section_data)
+    section_offsets = []
+
+    for i, addr in enumerate(section_addrs):
+        # filter out non-flash
+        if addr < 0x90000000:
+            continue
+
+        section_offsets.append(section['sh_addr'] + i * 4) # offset to this address in the section
+
+    return section_offsets
+
+
 with open(elf_filename, 'rb') as f:
     elffile = ELFFile(f)
+
+    # get addresses of GOT values that need patched
+    got_offsets = get_flash_addr_offsets( elffile.get_section_by_name('.got'))
+
+    # and the init/fini arrays
+    init_offsets = get_flash_addr_offsets( elffile.get_section_by_name('.init_array'))
+    fini_offsets = get_flash_addr_offsets( elffile.get_section_by_name('.fini_array'))
 
     reloc_offsets = []
 
@@ -49,16 +71,18 @@ with open(elf_filename, 'rb') as f:
 
         # map RAM address back to flash
         flash_offset = (reloc['r_offset'] - sdata) + sidata
-        print("{:08X} -> {:08X}".format(reloc['r_offset'], flash_offset))
+        #print("{:08X} -> {:08X}".format(reloc['r_offset'], flash_offset))
 
         assert((flash_offset & 3) == 0)
 
         reloc_offsets.append(flash_offset)
 
     with open(out_filename, 'wb') as out_f:
+        all_offsets = got_offsets + init_offsets + fini_offsets + reloc_offsets
+
         out_f.write(b"RELO")
-        out_f.write(struct.pack("<L", len(reloc_offsets)))
-        for off in reloc_offsets:
+        out_f.write(struct.pack("<L", len(all_offsets)))
+        for off in all_offsets:
             out_f.write(struct.pack("<L", off))
 
         out_f.write(open(bin_filename, 'rb').read())

--- a/tools/gather-relocs
+++ b/tools/gather-relocs
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+from elftools.elf.enums import ENUM_RELOC_TYPE_ARM
+from elftools.elf.relocation import RelocationSection
+
+elf_filename = sys.argv[1]
+bin_filename = sys.argv[2]
+out_filename = sys.argv[3]
+
+with open(elf_filename, 'rb') as f:
+    elffile = ELFFile(f)
+
+    reloc_offsets = []
+
+    # find sidata/sdata
+    sidata = 0
+    sdata = 0
+    relocs = elffile.get_section_by_name('.rel.text')
+    symtable = elffile.get_section(relocs['sh_link'])
+    for reloc in relocs.iter_relocations():
+        symbol = symtable.get_symbol(reloc['r_info_sym'])
+        if symbol.name == '_sidata':
+            sidata = symbol['st_value']
+        elif symbol.name == '_sdata':
+            sdata = symbol['st_value']
+
+        if sidata and sdata:
+            break
+
+    assert(sidata != 0 and sdata != 0)
+
+    # get all .data relocations
+    relocs = elffile.get_section_by_name('.rel.data')
+    symtable = elffile.get_section(relocs['sh_link'])
+
+    for reloc in relocs.iter_relocations():
+        symbol = symtable.get_symbol(reloc['r_info_sym'])
+
+        if reloc['r_info_type'] != ENUM_RELOC_TYPE_ARM['R_ARM_ABS32']:
+            continue
+
+        # doesn't point to flash
+        if symbol['st_value'] < 0x90000000:
+            continue
+
+        # map RAM address back to flash
+        flash_offset = (reloc['r_offset'] - sdata) + sidata
+        print("{:08X} -> {:08X}".format(reloc['r_offset'], flash_offset))
+
+        assert((flash_offset & 3) == 0)
+
+        reloc_offsets.append(flash_offset)
+
+    with open(out_filename, 'wb') as out_f:
+        out_f.write(b"RELO")
+        out_f.write(struct.pack("<L", len(reloc_offsets)))
+        for off in reloc_offsets:
+            out_f.write(struct.pack("<L", off))
+
+        out_f.write(open(bin_filename, 'rb').read())

--- a/tools/gather-relocs
+++ b/tools/gather-relocs
@@ -79,6 +79,7 @@ with open(elf_filename, 'rb') as f:
 
     with open(out_filename, 'wb') as out_f:
         all_offsets = got_offsets + init_offsets + fini_offsets + reloc_offsets
+        all_offsets.sort()
 
         out_f.write(b"RELO")
         out_f.write(struct.pack("<L", len(all_offsets)))


### PR DESCRIPTION
The last part is finally here...

1. Custom PIC/non-PIC newlib/libstdc++ builds (currently based on the versions from the 7.3 toolchain, build scripts in `stdlib/`)
2. Toolchain automatically downloads and extracts these
3. Games are built with PIC flags linked against the PIC libraries, firmware uses the non-PIC libs.
4. Games have a prepended "RELO" header, containing offsets to patch (GOT, init/fini arrays, data relocations) (currently `tools/gather-relocs`)
5. At flash time (from SD or over CDC) the relocation header is parsed and skipped, the flash offset is applied as we go
6. Many games at once!

A few relatively minor issues remain:

- CDC flashing doesn't check if the game is already there. (SD flashing uses the checksum + name)
- ~`gather-relocs` and the metadata tool don't work together (`[target].bin` contains metadata, `[target].reloc.bin` has reloc data, metadata tool runs after `gather-relocs` and doesn't handle the extra header)~
- ~The stdlibs are currently being downloaded from my "test server".~ Also, since CMake's zip extration command is only supported in the latest version the extraction is done by running `zip`.~
- The calculation for where a game should be flashed is "just throw it after the previous one" with no handling for running out of space or deleting things.
- Probably more, it's been a while...