### PR TITLE
Remove darwin toolchain

### DIFF
--- a/darwin.toolchain
+++ b/darwin.toolchain
@@ -1,3 +1,0 @@
-set(CMAKE_SYSTEM_NAME Darwin)
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -83,7 +83,7 @@ Then, set up the 32Blit Makefile from the root of the repository with the follow
 ```shell
 mkdir build
 cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE=../darwin.toolchain
+cmake ..
 ```
 
 Now to make any example, type:


### PR DESCRIPTION
Pretty sure this is unneeded as building for macOS on a mac isn't cross-compiling and it works fine on mine (CMake defaults to clang anyway)...