### PR TITLE
Spritesheet/Surface load from file

### DIFF
--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -102,6 +102,14 @@ namespace blit {
     return api.remove_file(path);
   }
 
+  bool File::open(const uint8_t *buf, uint32_t buf_len) {
+    close();
+
+    this->buf = buf;
+    this->buf_len = buf_len;
+    return true;
+  }
+
   /**
    * Open a file. If a file is already open it will be automatically closed.
    *

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -66,6 +66,7 @@ namespace blit {
     }
 
     bool open(const std::string &file, int mode = OpenMode::read);
+    bool File::open(const uint8_t *buf, uint32_t buf_len);
     int32_t read(uint32_t offset, uint32_t length, char *buffer);
     int32_t write(uint32_t offset, uint32_t length, const char *buffer);
     void close();

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -66,7 +66,7 @@ namespace blit {
     }
 
     bool open(const std::string &file, int mode = OpenMode::read);
-    bool File::open(const uint8_t *buf, uint32_t buf_len);
+    bool open(const uint8_t *buf, uint32_t buf_len);
     int32_t read(uint32_t offset, uint32_t length, char *buffer);
     int32_t write(uint32_t offset, uint32_t length, const char *buffer);
     void close();

--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -6,6 +6,8 @@
 #include "surface.hpp"
 #include "sprite.hpp"
 
+#include "../engine/file.hpp"
+
 using namespace blit;
 
 namespace blit {
@@ -38,6 +40,26 @@ namespace blit {
     }
     
     return new SpriteSheet(buffer, (PixelFormat)image->format, image);
+  }
+
+  SpriteSheet *SpriteSheet::load(const std::string& filename, uint8_t* buffer) {
+    File file;
+
+    if (!file.open(filename, OpenMode::read))
+      return nullptr;
+
+    // Read the header from the file
+    packed_image* header = (packed_image*)malloc(sizeof(packed_image));
+    file.read(0, sizeof(packed_image), (char*)header);
+
+    uint8_t *image = new uint8_t[header->byte_count];
+    file.read(0, header->byte_count, (char*)image);
+
+    if (buffer == nullptr) {
+      buffer = new uint8_t[pixel_format_stride[header->format] * header->width * header->height];
+    }
+
+    return new SpriteSheet(buffer, (PixelFormat)header->format, (packed_image *)image);
   }
 
   /**

--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -24,6 +24,11 @@ namespace blit {
     cols = bounds.w / 8;
   }
 
+  SpriteSheet::SpriteSheet(uint8_t *data, PixelFormat format, File &image) : Surface(data, format, image) {  
+    rows = bounds.h / 8;
+    cols = bounds.w / 8;
+  }
+
   SpriteSheet *SpriteSheet::load(const uint8_t *data, uint8_t *buffer) {
     return load((packed_image *)data, buffer);
   }
@@ -48,18 +53,14 @@ namespace blit {
     if (!file.open(filename, OpenMode::read))
       return nullptr;
 
-    // Read the header from the file
-    packed_image* header = (packed_image*)malloc(sizeof(packed_image));
-    file.read(0, sizeof(packed_image), (char*)header);
-
-    uint8_t *image = new uint8_t[header->byte_count];
-    file.read(0, header->byte_count, (char*)image);
+    packed_image image;
+    file.read(0, sizeof(packed_image), (char *)&image);
 
     if (buffer == nullptr) {
-      buffer = new uint8_t[pixel_format_stride[header->format] * header->width * header->height];
+      buffer = new uint8_t[pixel_format_stride[image.format] * image.width * image.height];
     }
 
-    return new SpriteSheet(buffer, (PixelFormat)header->format, (packed_image *)image);
+    return new SpriteSheet(buffer, (PixelFormat)image.format, file);
   }
 
   /**

--- a/32blit/graphics/sprite.hpp
+++ b/32blit/graphics/sprite.hpp
@@ -32,6 +32,7 @@ namespace blit {
 
     static SpriteSheet *load(const uint8_t *data, uint8_t *buffer = nullptr);
     static SpriteSheet *load(const packed_image *image, uint8_t *buffer = nullptr);
+    static SpriteSheet *load(const std::string& filename, uint8_t* buffer = nullptr);
 
     Rect sprite_bounds(const uint16_t &index);          
     Rect sprite_bounds(const Point &p);

--- a/32blit/graphics/sprite.hpp
+++ b/32blit/graphics/sprite.hpp
@@ -29,6 +29,7 @@ namespace blit {
     uint16_t  rows, cols;
 
     SpriteSheet(uint8_t *data, PixelFormat format, const packed_image *image);
+    SpriteSheet(uint8_t *data, PixelFormat format, File &image);
 
     static SpriteSheet *load(const uint8_t *data, uint8_t *buffer = nullptr);
     static SpriteSheet *load(const packed_image *image, uint8_t *buffer = nullptr);

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -597,22 +597,22 @@ namespace blit {
     }
 
     // avoid allocating if in flash
-    const uint8_t *bytes, *end;
+    const uint8_t *image_data, *end;
 
     if(file.get_ptr())
-      bytes = file.get_ptr() + offset;
+      image_data = file.get_ptr() + offset;
     else {
-      bytes = new uint8_t[image.width * image.height * pixel_format_stride[image.format]];
-      file.read(offset, image.width * image.height * pixel_format_stride[image.format], (char *)bytes);
+      image_data = new uint8_t[image.width * image.height * pixel_format_stride[image.format]];
+      file.read(offset, image.width * image.height * pixel_format_stride[image.format], (char *)image_data);
     }
 
-    end = bytes + image.byte_count - offset;
+    end = image_data + image.byte_count - offset;
 
     if (format == PixelFormat::P) {
       // load paletted
       uint8_t *pdest = (uint8_t *)data;
 
-      for (; bytes < end; ++bytes) {
+      for (auto bytes = image_data; bytes < end; ++bytes) {
         uint8_t b = *bytes;
         for (auto j = 0; j < 8; j++) {
           col <<= 1;
@@ -629,7 +629,7 @@ namespace blit {
       // packed RGBA
       Pen *pdest = (Pen *)data;
 
-      for (; bytes < end; ++bytes) {
+      for (auto bytes = image_data; bytes < end; ++bytes) {
         uint8_t b = *bytes;
         for (auto j = 0; j < 8; j++) {
           col <<= 1;
@@ -650,7 +650,7 @@ namespace blit {
     }
 
     if (!file.get_ptr()) {
-      delete[] (uint8_t*)(bytes - image.byte_count + offset);
+      delete[] image_data;
     }
   }
 

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -42,7 +42,7 @@ namespace blit {
    * 
    * \param image
    * 
-   * \return `Surface` containng loaded data or `nullptr` if the image was invalid
+   * \return `Surface` containing loaded data or `nullptr` if the image was invalid
    */
   Surface *Surface::load(const packed_image *image) {
     if(memcmp(image->type, "SPRITEPK", 8) != 0 && memcmp(image->type, "SPRITERW", 8) != 0)
@@ -65,6 +65,27 @@ namespace blit {
   }
 
   /**
+   * \overload
+   * 
+   * \param filename string filename
+   */
+  Surface *Surface::load(std::string &filename) {
+    File file;
+
+    if(!file.open(filename, OpenMode::read))
+      return nullptr;
+
+    // Read the header from the file
+    packed_image *image = (packed_image *)malloc(sizeof(packed_image));
+    file.read(0, sizeof(packed_image), (char *)image);
+
+    uint8_t *data = new uint8_t[image->byte_count];
+    file.read(0, image->byte_count, (char *)data);
+
+    return load((const packed_image *)data);
+  }
+
+  /**
    * Similar to @ref load, but the resulting `Surface` points directly at the image data instead of copying it.
    * `data` should not be modified after loading, so no drawing can be done to this surface. If the image is paletted, the palette can still be modified.
    * 
@@ -72,7 +93,7 @@ namespace blit {
    *
    * \param image
    * 
-   * \return `Surface` containng loaded data or `nullptr` if the image was invalid
+   * \return `Surface` containing loaded data or `nullptr` if the image was invalid
    */
   Surface *Surface::load_read_only(const packed_image *image) {
     if(memcmp(image->type, "SPRITERW", 8) != 0)

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -649,8 +649,9 @@ namespace blit {
       palette = nullptr;
     }
 
-    //if(!file.get_ptr())
-    //  delete[] bytes;
+    if (!file.get_ptr()) {
+      delete[] (uint8_t*)(bytes - image.byte_count + offset);
+    }
   }
 
   /**

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -33,6 +33,13 @@ namespace blit {
   }
 
   Surface::Surface(uint8_t *data, const PixelFormat &format, const packed_image *image) : data(data), format(format) {
+    File f_image;
+    f_image.open((const uint8_t *)image, image->byte_count);
+    load_from_packed(f_image);
+    init();
+  }
+
+  Surface::Surface(uint8_t *data, const PixelFormat &format, File &image) : data(data), format(format) {
     load_from_packed(image);
     init();
   }
@@ -75,14 +82,11 @@ namespace blit {
     if(!file.open(filename, OpenMode::read))
       return nullptr;
 
-    // Read the header from the file
-    packed_image *image = (packed_image *)malloc(sizeof(packed_image));
-    file.read(0, sizeof(packed_image), (char *)image);
+    packed_image image;
+    file.read(0, sizeof(packed_image), (char *)&image);
 
-    uint8_t *data = new uint8_t[image->byte_count];
-    file.read(0, image->byte_count, (char *)data);
-
-    return load((const packed_image *)data);
+    uint8_t *buffer = new uint8_t[pixel_format_stride[image.format] * image.width * image.height];
+    return new Surface(buffer, (PixelFormat)image.format, file);
   }
 
   /**
@@ -556,50 +560,59 @@ namespace blit {
    *
    * \param image
    */
-  void Surface::load_from_packed(const packed_image *image) {        
-    uint8_t *palette_entries = ((uint8_t *)image) + sizeof(packed_image);
+  void Surface::load_from_packed(File &file) {
+    packed_image image;
+    file.read(0, sizeof(packed_image), (char *)&image);
 
-    int palette_entry_count = image->palette_entry_count;
+    int palette_entry_count = image.palette_entry_count;
     if(palette_entry_count == 0)
       palette_entry_count = 256;
 
-    bool is_raw = image->type[6] == 'R' && image->type[7] == 'W'; // "SPRITERW"
+    bool is_raw = image.type[6] == 'R' && image.type[7] == 'W'; // SPRITE[RW]
 
-    uint8_t *bytes = ((uint8_t *)image) + sizeof(packed_image) + (palette_entry_count * 4);
-
-    bounds = Size(image->width, image->height);
+    bounds = Size(image.width, image.height);
 
     uint8_t bit_depth = log2i(std::max(1, palette_entry_count - 1)) + 1;
 
     uint8_t col = 0;
     uint8_t bit = 0;
 
-    if (format == PixelFormat::P) {
+    // Skip over image header to palette entries
+    uint32_t offset = sizeof(packed_image);
+
+    if (format == PixelFormat::P || !is_raw) {
       // load palette
       palette = new Pen[256];
-      for (int pidx = 0; pidx < palette_entry_count; pidx++) {
-        palette[pidx] = Pen(
-          palette_entries[pidx * 4 + 0],
-          palette_entries[pidx * 4 + 1],
-          palette_entries[pidx * 4 + 2],
-          palette_entries[pidx * 4 + 3]);
-      }
+      file.read(offset, palette_entry_count * 4, (char *)palette);
+      offset += palette_entry_count * 4;
     }
 
     if (is_raw) {
-      if(data) // just copy the data
-        memcpy(data, bytes, image->width * image->height * pixel_format_stride[image->format]);
+      if(data) // just read/copy the data
+        file.read(offset, image.width * image.height * pixel_format_stride[image.format], (char *)data);
       else // no data pointer, assume load_read_only is being used
-        data = bytes;
+        data = (uint8_t *)file.get_ptr() + offset;
 
       return;
     }
+
+    // avoid allocating if in flash
+    const uint8_t *bytes, *end;
+
+    if(file.get_ptr())
+      bytes = file.get_ptr() + offset;
+    else {
+      bytes = new uint8_t[image.width * image.height * pixel_format_stride[image.format]];
+      file.read(offset, image.width * image.height * pixel_format_stride[image.format], (char *)bytes);
+    }
+
+    end = bytes + image.byte_count - offset;
 
     if (format == PixelFormat::P) {
       // load paletted
       uint8_t *pdest = (uint8_t *)data;
 
-      for (; bytes < ((uint8_t *)image) + image->byte_count; ++bytes) {
+      for (; bytes < end; ++bytes) {
         uint8_t b = *bytes;
         for (auto j = 0; j < 8; j++) {
           col <<= 1;
@@ -616,7 +629,7 @@ namespace blit {
       // packed RGBA
       Pen *pdest = (Pen *)data;
 
-      for (; bytes < ((uint8_t *)image) + image->byte_count; ++bytes) {
+      for (; bytes < end; ++bytes) {
         uint8_t b = *bytes;
         for (auto j = 0; j < 8; j++) {
           col <<= 1;
@@ -624,17 +637,20 @@ namespace blit {
 
           bit++;
           if (bit == bit_depth) {
-            *pdest++ = Pen(
-              palette_entries[col * 4 + 0],
-              palette_entries[col * 4 + 1],
-              palette_entries[col * 4 + 2],
-              palette_entries[col * 4 + 3]);
+            *pdest++ = palette[col];
 
             bit = 0; col = 0;
           }
         }
       }
+
+      // unpacked, no longer needed
+      delete[] palette;
+      palette = nullptr;
     }
+
+    //if(!file.get_ptr())
+    //  delete[] bytes;
   }
 
   /**

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -12,6 +12,7 @@
 #endif
 
 #include "font.hpp"
+#include "../engine/file.hpp"
 #include "../types/rect.hpp"
 #include "../types/size.hpp"
 #include "../graphics/blend.hpp"
@@ -110,11 +111,12 @@ namespace blit {
 
   private:
     void init();
-    void load_from_packed(const packed_image *image);
+    void load_from_packed(File &file);
 
   public:
     Surface(uint8_t *data, const PixelFormat &format, const Size &bounds);
     Surface(uint8_t *data, const PixelFormat &format, const packed_image *image);
+    Surface(uint8_t *data, const PixelFormat &format, File &image);
 
     static Surface *load(const packed_image *image);
     static Surface *load(const uint8_t *data);

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -118,6 +118,7 @@ namespace blit {
 
     static Surface *load(const packed_image *image);
     static Surface *load(const uint8_t *data);
+    static Surface *load(std::string &filename);
 
     static Surface *load_read_only(const packed_image *image);
     static Surface *load_read_only(const uint8_t *data);


### PR DESCRIPTION
A crude attempt at loading Spritesheet or Surface data from a file.

There seems to be a fair amount of duplication here, and if we switch to bytewise loading of images then `load_from_packed` could end up looking something like this:

```c++
  void Surface::load_from_packed(const packed_image *image, File *file) {        
    uint8_t *palette_entries = ((uint8_t *)image) + sizeof(packed_image);

    int palette_entry_count = image->palette_entry_count;
    if(palette_entry_count == 0)
      palette_entry_count = 256;

    bool is_raw = image->type[6] == 'R' && image->type[7] == 'W'; // "SPRITERW"

    uint8_t *bytes = ((uint8_t *)image) + sizeof(packed_image) + (palette_entry_count * 4);

    bounds = Size(image->width, image->height);

    uint8_t bit_depth = log2i(std::max(1, palette_entry_count - 1)) + 1;

    uint8_t col = 0;
    uint8_t bit = 0;

    if (format == PixelFormat::P) {
      if(file){
        // load palette
        palette = new Pen[palette_entry_count];
        file->read(sizeof(packed_image), (palette_entry_count * 4), (char *)&palette);
      } else {
        // load palette
        palette = new Pen[palette_entry_count];
        for (int pidx = 0; pidx < palette_entry_count; pidx++) {
          palette[pidx] = Pen(
            palette_entries[pidx * 4 + 0],
            palette_entries[pidx * 4 + 1],
            palette_entries[pidx * 4 + 2],
            palette_entries[pidx * 4 + 3]);
        }
      }
    }

    if (is_raw) {
      if(data) { // just copy the data
        if(file){
          file->read(sizeof(packed_image) + (palette_entry_count * 4), image->width * image->height * pixel_format_stride[image->format], (char *)data);
        }
        else
        {
          memcpy(data, bytes, image->width * image->height * pixel_format_stride[image->format]);
        }
      } else { // no data pointer, assume load_read_only is being used
        data = bytes;
      }
      return;
    }
```