### PR TITLE
Add VS Code CMake tools config

### DIFF
--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,0 +1,6 @@
+[
+    {
+      "name": "32Blit",
+      "toolchainFile": "${workspaceFolder}/32blit.toolchain"
+    }
+]


### PR DESCRIPTION
This makes the toolchain automatically appear as a kit in VS Code (still needs the manual config in the docs for out of tree projects)