### PR TITLE
Avoid copying entire screen surface in set_screen_mode

### DIFF
--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -14,7 +14,9 @@ namespace blit {
   void (*render)(uint32_t time)                     = nullptr;
 
   void set_screen_mode(ScreenMode new_mode) {
-    screen = api.set_screen_mode(new_mode);
+    auto &new_screen = api.set_screen_mode(new_mode);
+    screen = Surface(new_screen.data, new_screen.format, new_screen.bounds);
+    screen.palette = new_screen.palette;
   }
 
   void set_screen_palette(const Pen *colours, int num_cols) {


### PR DESCRIPTION
This avoids the blend functions from the firmware being used in user code, which are slightly slower due to optimisation level differences. The fact that `set_screen_mode` resets most of `screen` should probably be documented somewhere... (it already did that)

I only noticed this due to drawing not being any faster in a release build...