### PR TITLE
Free metadata before launching games

### DIFF
--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -156,8 +156,9 @@ int main(void)
   blit_init();
 
 #if (INITIALISE_QSPI==1)
-  if((persist.reset_target == prtGame) && HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port,  BUTTON_MENU_Pin) && !persist.reset_error)
-    blit_switch_execution(persist.last_game_offset);
+  // don't switch to game if it crashed, or menu is held
+  if(persist.reset_target == prtGame && (!HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port,  BUTTON_MENU_Pin) || persist.reset_error))
+    persist.reset_target = prtFirmware;
 #endif
 
   // add CDC handler to reset device on receiving "_RST" and "SWIT"

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -239,6 +239,12 @@ void load_current_game_metadata() {
   }
 }
 
+void launch_game(uint32_t address) {
+  selected_game_metadata.free_surfaces();
+
+  blit_switch_execution(address);
+}
+
 void mass_storage_overlay(uint32_t time)
 {
   static uint8_t uActivityAnim = 0;
@@ -299,14 +305,14 @@ void init() {
 
   // auto-launch
   if(persist.reset_target == prtGame)
-    blit_switch_execution(persist.last_game_offset);
+    launch_game(persist.last_game_offset);
 
   // error reset handling
   if(persist.reset_error) {
     dialog.show("Oops!", "Restart game?", [](bool yes){
 
       if(yes)
-        blit_switch_execution(persist.last_game_offset);
+        launch_game(persist.last_game_offset);
 
       persist.reset_error = false;
     });
@@ -505,7 +511,7 @@ void update(uint32_t time) {
         offset = flash_from_sd_to_qspi_flash(game.filename.c_str()); // sd
 
       if(offset != 0xFFFFFFFF)
-        blit_switch_execution(offset);
+        launch_game(offset);
     }
 
     // delete current game
@@ -951,7 +957,7 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
                     if(result != srError)
                     {
                       result = srFinish;
-                      blit_switch_execution(flash_start_offset);
+                      launch_game(flash_start_offset);
                     }
                     else
                       state = stFlashFile;

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -297,14 +297,16 @@ void init() {
 
   g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'E', 'R', 'S', 'E'>::value, &cdc_erase_handler);
 
+  // auto-launch
+  if(persist.reset_target == prtGame)
+    blit_switch_execution(persist.last_game_offset);
+
   // error reset handling
   if(persist.reset_error) {
     dialog.show("Oops!", "Restart game?", [](bool yes){
 
       if(yes)
         blit_switch_execution(persist.last_game_offset);
-      else
-        persist.reset_target = prtFirmware;
 
       persist.reset_error = false;
     });


### PR DESCRIPTION
Free up some memory as API calls still allocate from the firmware heap. (I noticed that opening too many files at once would cause a crash, still doesn't work as there's a limit of 2 in fatfs but returns an error instead of crashing)