### PR TITLE
Menu refactor

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -460,6 +460,16 @@ public:
     selected_item_background = get_menu_colour(4);
   }
 
+  void draw_slider(Point pos, int width, float value, Pen colour) const {
+    const int bar_margin = 2;
+    const int bar_height = item_h - bar_margin * 2;
+
+    screen.pen = bar_background_color;
+    screen.rectangle(Rect(pos, Size(width, bar_height)));
+    screen.pen = colour;
+    screen.rectangle(Rect(pos, Size(width * value, bar_height)));
+  }
+
 protected:
   void render_item(const Item &item, int y) const override {
     Menu::render_item(item, y);
@@ -471,18 +481,10 @@ protected:
 
     switch(item.id) {
       case BACKLIGHT:
-        screen.pen = bar_background_color;
-        screen.rectangle(Rect(screen_width / 2, y + bar_margin, 75, bar_height));
-        screen.pen = foreground_colour;
-        screen.rectangle(Rect(screen_width / 2, y + bar_margin, 75 * persist.backlight, bar_height));
-
+        draw_slider(Point(screen_width / 2, y + bar_margin), 75, persist.backlight, foreground_colour);
         break;
       case VOLUME:
-        screen.pen = bar_background_color;
-        screen.rectangle(Rect(screen_width / 2, y + bar_margin, 75, bar_height));
-        screen.pen = foreground_colour;
-        screen.rectangle(Rect(screen_width / 2, y + bar_margin, 75 * persist.volume, bar_height));
-
+        draw_slider(Point(screen_width / 2, y + bar_margin), 75, persist.volume, foreground_colour);
         break;
       default:
         screen.pen = foreground_colour;

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -458,6 +458,9 @@ public:
     foreground_colour = get_menu_colour(2);
     bar_background_color = get_menu_colour(3);
     selected_item_background = get_menu_colour(4);
+
+    display_rect.w = screen.bounds.w;
+    display_rect.h = screen.bounds.h;
   }
 
   void draw_slider(Point pos, int width, float value, Pen colour) const {

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -553,7 +553,7 @@ static Menu::Item firmware_menu_items[]{
 FirmwareMenu firmware_menu("System Menu", firmware_menu_items, MenuItem::LAST_COUNT);
 
 void blit_menu_update(uint32_t time) {
-  firmware_menu.update();
+  firmware_menu.update(time);
 }
 
 void blit_menu_render(uint32_t time) {

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -482,7 +482,7 @@ protected:
     const int bar_margin = 2;
     const int bar_height = item_h - bar_margin * 2;
     const int bar_width = 75;
-    int bar_x = screen_width - bar_width - margin_x;
+    int bar_x = screen_width - bar_width - item_padding_x;
   
     switch(item.id) {
       case BACKLIGHT:
@@ -493,7 +493,7 @@ protected:
         break;
       default:
         screen.pen = foreground_colour;
-        screen.text("Press A", minimal_font, Point(screen_width - margin_x, y + item_margin_y), true, TextAlign::right);
+        screen.text("Press A", minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
         break;  
     }
   }
@@ -599,13 +599,13 @@ void blit_menu_render(uint32_t time) {
   */
 
   // add battery info to header
-  screen.text("bat", minimal_font, Point(screen_width - 80, 5));
+  screen.text("bat", minimal_font, Point(screen_width - 80, 4));
   int battery_meter_width = 55;
   battery_meter_width = float(battery_meter_width) * (battery - 3.0f) / 1.1f;
   battery_meter_width = std::max(0, std::min(55, battery_meter_width));
 
   screen.pen = bar_background_color;
-  screen.rectangle(Rect(screen_width - 60, 6, 55, 5));
+  screen.rectangle(Rect(screen_width - 60, 5, 55, 5));
 
   switch(battery_status >> 6){
     case 0b00: // Unknown
@@ -621,13 +621,13 @@ void blit_menu_render(uint32_t time) {
         screen.pen = get_menu_colour(7);
         break;
   }
-  screen.rectangle(Rect(screen_width - 60, 6, battery_meter_width, 5));
+  screen.rectangle(Rect(screen_width - 60, 5, battery_meter_width, 5));
   uint8_t battery_charge_status = (battery_status >> 4) & 0b11;
   if(battery_charge_status == 0b01 || battery_charge_status == 0b10){
     int battery_fill_width = (time / 500) % battery_meter_width;
     battery_fill_width = std::min(battery_meter_width, battery_fill_width);
     screen.pen = get_menu_colour(8);
-    screen.rectangle(Rect(screen_width - 60, 6, battery_fill_width, 5));
+    screen.rectangle(Rect(screen_width - 60, 5, battery_fill_width, 5));
   }
 }
 

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -440,6 +440,8 @@ static const Pen menu_colours[]{
   {  0, 255,   0}, // battery usb host/adapter port
   {255,   0,   0}, // battery otg
   {100, 100, 255}, // battery charging
+  {235, 245, 255}, // header/footer bg
+  {  3,   5,   7}, // header/footer fg
 };
 static constexpr int num_menu_colours = sizeof(menu_colours) / sizeof(Pen);
 static Pen menu_saved_colours[num_menu_colours];
@@ -458,6 +460,8 @@ public:
     foreground_colour = get_menu_colour(2);
     bar_background_color = get_menu_colour(3);
     selected_item_background = get_menu_colour(4);
+    header_background = get_menu_colour(9);
+    header_foreground = get_menu_colour(10);
 
     display_rect.w = screen.bounds.w;
     display_rect.h = screen.bounds.h;
@@ -577,7 +581,7 @@ void blit_menu_render(uint32_t time) {
   const int screen_width = blit::screen.bounds.w;
   const int screen_height = blit::screen.bounds.h;
 
-  const Pen foreground_colour = get_menu_colour(2);
+  const Pen foreground_colour = get_menu_colour(10);
   const Pen bar_background_color = get_menu_colour(3);
 
   screen.pen = foreground_colour;
@@ -588,7 +592,7 @@ void blit_menu_render(uint32_t time) {
     battery_charge_status(),
     battery_vbus_status(),
     int(battery), int((battery - int(battery)) * 10.0f));
-  screen.text(buf, minimal_font, Point(0, screen_height - 10));
+  screen.text(buf, minimal_font, Point(5, screen_height - 11));
 
   /*
   // Raw register values can be displayed with a fixed-width font using std::bitset<8> for debugging

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -478,8 +478,8 @@ public:
   }
 
 protected:
-  void render_item(const Item &item, int y) const override {
-    Menu::render_item(item, y);
+  void render_item(const Item &item, int y, int index) const override {
+    Menu::render_item(item, y, index);
 
     const auto screen_width = screen.bounds.w;
 

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -478,17 +478,19 @@ protected:
 
     const int bar_margin = 2;
     const int bar_height = item_h - bar_margin * 2;
-
+    const int bar_width = 75;
+    int bar_x = screen_width - bar_width - margin_x;
+  
     switch(item.id) {
       case BACKLIGHT:
-        draw_slider(Point(screen_width / 2, y + bar_margin), 75, persist.backlight, foreground_colour);
+        draw_slider(Point(bar_x, y + bar_margin), bar_width, persist.backlight, foreground_colour);
         break;
       case VOLUME:
-        draw_slider(Point(screen_width / 2, y + bar_margin), 75, persist.volume, foreground_colour);
+        draw_slider(Point(bar_x, y + bar_margin), bar_width, persist.volume, foreground_colour);
         break;
       default:
         screen.pen = foreground_colour;
-        screen.text("Press A", minimal_font, Point(screen_width / 2, y + item_margin_y));
+        screen.text("Press A", minimal_font, Point(screen_width - margin_x, y + item_margin_y), true, TextAlign::right);
         break;  
     }
   }
@@ -594,13 +596,13 @@ void blit_menu_render(uint32_t time) {
   */
 
   // add battery info to header
-  screen.text("bat", minimal_font, Point(screen_width / 2, 5));
+  screen.text("bat", minimal_font, Point(screen_width - 80, 5));
   int battery_meter_width = 55;
   battery_meter_width = float(battery_meter_width) * (battery - 3.0f) / 1.1f;
   battery_meter_width = std::max(0, std::min(55, battery_meter_width));
 
   screen.pen = bar_background_color;
-  screen.rectangle(Rect((screen_width / 2) + 20, 6, 55, 5));
+  screen.rectangle(Rect(screen_width - 60, 6, 55, 5));
 
   switch(battery_status >> 6){
     case 0b00: // Unknown
@@ -616,13 +618,13 @@ void blit_menu_render(uint32_t time) {
         screen.pen = get_menu_colour(7);
         break;
   }
-  screen.rectangle(Rect((screen_width / 2) + 20, 6, battery_meter_width, 5));
+  screen.rectangle(Rect(screen_width - 60, 6, battery_meter_width, 5));
   uint8_t battery_charge_status = (battery_status >> 4) & 0b11;
   if(battery_charge_status == 0b01 || battery_charge_status == 0b10){
     int battery_fill_width = (time / 500) % battery_meter_width;
     battery_fill_width = std::min(battery_meter_width, battery_fill_width);
     screen.pen = get_menu_colour(8);
-    screen.rectangle(Rect((screen_width / 2) + 20, 6, battery_fill_width, 5));
+    screen.rectangle(Rect(screen_width - 60, 6, battery_fill_width, 5));
   }
 }
 

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -35,15 +35,11 @@ namespace blit {
 
       int y = display_rect.y + header_h + margin_y;
 
-      // selected item
-      screen.pen = selected_item_background;
-      screen.rectangle(Rect(display_rect.x, y + current_item * (item_h + item_spacing), display_rect.w, item_h));
-
       // items
       for(int i = 0; i < num_items; i++) {
         auto &item = items[i];
 
-        render_item(item, y);
+        render_item(item, y, i);
 
         y += item_h + item_spacing;
       }
@@ -86,9 +82,18 @@ namespace blit {
     std::string_view title;
 
   protected:
-    virtual void render_item(const Item &item, int y) const {
+    virtual void render_item(const Item &item, int y, int index) const {
+      Rect item_rect(display_rect.x, y, display_rect.w, item_h);
+
+      // selected item
+      if(index == current_item) {
+        screen.pen = selected_item_background;
+        screen.rectangle(item_rect);
+      }
+      
       screen.pen = foreground_colour;
-      Rect item_rect(display_rect.x + item_padding_x, y + item_adjust_y, display_rect.w - item_padding_x * 2, item_h);
+      item_rect.x += item_padding_x;
+      item_rect.y += item_adjust_y;
       item_rect.h += minimal_font.spacing_y; // adjust for alignment
       screen.text(item.label, minimal_font, item_rect, true, TextAlign::center_left);
     }

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -33,7 +33,12 @@ namespace blit {
       header_rect.h += font.spacing_y; // adjust for alignment
       screen.text(title, font, header_rect, true, TextAlign::center_left);
 
-      int y = display_rect.y + header_h + margin_y;
+      int y = display_rect.y + header_h;
+      int display_height = display_rect.h - (header_h + footer_h);
+
+      auto old_clip = screen.clip;
+      screen.clip = Rect(display_rect.x, y, display_rect.w, display_height);
+      y += scroll_offset + margin_y;
 
       // items
       for(int i = 0; i < num_items; i++) {
@@ -43,6 +48,8 @@ namespace blit {
 
         y += item_h + item_spacing;
       }
+
+      screen.clip = old_clip;
 
       // footer
       if(footer_h) {
@@ -65,6 +72,18 @@ namespace blit {
         current_item = current_item == num_items - 1 ? 0 : current_item + 1;
       else if(buttons.pressed & Button::A)
         item_activated(items[current_item]);
+
+      // scrolling
+      int total_height = num_items * (item_h + item_spacing);
+      int display_height = display_rect.h - (header_h + footer_h + margin_y * 2);
+  
+      int current_y = current_item * (item_h + item_spacing);
+      int target_scroll = display_height / 2 - current_y;
+
+      // clamp
+      target_scroll = std::min(0, std::max(-(total_height - display_height), target_scroll));
+
+      scroll_offset += (target_scroll - scroll_offset) * 0.2f;
 
       update_item(items[current_item]);
     }
@@ -107,6 +126,7 @@ namespace blit {
     const Item *items;
     int num_items;
     int current_item = 0;
+    float scroll_offset = 0.0f;
 
     // layout
     Rect display_rect;

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -14,8 +14,8 @@ namespace blit {
       const char *label;
     };
 
-    Menu(std::string_view title, const Item *items = nullptr, int num_items = 0) : title(title), items(items), num_items(num_items),
-      display_rect(0, 0, 0, 0) {
+    Menu(std::string_view title, const Item *items = nullptr, int num_items = 0, const Font &font = minimal_font)
+      : title(title), items(items), num_items(num_items), display_rect(0, 0, 0, 0), font(font) {
     }
     virtual ~Menu() {}
 
@@ -30,8 +30,8 @@ namespace blit {
 
       screen.pen = header_foreground;
       header_rect.x += item_padding_x;
-      header_rect.h += minimal_font.spacing_y; // adjust for alignment
-      screen.text(title, minimal_font, header_rect, true, TextAlign::center_left);
+      header_rect.h += font.spacing_y; // adjust for alignment
+      screen.text(title, font, header_rect, true, TextAlign::center_left);
 
       int y = display_rect.y + header_h + margin_y;
 
@@ -94,8 +94,8 @@ namespace blit {
       screen.pen = foreground_colour;
       item_rect.x += item_padding_x;
       item_rect.y += item_adjust_y;
-      item_rect.h += minimal_font.spacing_y; // adjust for alignment
-      screen.text(item.label, minimal_font, item_rect, true, TextAlign::center_left);
+      item_rect.h += font.spacing_y; // adjust for alignment
+      screen.text(item.label, font, item_rect, true, TextAlign::center_left);
     }
 
     virtual void update_item(const Item &item) {
@@ -117,6 +117,8 @@ namespace blit {
     int item_padding_x = 5;
     int item_adjust_y = 1; // minimal_font y is a bit off
     int item_spacing = 1;
+
+    const Font &font;
 
     // colours
     Pen background_colour = Pen(30,  30,  50, 200);

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -24,12 +24,14 @@ namespace blit {
       screen.rectangle(display_rect);
 
       // header
-      screen.pen = foreground_colour;
-      Rect header_rect(display_rect.x + item_padding_x, display_rect.y, display_rect.w - item_padding_x * 2, header_h);
+      screen.pen = header_background;
+      Rect header_rect(display_rect.x, display_rect.y, display_rect.w, header_h);
+      screen.rectangle(header_rect);
+
+      screen.pen = header_foreground;
+      header_rect.x += item_padding_x;
       header_rect.h += minimal_font.spacing_y; // adjust for alignment
       screen.text(title, minimal_font, header_rect, true, TextAlign::center_left);
-
-      screen.h_span(Point(display_rect.x, display_rect.y + header_h - 1), display_rect.w);
 
       int y = display_rect.y + header_h + margin_y;
 
@@ -48,8 +50,9 @@ namespace blit {
 
       // footer
       if(footer_h) {
-        screen.pen = foreground_colour;
-        screen.h_span(Point(display_rect.x, display_rect.y + display_rect.h - footer_h + 1), display_rect.w);
+        screen.pen = header_background;
+        Rect footer_rect(display_rect.x, display_rect.y + display_rect.h - footer_h, display_rect.w, footer_h);
+        screen.rectangle(footer_rect);
       }
     }
 
@@ -114,5 +117,8 @@ namespace blit {
     Pen background_colour = Pen(30,  30,  50, 200);
     Pen foreground_colour = Pen(255, 255, 255);
     Pen selected_item_background = Pen(50,  50,  70);
+
+    Pen header_background = Pen(235, 245, 255);
+    Pen header_foreground = Pen(3, 5, 7);
   };
 }

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <string>
+
+#include "engine/api.hpp"
+#include "engine/engine.hpp"
+#include "graphics/surface.hpp"
+
+namespace blit {
+  class Menu {
+  public:
+    struct Item {
+      uint16_t id;
+      const char *label;
+    };
+
+    Menu(std::string_view title, const Item *items = nullptr, int num_items = 0) : title(title), items(items), num_items(num_items) {
+    }
+    virtual ~Menu() {}
+
+    void render() {
+      screen.pen = background_colour;
+      screen.clear();
+
+      // header
+      screen.pen = foreground_colour;
+      screen.text(title, minimal_font, Point(margin_x, margin_y));
+
+      screen.h_span(Point(0, header_h), screen.bounds.w);
+
+      int y = header_h + margin_y;
+
+      // selected item
+      screen.pen = selected_item_background;
+      screen.rectangle(Rect(0, y + current_item * (item_h + item_spacing), screen.bounds.w, item_h));
+
+      // items
+      for(int i = 0; i < num_items; i++) {
+        auto &item = items[i];
+
+        render_item(item, y);
+
+        y += item_h + item_spacing;
+      }
+
+      // footer
+      screen.pen = foreground_colour;
+      screen.h_span(Point(0, screen.bounds.h - 15), screen.bounds.w);
+    }
+
+    void update() {
+      if(buttons.pressed & Button::DPAD_UP)
+        current_item = current_item == 0 ? num_items - 1 : current_item - 1;
+      else if(buttons.pressed & Button::DPAD_DOWN)
+        current_item = current_item == num_items - 1 ? 0 : current_item + 1;
+      else if(buttons.pressed & Button::A)
+        item_activated(items[current_item]);
+
+      update_item(items[current_item]);
+    }
+
+    void set_items(const Item *items, int num_items) {
+      this->items = items;
+      this->num_items = num_items;
+      current_item = 0;
+    }
+
+    std::string_view title;
+
+  protected:
+    virtual void render_item(const Item &item, int y) const {
+      screen.pen = foreground_colour;
+      screen.text(item.label, minimal_font, Point(margin_x, y + item_margin_y));
+    }
+
+    virtual void update_item(const Item &item) {
+    }
+
+    virtual void item_activated(const Item &item) {
+    }
+
+    const Item *items;
+    int num_items;
+    int current_item = 0;
+
+    // layout
+    const int header_h = 15, footer_h = 15;
+    const int margin_x = 5, margin_y = 5;
+    const int item_h = 9;
+    const int item_margin_y = 1;
+    const int item_spacing = 1;
+
+    // colours
+    Pen background_colour = Pen(30,  30,  50, 200);
+    Pen foreground_colour = Pen(255, 255, 255);
+    Pen selected_item_background = Pen(50,  50,  70);
+  };
+}

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -46,7 +46,7 @@ namespace blit {
 
       // footer
       screen.pen = foreground_colour;
-      screen.h_span(Point(display_rect.x, display_rect.y + display_rect.h - 15), display_rect.w);
+      screen.h_span(Point(display_rect.x, display_rect.y + display_rect.h - footer_h), display_rect.w);
     }
 
     void update() {

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -23,9 +23,13 @@ namespace blit {
       screen.pen = background_colour;
       screen.rectangle(display_rect);
 
+      int x = display_rect.x;
+      int y = display_rect.y;
+      int w = display_rect.w;
+
       // header
       screen.pen = header_background;
-      Rect header_rect(display_rect.x, display_rect.y, display_rect.w, header_h);
+      Rect header_rect(x, y, w, header_h);
       screen.rectangle(header_rect);
 
       screen.pen = header_foreground;
@@ -33,12 +37,20 @@ namespace blit {
       header_rect.h += font.spacing_y; // adjust for alignment
       screen.text(title, font, header_rect, true, TextAlign::center_left);
 
-      int y = display_rect.y + header_h;
+      // y region to clip to
+      y += header_h;
       int display_height = display_rect.h - (header_h + footer_h);
 
+      // footer
+      if(footer_h) {
+        screen.pen = header_background;
+        Rect footer_rect(x, y + display_height, w, footer_h);
+        screen.rectangle(footer_rect);
+      }
+
       auto old_clip = screen.clip;
-      screen.clip = Rect(display_rect.x, y, display_rect.w, display_height);
-      y += scroll_offset + margin_y;
+      screen.clip = Rect(x, y, w, display_height);
+      y += (int)scroll_offset + margin_y;
 
       // items
       for(int i = 0; i < num_items; i++) {
@@ -50,13 +62,6 @@ namespace blit {
       }
 
       screen.clip = old_clip;
-
-      // footer
-      if(footer_h) {
-        screen.pen = header_background;
-        Rect footer_rect(display_rect.x, display_rect.y + display_rect.h - footer_h, display_rect.w, footer_h);
-        screen.rectangle(footer_rect);
-      }
     }
 
     void update(uint32_t time) {

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -59,18 +59,31 @@ namespace blit {
       }
     }
 
-    void update() {
+    void update(uint32_t time) {
       // default size
       if(display_rect.w == 0 && display_rect.h == 0) {
         display_rect.w = screen.bounds.w;
         display_rect.h = screen.bounds.h;
       }
 
-      if(buttons.pressed & Button::DPAD_UP)
-        current_item = current_item == 0 ? num_items - 1 : current_item - 1;
-      else if(buttons.pressed & Button::DPAD_DOWN)
-        current_item = current_item == num_items - 1 ? 0 : current_item + 1;
-      else if(buttons.pressed & Button::A)
+      // key repeat for up/down
+      const int repeat_ms = 200;
+      if(buttons.pressed & (Button::DPAD_UP | Button::DPAD_DOWN))
+        repeat_start_time = time - repeat_ms;
+
+      if((time - repeat_start_time) >= repeat_ms) {
+        if(buttons & Button::DPAD_UP) {
+          if(--current_item < 0)
+            current_item += num_items;
+        } else if(buttons & Button::DPAD_DOWN) {
+          if(++current_item == num_items)
+            current_item = 0;
+        }
+
+        repeat_start_time = time;
+      }
+
+      if(buttons.pressed & Button::A)
         item_activated(items[current_item]);
 
       // scrolling
@@ -127,6 +140,8 @@ namespace blit {
     int num_items;
     int current_item = 0;
     float scroll_offset = 0.0f;
+
+    uint32_t repeat_start_time = 0;
 
     // layout
     Rect display_rect;

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -25,9 +25,11 @@ namespace blit {
 
       // header
       screen.pen = foreground_colour;
-      screen.text(title, minimal_font, Point(display_rect.x + margin_x, display_rect.y + margin_y));
+      Rect header_rect(display_rect.x + item_padding_x, display_rect.y, display_rect.w - item_padding_x * 2, header_h);
+      header_rect.h += minimal_font.spacing_y; // adjust for alignment
+      screen.text(title, minimal_font, header_rect, true, TextAlign::center_left);
 
-      screen.h_span(Point(display_rect.x, display_rect.y + header_h), display_rect.w);
+      screen.h_span(Point(display_rect.x, display_rect.y + header_h - 1), display_rect.w);
 
       int y = display_rect.y + header_h + margin_y;
 
@@ -45,8 +47,10 @@ namespace blit {
       }
 
       // footer
-      screen.pen = foreground_colour;
-      screen.h_span(Point(display_rect.x, display_rect.y + display_rect.h - footer_h), display_rect.w);
+      if(footer_h) {
+        screen.pen = foreground_colour;
+        screen.h_span(Point(display_rect.x, display_rect.y + display_rect.h - footer_h + 1), display_rect.w);
+      }
     }
 
     void update() {
@@ -81,7 +85,9 @@ namespace blit {
   protected:
     virtual void render_item(const Item &item, int y) const {
       screen.pen = foreground_colour;
-      screen.text(item.label, minimal_font, Point(display_rect.x + margin_x, y + item_margin_y));
+      Rect item_rect(display_rect.x + item_padding_x, y + item_adjust_y, display_rect.w - item_padding_x * 2, item_h);
+      item_rect.h += minimal_font.spacing_y; // adjust for alignment
+      screen.text(item.label, minimal_font, item_rect, true, TextAlign::center_left);
     }
 
     virtual void update_item(const Item &item) {
@@ -96,11 +102,13 @@ namespace blit {
 
     // layout
     Rect display_rect;
-    const int header_h = 15, footer_h = 15;
-    const int margin_x = 5, margin_y = 5;
-    const int item_h = 9;
-    const int item_margin_y = 1;
-    const int item_spacing = 1;
+    int header_h = 16, footer_h = 16;
+    int margin_y = 5; // margin between items and header
+
+    int item_h = 9;
+    int item_padding_x = 5;
+    int item_adjust_y = 1; // minimal_font y is a bit off
+    int item_spacing = 1;
 
     // colours
     Pen background_colour = Pen(30,  30,  50, 200);


### PR DESCRIPTION
Reworks the firmware menu into a basic reusable menu class and adds scrolling and customisation options. Also changes the menu appearance a bit:

![screenshot13](https://user-images.githubusercontent.com/3074891/95460273-a5571e00-096c-11eb-96b3-fd404b67838a.png)

Customised menu from my emulator:
![emumenu](https://user-images.githubusercontent.com/3074891/95460338-bd2ea200-096c-11eb-93e0-d25554bd1a62.png)

And even the file browser:
![emubrowse](https://user-images.githubusercontent.com/3074891/95460512-f6ffa880-096c-11eb-8cd9-99ec4bd2277d.png)

Usage example:
```c++
class MyMenu final : public Menu {
public:
  MyMenu() : Menu("Title", item_data, 2) {
    // optionally replace some pens/layout
  }

  // optionally render_item/update_item for more customisation

  void item_activated(const Item &item) override {
   // do things
  }

  Item item_data[2]{
    {0, "Item 1"},
    {1, "Item 2"}
  };
};

MyMenu menu;

...
menu.update(time);

...
menu.render();

```

All the base class does is display a scrollable list of items that you can sellect with A.

Has (possibly a lot of) overlap with #216. I think that one does a more in the common menu class. (Sub menus/navigation, lists, sliders). Hmm... probably need a compromise somewhere between features and blowing up the build size...