### PR TITLE
Fix offset calc in scan_flash

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -193,7 +193,7 @@ void scan_flash() {
 
     game_list.push_back(game);
 
-    offset += calc_num_blocks(game.size);
+    offset += calc_num_blocks(game.size) * qspi_flash_sector_size;
   }
   sort_file_list();
 }


### PR DESCRIPTION
Included in #388 and #396, ignore if either of those get merged first.