### PR TITLE
VS warning fixes

### DIFF
--- a/32blit-sdl/File.cpp
+++ b/32blit-sdl/File.cpp
@@ -46,7 +46,7 @@ int32_t read_file(void *fh, uint32_t offset, uint32_t length, char *buffer) {
     size_t bytes_read = SDL_RWread(file, buffer, 1, length);
 
     if(bytes_read > 0)
-      return bytes_read;
+      return (int32_t)bytes_read;
   }
 
   return -1;
@@ -56,10 +56,10 @@ int32_t write_file(void *fh, uint32_t offset, uint32_t length, const char *buffe
   auto file = (SDL_RWops *)fh;
 
   if(file && SDL_RWseek(file, offset, RW_SEEK_SET) != -1) {
-    size_t bytes_read = SDL_RWwrite(file, buffer, 1, length);
+    size_t bytes_written = SDL_RWwrite(file, buffer, 1, length);
 
-    if(bytes_read > 0)
-      return bytes_read;
+    if(bytes_written > 0)
+      return (int32_t)bytes_written;
   }
 
   return -1;
@@ -74,7 +74,7 @@ uint32_t get_file_length(void *fh)
   auto file = (SDL_RWops *)fh;
   SDL_RWseek(file, 0, RW_SEEK_END);
 
-  return SDL_RWtell(file);
+  return (uint32_t)SDL_RWtell(file);
 }
 
 std::vector<blit::FileInfo> list_files(const std::string &path) {

--- a/32blit-sdl/Input.cpp
+++ b/32blit-sdl/Input.cpp
@@ -114,7 +114,7 @@ bool Input::handle_controller_button(int button, bool state) {
 }
 
 bool Input::handle_controller_motion(int axis, int value) {
-	float fvalue = value / 32768.0;
+	float fvalue = value / 32768.0f;
 	switch(axis) {
 		case SDL_CONTROLLER_AXIS_LEFTX:
 			target->set_joystick(0, fvalue);
@@ -135,7 +135,7 @@ bool Input::handle_controller_motion(int axis, int value) {
 }
 
 void Input::_virtual_tilt(int x, int y) {
-	int z = 80;
+	float z = 80.0f;
 	x = x - (win_width / 2);
 	y = y - (win_height / 2);
 	blit::Vec3 shadow_tilt(x, y, z);

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cstdio>
+#include <cmath>
 #include "SDL.h"
 
 #include "Renderer.hpp"
@@ -37,8 +38,8 @@ void Renderer::set_mode(Mode new_mode) {
 		dest.w = win_width; dest.h = win_height;
 	} else {
 		float current_pixel_size = std::min((float)win_width / sys_width, (float)win_height / sys_height);
-		if (mode == KeepPixels) current_pixel_size = (int)current_pixel_size;
-		else if (mode == KeepPixelsLores) current_pixel_size = ((int)(2*current_pixel_size)) / 2.0;
+		if (mode == KeepPixels) current_pixel_size = floor(current_pixel_size);
+		else if (mode == KeepPixelsLores) current_pixel_size = (floor(2*current_pixel_size)) / 2.0f;
 		dest.w = sys_width * current_pixel_size;
 		dest.h = sys_height * current_pixel_size;
 		dest.x = (win_width - dest.w) / 2;

--- a/32blit/engine/profiler.cpp
+++ b/32blit/engine/profiler.cpp
@@ -190,7 +190,7 @@ void Profiler::display_probe_overlay(uint8_t uPage)
 
 		// display header
 		screen.pen = Pen(255, 255, 255, m_uAlpha);
-		sprintf(buffer, "%" PRIu32 " (%u/%u)", m_uGraphTimeUs, uPage, uMaxPage);
+		snprintf(buffer, 64, "%" PRIu32 " (%u/%u)", m_uGraphTimeUs, uPage, uMaxPage);
 		screen.text(buffer, minimal_font, Point(m_uBorder, m_uBorder));
 
 		// labels
@@ -240,7 +240,7 @@ void Profiler::display_probe_overlay(uint8_t uPage)
 					screen.pen = Pen(255, 255, 255, m_uAlpha);
 					if(m_graphElements[uM].bDisplayLabel)
 					{
-						sprintf(buffer, "%" PRIu32, metrics[uM]);
+						snprintf(buffer, 64, "%" PRIu32, metrics[uM]);
 						screen.text(buffer, minimal_font, Rect(uMetricX, uY, uMetricWidth, m_uRowHeight), true, TextAlign::center_v);
 						uMetricX+=uMetricWidth;
 					}

--- a/32blit/engine/profiler.cpp
+++ b/32blit/engine/profiler.cpp
@@ -52,7 +52,8 @@ const char *Profiler::g_pszMetricNames[4]= {"Min", "Cur", "Avg", "Max"};
 
 Profiler::Profiler(uint32_t uRunningAverageSize, uint32_t uRunningAverageSpan ) : m_uGraphTimeUs(20000), m_uRunningAverageSize(uRunningAverageSize), m_uRunningAverageSpan(uRunningAverageSpan), m_uRowHeight(10), m_uBorder(5), m_uHeaderSize(15), m_uAlpha(160)
 {
-	api.enable_us_timer();
+  if(api.enable_us_timer)
+	  api.enable_us_timer();
 
 	// default to lowres
 	set_display_size(160, 120);
@@ -110,15 +111,14 @@ void Profiler::log_probes()
 	debugf("\n\r");
 }
 
-uint32_t Profiler::get_probe_count()
+size_t Profiler::get_probe_count()
 {
 	return m_probes.size();
 }
 
-uint32_t Profiler::get_page_count()
+size_t Profiler::get_page_count()
 {
-	uint32_t uPages = (m_probes.size() + m_uRows - 1) / m_uRows;
-	return uPages;
+	return (m_probes.size() + m_uRows - 1) / m_uRows;
 }
 
 void Profiler::set_display_size(uint16_t uWidth, uint32_t uHeight)
@@ -184,7 +184,7 @@ void Profiler::display_probe_overlay(uint8_t uPage)
 		uint16_t uNameX = m_uBorder;
 		uint16_t uMetricX  = uNameX + uNameWidth;
 
-		uint16_t uMaxPage = get_page_count();
+		auto uMaxPage = uint8_t(get_page_count());
 		if(uPage > uMaxPage)
 			uPage = uMaxPage;
 

--- a/32blit/engine/profiler.hpp
+++ b/32blit/engine/profiler.hpp
@@ -179,8 +179,8 @@ public:
 
 	void					log_probes();
 
-	uint32_t			get_probe_count();
-	uint32_t			get_page_count();
+	size_t        get_probe_count();
+	size_t        get_page_count();
 
 	void 					set_display_size(uint16_t uWidth, uint32_t uHeight);
 	void					set_graph_time(uint32_t uTimeUs);

--- a/32blit/graphics/text.cpp
+++ b/32blit/graphics/text.cpp
@@ -165,7 +165,7 @@ namespace blit {
         if (end == std::string::npos)
           end = message.length();
 
-        line_len = (end - char_off) * font.char_w;
+        line_len = int(end - char_off) * font.char_w;
         char_off = end;
       }
     }

--- a/32blit/types/map.cpp
+++ b/32blit/types/map.cpp
@@ -35,7 +35,7 @@ namespace blit {
     uint16_t mipmap_index = floorf(mipmap);
     uint8_t blend = (mipmap - floorf(mipmap)) * 255;
 
-    mipmap_index = mipmap_index >= (int)sprites->mipmaps.size() ? sprites->mipmaps.size() - 1 : mipmap_index;
+    mipmap_index = mipmap_index >= sprites->mipmaps.size() ? uint16_t(sprites->mipmaps.size() - 1) : mipmap_index;
     mipmap_index = mipmap_index < 0 ? 0 : mipmap_index;
 
     dest->alpha = 255;

--- a/examples/hardware-test/hardware-test.cpp
+++ b/examples/hardware-test/hardware-test.cpp
@@ -96,7 +96,7 @@ void render(uint32_t time) {
     ));
 
     if(joystick_history.size() > 256){
-        int trim = joystick_history.size() - 256;
+        auto trim = joystick_history.size() - 256;
         joystick_history.erase(joystick_history.begin(), joystick_history.begin() + trim);
     }
 

--- a/examples/matrix-test/matrix-test.cpp
+++ b/examples/matrix-test/matrix-test.cpp
@@ -28,7 +28,7 @@ float deg2rad(float a) {
 }
 
 void draw(std::array<Vec2, 4> vecs, std::vector<Mat3> trs) {
-  int s = (150) / trs.size();
+  auto s = uint8_t(150 / trs.size());
   Pen p(255, 255, 255, 32);
 
   auto o = Vec2(80, 60);
@@ -57,7 +57,7 @@ void draw(std::array<Vec2, 4> vecs, std::vector<Mat3> trs) {
   }
 
   // then apply the translations in reverse and ensure we end up back at the start
-  for (int i = trs.size() - 1; i >= 0; i--) {
+  for (auto i = trs.size() - 1; i >= 0; i--) {
     Mat3 tr = trs[i];
 
     tr.inverse();

--- a/examples/platformer/platformer.cpp
+++ b/examples/platformer/platformer.cpp
@@ -74,7 +74,7 @@ struct Player {
   }
 
   uint8_t animation_sprite_index(uint8_t animation) {
-    uint8_t animation_length = animations[animation].size();
+    auto animation_length = animations[animation].size();
     return animations[animation][uint32_t(animation_frame) % animation_length];
   }
 

--- a/examples/profiler-test/profiler-test.cpp
+++ b/examples/profiler-test/profiler-test.cpp
@@ -34,7 +34,7 @@ ProfilerProbe *g_pUpdateProbe;
 uint32_t g_uSize = 2;
 uint32_t g_uSizeMax	= SCREEN_HEIGHT-1;
 uint32_t g_uSizeMin	= 2;
-uint32_t g_uSizeChange = 1;
+int g_uSizeChange = 1;
 
 bool g_bGraphEnabled   = true;
 bool g_bLabelsEnabled  = true;

--- a/examples/serial-debug/serial-debug.cpp
+++ b/examples/serial-debug/serial-debug.cpp
@@ -35,7 +35,7 @@ void render(uint32_t time) {
 
   screen.text("Time:", minimal_font, Point(COL1, ROW1));
 
-  sprintf(text_buf, "%" PRIu32, time);
+  snprintf(text_buf, 100, "%" PRIu32, time);
   screen.text(text_buf, minimal_font, Point(COL2, ROW1));
 
   blit::debugf("Hello from 32blit time = %lu\n\r", time);

--- a/examples/tilemap-test/tilemap-test.cpp
+++ b/examples/tilemap-test/tilemap-test.cpp
@@ -210,7 +210,7 @@ using namespace blit;
 
 
     screen.alpha = 255;
-    for (auto i = 0; i < effect_names.size(); i++) {
+    for (auto i = 0u; i < effect_names.size(); i++) {
       if (effect == i)
         screen.pen = Pen(255, 255, 255);
       else
@@ -248,12 +248,14 @@ using namespace blit;
 
   uint32_t last_buttons = 0;
   void update(uint32_t time) {
+    auto last_effect = uint8_t(effect_names.size() - 1);
+
     if (buttons != last_buttons) {
       if (pressed(Button::DPAD_DOWN)) {
-        effect = effect == effect_names.size() - 1 ? 0 : effect + 1;
+        effect = effect == last_effect ? 0 : effect + 1;
       }
       if (pressed(Button::DPAD_UP)) {
-        effect = effect == 0 ? effect_names.size() - 1 : effect - 1;
+        effect = effect == 0 ? last_effect : effect - 1;
       }
     }
 

--- a/examples/tilemap-test/tilemap-test.cpp
+++ b/examples/tilemap-test/tilemap-test.cpp
@@ -168,7 +168,7 @@ using namespace blit;
     return transform;
   };
 
-  std::function<Mat3(uint8_t)> effect_callbacks[]{
+  const std::function<Mat3(uint8_t)> effect_callbacks[]{
     zoom,
     dream,
     ripple,
@@ -180,7 +180,7 @@ using namespace blit;
     shake
   };
 
-  std::vector<std::string> effect_names = {
+  const std::array<std::string, 9> effect_names{
     "zoom",
     "dream",
     "ripple",

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -248,7 +248,7 @@ void mass_storage_overlay(uint32_t time)
 
   screen.pen = Pen(255, 255, 255);
   char buffer[128];
-  sprintf(buffer, "Mass Storage mode (%s)", g_usbManager.GetStateName());
+  snprintf(buffer, 128, "Mass Storage mode (%s)", g_usbManager.GetStateName());
   screen.text(buffer, minimal_font, Rect(Point(0), screen.bounds), true, TextAlign::center_center);
 
   if(uActivityAnim)


### PR DESCRIPTION
This fixes most of the non-"converting X to Y" warnings in VS. (With [this slightly nasty patch](https://github.com/Daft-Freak/32blit-beta/commit/98b07a02e62509190030230f3f10f65a3e358b28), there are two in the tool).