### PR TITLE
Defaults fix

### DIFF
--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -15,7 +15,7 @@ namespace blit {
    * @param duration Duration of the timer in milliseconds.
    * @param loops Number of times the timer should repeat, -1 = forever.
    */
-  void Timer::init(TimerCallback callback, uint32_t duration, int32_t loops = -1) {
+  void Timer::init(TimerCallback callback, uint32_t duration, int32_t loops) {
     this->callback = callback;
     this->duration = duration;
     this->loops = loops;

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -23,7 +23,7 @@ namespace blit {
     };
     uint8_t state = STOPPED;
 
-    void init(TimerCallback callback, uint32_t duration, int32_t loops);
+    void init(TimerCallback callback, uint32_t duration, int32_t loops = -1);
     void start();
     void stop();
 

--- a/32blit/engine/tweening.cpp
+++ b/32blit/engine/tweening.cpp
@@ -19,7 +19,7 @@ namespace blit {
    * @param duration Duration of the tween in milliseconds.
    * @param loops Number of times the tween should repeat, -1 = forever.
    */
-  void Tween::init(TweenFunction function, float from, float to, uint32_t duration, int32_t loops = -1) {
+  void Tween::init(TweenFunction function, float from, float to, uint32_t duration, int32_t loops) {
     this->loops = loops;
     this->function = function;
     this->from = from;

--- a/32blit/engine/tweening.hpp
+++ b/32blit/engine/tweening.hpp
@@ -27,7 +27,7 @@ namespace blit {
     };
     uint8_t state = STOPPED;
 
-    void init(TweenFunction function, float start, float end, uint32_t duration, int32_t loops);
+    void init(TweenFunction function, float start, float end, uint32_t duration, int32_t loops = -1);
     void start();
     void stop();
 

--- a/32blit/types/map.cpp
+++ b/32blit/types/map.cpp
@@ -47,7 +47,7 @@ namespace blit {
     }
   }
 
-  void MapLayer::texture_span(Surface *dest, Point s, uint16_t c, Surface *sprites, Vec2 swc, Vec2 ewc, uint8_t mipmap_index = 0) {
+  void MapLayer::texture_span(Surface *dest, Point s, uint16_t c, Surface *sprites, Vec2 swc, Vec2 ewc, uint8_t mipmap_index) {
     BlitBlendFunc bbf = dest->bbf;
 
     int world_size = map->bounds.w * 8;

--- a/32blit/types/map.hpp
+++ b/32blit/types/map.hpp
@@ -25,7 +25,7 @@ namespace blit {
     uint8_t transform_at(blit::Point p);
 
     void mipmap_texture_span(blit::Surface *dest, blit::Point s, uint16_t c, blit::Surface *sprites, Vec2 swc, Vec2 ewc);
-    void texture_span(blit::Surface *dest, blit::Point s, uint16_t c, blit::Surface *sprites, Vec2 swc, Vec2 ewc, uint8_t mipmap_index);
+    void texture_span(blit::Surface *dest, blit::Point s, uint16_t c, blit::Surface *sprites, Vec2 swc, Vec2 ewc, uint8_t mipmap_index = 0);
   };
 
   struct Map {


### PR DESCRIPTION
Some functions in 32blit have defaults declared in their `.cpp` instead of `.hpp`, which pretty much renders them invisible.

First noticed it playing with Tweens (which are, by the way, awesome), then found other instances, in Timers and Maps.