### PR TITLE
Use python tool for .flash targets

### DIFF
--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -15,6 +15,8 @@ function(blit_executable_common NAME)
 endfunction()
 
 function(blit_executable NAME SOURCES)
+	find_package(PythonInterp 3.6 REQUIRED)
+
 	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
 	add_executable(${NAME} ${USER_STARTUP} ${SOURCES} ${ARGN})
 
@@ -27,7 +29,5 @@ function(blit_executable NAME SOURCES)
 
 	blit_executable_common(${NAME})
 
-	if(32BLIT_TOOL)
-		add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${32BLIT_TOOL} PROG ${FLASH_PORT} ${NAME}.bin)
-	endif()
+	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${PYTHON_EXECUTABLE} -m ttblit flash --port=${FLASH_PORT} flash --file=${CMAKE_CURRENT_BINARY_DIR}/${NAME}.bin)
 endfunction()

--- a/32blit.cmake
+++ b/32blit.cmake
@@ -39,22 +39,6 @@ if (NOT DEFINED BLIT_ONCE)
 	if (${CMAKE_SYSTEM_NAME} STREQUAL Generic)
 		set(FLASH_PORT "AUTO" CACHE STRING "Port to use for flash")
 
-		# attempt to find the upload tool
-		find_program(32BLIT_TOOL 32Blit PATHS
-			${CMAKE_CURRENT_BINARY_DIR}/../build/tools/src/
-		)
-
-		if(NOT 32BLIT_TOOL)
-			message(WARNING "32Blit tool not found. Looking for 32Blit.exe instead")
-			find_program(32BLIT_TOOL 32Blit.exe PATHS
-				${CMAKE_CURRENT_BINARY_DIR}/../build.mingw/tools/src/
-			)
-		endif()
-
-		if(NOT 32BLIT_TOOL)
-			message(WARNING "32Blit tool not found")
-		endif()
-
 		include(${CMAKE_CURRENT_LIST_DIR}/32blit-stm32/executable.cmake)
 	else()
 		add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/32blit-sdl 32blit-sdl)

--- a/docs/32Blit-Firmware.md
+++ b/docs/32Blit-Firmware.md
@@ -17,7 +17,7 @@ This repository includes firmware for the 32Blit that lets you manage games on S
 In order to use the 32blit firmware, you will need to:
 
 1. Build and install the 32Blit firmware (if you don't have it already)
-2. [Build the flash loader](32Blit-Loader.md) tool in `tools/src`
+2. The 32blit tools `pip install 32blit`
 3. Flash the firmware to your 32Blit
 
 You must make sure you have an ARM GCC cross-compile environment set up on your computer, refer to the relevant documentation below:


### PR DESCRIPTION
Removes the need to do a local build before a device build... Attempted to update the docs, `docs/32Blit-Loader.md` will need updated/replaced...