### PR TITLE
Packed image/surface improvements

### DIFF
--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -27,7 +27,7 @@ namespace blit {
   }
 
   SpriteSheet *SpriteSheet::load(const packed_image *image, uint8_t *buffer) {
-    if(memcmp(image->type, "SPRITEPK", 8) != 0)
+    if(memcmp(image->type, "SPRITEPK", 8) != 0 && memcmp(image->type, "SPRITERW", 8) != 0)
       return nullptr;
 
     if(image->format > (uint8_t)PixelFormat::M)

--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -30,6 +30,9 @@ namespace blit {
     if(memcmp(image->type, "SPRITEPK", 8) != 0)
       return nullptr;
 
+    if(image->format > (uint8_t)PixelFormat::M)
+      return nullptr;
+
     if (buffer == nullptr) {
       buffer = new uint8_t[pixel_format_stride[image->format] * image->width * image->height];
     }

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -52,6 +52,20 @@ namespace blit {
     return load((const packed_image *)data);
   }
 
+  Surface *Surface::load_read_only(const packed_image *image) {
+    if(memcmp(image->type, "SPRITERW", 8) != 0)
+      return nullptr;
+
+    if(image->format > (uint8_t)PixelFormat::M)
+      return nullptr;
+
+    return new Surface(nullptr, (PixelFormat)image->format, image);
+  }
+
+  Surface *Surface::load_read_only(const uint8_t *data) {
+    return load_read_only((const packed_image *)data);
+  }
+
   bool Surface::save(const std::string &filename) {
     File file;
 
@@ -525,8 +539,11 @@ namespace blit {
     }
 
     if (is_raw) {
-      // raw, just copy the data
-      memcpy(data, bytes, image->width * image->height * pixel_format_stride[image->format]);
+      if(data) // just copy the data
+        memcpy(data, bytes, image->width * image->height * pixel_format_stride[image->format]);
+      else // no data pointer, assume load_read_only is being used
+        data = bytes;
+
       return;
     }
 

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -485,11 +485,16 @@ namespace blit {
    */
   void Surface::load_from_packed(const packed_image *image) {        
     uint8_t *palette_entries = ((uint8_t *)image) + sizeof(packed_image);
-    uint8_t *bytes = ((uint8_t *)image) + sizeof(packed_image) + (image->palette_entry_count * 4);
+
+    int palette_entry_count = image->palette_entry_count;
+    if(palette_entry_count == 0)
+      palette_entry_count = 256;
+
+    uint8_t *bytes = ((uint8_t *)image) + sizeof(packed_image) + (palette_entry_count * 4);
 
     bounds = Size(image->width, image->height);
 
-    uint8_t bit_depth = log2i(std::max(1, (int)image->palette_entry_count - 1)) + 1;
+    uint8_t bit_depth = log2i(std::max(1, palette_entry_count - 1)) + 1;
 
     uint8_t col = 0;
     uint8_t bit = 0;
@@ -499,7 +504,7 @@ namespace blit {
       uint8_t *pdest = (uint8_t *)data;
       
       palette = new Pen[256];
-      for (uint8_t pidx = 0; pidx < image->palette_entry_count; pidx++) {
+      for (int pidx = 0; pidx < palette_entry_count; pidx++) {
         palette[pidx] = Pen(
           palette_entries[pidx * 4 + 0],
           palette_entries[pidx * 4 + 1],

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -41,6 +41,9 @@ namespace blit {
     if(memcmp(image->type, "SPRITEPK", 8) != 0)
       return nullptr;
 
+    if(image->format > (uint8_t)PixelFormat::M)
+      return nullptr;
+
     uint8_t *buffer = new uint8_t[pixel_format_stride[image->format] * image->width * image->height];
     return new Surface(buffer, (PixelFormat)image->format, image);
   }

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -1,6 +1,7 @@
 /*! \file surface.cpp
 */
 #include <algorithm>
+#include <cstring>
 #include <string>
 
 #include "font.hpp"
@@ -37,8 +38,15 @@ namespace blit {
   }
 
   Surface *Surface::load(const packed_image *image) {
+    if(memcmp(image->type, "SPRITEPK", 8) != 0)
+      return nullptr;
+
     uint8_t *buffer = new uint8_t[pixel_format_stride[image->format] * image->width * image->height];
     return new Surface(buffer, (PixelFormat)image->format, image);
+  }
+
+  Surface *Surface::load(const uint8_t *data) {
+    return load((const packed_image *)data);
   }
 
   bool Surface::save(const std::string &filename) {

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -507,7 +507,7 @@ namespace blit {
           palette_entries[pidx * 4 + 3]);
       }
 
-      for (; bytes < ((uint8_t *)image) + sizeof(packed_image) + (image->palette_entry_count * 4) + image->byte_count; ++bytes) {
+      for (; bytes < ((uint8_t *)image) + image->byte_count; ++bytes) {
         uint8_t b = *bytes;
         for (auto j = 0; j < 8; j++) {
           col <<= 1;
@@ -523,7 +523,7 @@ namespace blit {
     }else{
       Pen *pdest = (Pen *)data;
 
-      for (; bytes < ((uint8_t *)image) +  sizeof(packed_image) + (image->palette_entry_count * 4) + image->byte_count; ++bytes) {
+      for (; bytes < ((uint8_t *)image) + image->byte_count; ++bytes) {
         uint8_t b = *bytes;
         for (auto j = 0; j < 8; j++) {
           col <<= 1;

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -37,6 +37,13 @@ namespace blit {
     init();
   }
 
+  /**
+   * Loads a packed or raw image asset into a `Surface`
+   * 
+   * \param image
+   * 
+   * \return `Surface` containng loaded data or `nullptr` if the image was invalid
+   */
   Surface *Surface::load(const packed_image *image) {
     if(memcmp(image->type, "SPRITEPK", 8) != 0 && memcmp(image->type, "SPRITERW", 8) != 0)
       return nullptr;
@@ -48,10 +55,25 @@ namespace blit {
     return new Surface(buffer, (PixelFormat)image->format, image);
   }
 
+  /**
+   * \overload
+   * 
+   * \param data pointer to an image asset
+   */
   Surface *Surface::load(const uint8_t *data) {
     return load((const packed_image *)data);
   }
 
+  /**
+   * Similar to @ref load, but the resulting `Surface` points directly at the image data instead of copying it.
+   * `data` should not be modified after loading, so no drawing can be done to this surface. If the image is paletted, the palette can still be modified.
+   * 
+   * Only works for non-packed images.
+   *
+   * \param image
+   * 
+   * \return `Surface` containng loaded data or `nullptr` if the image was invalid
+   */
   Surface *Surface::load_read_only(const packed_image *image) {
     if(memcmp(image->type, "SPRITERW", 8) != 0)
       return nullptr;
@@ -62,6 +84,11 @@ namespace blit {
     return new Surface(nullptr, (PixelFormat)image->format, image);
   }
 
+  /**
+   * \overload
+   * 
+   * \param data pointer to an image asset
+   */
   Surface *Surface::load_read_only(const uint8_t *data) {
     return load_read_only((const packed_image *)data);
   }

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -116,7 +116,8 @@ namespace blit {
     Surface(uint8_t *data, const PixelFormat &format, const Size &bounds);
     Surface(uint8_t *data, const PixelFormat &format, const packed_image *image);
 
-    Surface *load(const packed_image *image);
+    static Surface *load(const packed_image *image);
+    static Surface *load(const uint8_t *data);
 
     bool save(const std::string &filename);
 

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -119,6 +119,9 @@ namespace blit {
     static Surface *load(const packed_image *image);
     static Surface *load(const uint8_t *data);
 
+    static Surface *load_read_only(const packed_image *image);
+    static Surface *load_read_only(const uint8_t *data);
+
     bool save(const std::string &filename);
 
     // helpers to retrieve pointer to pixel

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -24,11 +24,9 @@ namespace blit {
 #pragma pack(push, 1)
   struct packed_image {
     uint8_t type[8];
-    uint16_t byte_count;
+    uint32_t byte_count;
     uint16_t width;
     uint16_t height;
-    uint16_t cols;
-    uint16_t rows;
     uint8_t format;
     uint8_t palette_entry_count;
   };

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -38,7 +38,7 @@ void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadat
     // not really sprite sheets, but that's where the load helper is...
     auto image = reinterpret_cast<packed_image *>(data + offset);
     metadata.icon = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
-    offset += sizeof(packed_image) + image->byte_count + image->palette_entry_count * 4;
+    offset += image->byte_count;
 
     image = reinterpret_cast<packed_image *>(data + offset);
     metadata.splash = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));

--- a/firmware/metadata.cpp
+++ b/firmware/metadata.cpp
@@ -35,13 +35,12 @@ void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadat
 
   if(offset != metadata_len && unpack_images) {
     // icon/splash
-    // not really sprite sheets, but that's where the load helper is...
     auto image = reinterpret_cast<packed_image *>(data + offset);
-    metadata.icon = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
+    metadata.icon = Surface::load(reinterpret_cast<uint8_t *>(data + offset));
     offset += image->byte_count;
 
     image = reinterpret_cast<packed_image *>(data + offset);
-    metadata.splash = SpriteSheet::load(reinterpret_cast<uint8_t *>(data + offset));
+    metadata.splash = Surface::load(reinterpret_cast<uint8_t *>(data + offset));
   }
 }
 


### PR DESCRIPTION
Reverts `byte_count` back to how it was originally (before I broke it), handles a 0-size palette as a full 256 colours and changes the packed image format a bit to allow larger images.

Also, handles loading unpacked images, adjusts `Surface::load` to be more consistent with `SpriteSheet::load` and adds a helper to use an unpacked image without loading it into ram...

Requires https://github.com/pimoroni/32blit-tools/pull/32 for breaking changes to `packed_image` format.