### PR TITLE
Firmware list/erase commands

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -20,6 +20,7 @@ enum State {stFlashFile, stSaveFile, stFlashCDC, stMassStorage};
 
 constexpr uint32_t qspi_flash_sector_size = 64 * 1024;
 constexpr uint32_t qspi_flash_size = 32768 * 1024;
+constexpr uint32_t qspi_flash_address = 0x90000000;
 
 Vec2 file_list_scroll_offset(20.0f, 0.0f);
 float directory_list_scroll_offset = 0.0f;
@@ -175,7 +176,7 @@ bool read_flash_game_header(uint32_t offset, BlitGameHeader &header) {
     return false;
 
   // make sure end/size is sensible
-  if(header.end <= 0x90000000)
+  if(header.end <= qspi_flash_address)
     return false;
 
   return true;
@@ -194,7 +195,7 @@ void scan_flash() {
 
     GameInfo game;
     game.offset = offset;
-    game.size = header.end - 0x90000000;
+    game.size = header.end - qspi_flash_address;
     game.title = "game @" + std::to_string(game.offset / qspi_flash_sector_size);
 
     // check for valid metadata
@@ -516,7 +517,7 @@ uint32_t get_flash_offset_for_file(BlitGameHeader &bin_header) {
     auto expected_addr = bin_header.start;
 
     // this should be sector aligned to not break things later...
-    return expected_addr - 0x90000000;
+    return expected_addr - qspi_flash_address;
   }
 
   return 0;
@@ -604,7 +605,7 @@ void cdc_flash_list() {
       continue;
     }
 
-    uint32_t size = header.end - 0x90000000;
+    uint32_t size = header.end - qspi_flash_address;
 
     // metadata header
     uint8_t buf[10];

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -67,7 +67,7 @@ int calc_num_blocks(uint32_t size) {
 }
 
 void erase_qspi_flash(uint32_t start_sector, uint32_t size_bytes) {
-  uint32_t sector_count = (size_bytes / qspi_flash_sector_size) + 1;
+  uint32_t sector_count = calc_num_blocks(size_bytes);
 
   progress.show("Erasing flash sectors...", sector_count);
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -623,6 +623,7 @@ void cdc_flash_list() {
     if(memcmp(buf, "BLITMETA", 8) == 0)
       metadata_len = *reinterpret_cast<uint16_t *>(buf + 8);
 
+    while(CDC_Transmit_HS((uint8_t *)"BLITMETA", 8) == USBD_BUSY){}
     while(CDC_Transmit_HS((uint8_t *)&metadata_len, 2) == USBD_BUSY){}
 
     // send metadata

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -193,7 +193,7 @@ void scan_flash() {
 
     game_list.push_back(game);
 
-    offset += calc_num_blocks(game.size);
+    offset += calc_num_blocks(game.size) * qspi_flash_sector_size;
   }
   sort_file_list();
 }

--- a/firmware/firmware.hpp
+++ b/firmware/firmware.hpp
@@ -108,6 +108,15 @@ struct {
 
 } dialog;
 
+class CDCEraseHandler final : public CDCCommandHandler {
+public:
+  StreamResult StreamData(CDCDataStream &dataStream) override;
+
+  bool StreamInit(CDCFourCC uCommand) override {
+    return true;
+  }
+};
+
 class FlashLoader : public CDCCommandHandler
 {
 public:


### PR DESCRIPTION
Small cleanup/fixes and adds two new commands to the firmware:

- `__LS` - lists games in flash (returns offset and size (uint32), then metadata for each game)
- `ERSE[32bit offset]` - erases game at an offset

(`__LS` already existed, but all it did was reload the file list)

WIP for the tools:
```diff
diff --git a/src/ttblit/tool/flasher.py b/src/ttblit/tool/flasher.py
index 053106c..530ac28 100644
--- a/src/ttblit/tool/flasher.py
+++ b/src/ttblit/tool/flasher.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import struct
 import time
 
 import serial.tools.list_ports
@@ -28,6 +29,8 @@ class Flasher(Tool):
         self.op_flash.add_argument('--file', type=pathlib.Path, required=True, help='File to flash')
 
         self.op_delete = operations.add_parser('delete', help='Delete a game/file from your 32Blit')
+        self.op_delete.add_argument('--offset', type=int, help='Flash offset of game to delete')
+
         self.op_list = operations.add_parser('list', help='List games/files on your 32Blit')
         self.op_debug = operations.add_parser('debug', help='Enter serial debug mode')
         self.op_reset = operations.add_parser('reset', help='Reset your 32Blit')
@@ -138,11 +141,28 @@ class Flasher(Tool):
 
     @serial_command
     def run_delete(self, serial, args):
-        pass
+        self._reset_to_firmware(serial)
+        serial.write(b'32BLERSE\x00')
+        serial.write(struct.pack("<I", args.get('offset')))
 
     @serial_command
     def run_list(self, serial, args):
-        pass
+        self._reset_to_firmware(serial)
+
+        serial.write(b'32BL__LS\x00')
+        offset_str = serial.read(4)
+
+        while offset_str != '' and offset_str != b'\xff\xff\xff\xff':
+            offset, = struct.unpack('<I', offset_str)
+            size, meta_size = struct.unpack('<IH', serial.read(6))
+
+            metadata = None
+            if meta_size:
+                metadata = serial.read(meta_size)
+
+            print(offset, size, metadata[20:45].rstrip(b'\0') if metadata else None)
+
+            offset_str = serial.read(4)
 
     @serial_command
     def run_debug(self, serial, args):

```
Needs more metadata parsing...