### PR TITLE
Unbreak non-framework macOS builds

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -148,7 +148,7 @@ function(blit_executable NAME SOURCES)
 		)
 	endif()
 
-	if(APPLE)
+	if(APPLE AND SDL2_LIBRARIES MATCHES "\.framework$")
 	    # install the SDL frameworks
 		install(DIRECTORY ${SDL2_LIBRARIES} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
 		install(DIRECTORY ${SDL2_IMAGE_LIBRARY} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")


### PR DESCRIPTION
Should build, won't package the libraries though. (That would need something like https://github.com/Daft-Freak/32blit-beta/commit/647d0fe1cd4eac77bfe3709305d186ae089b5fb8, which ended up [failing with permission errors when I tried it](https://github.com/Daft-Freak/32blit-beta/runs/1412024010?check_suite_focus=true) )