### PR TITLE
Fix HOME+reset and crash reset

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -366,6 +366,12 @@ void blit_init() {
       persist.last_game_offset = 0;
     }
 
+#if (INITIALISE_QSPI==1)
+    // don't switch to game if it crashed, or menu is held
+    if(persist.reset_target == prtGame && (!HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port,  BUTTON_MENU_Pin) || persist.reset_error))
+      persist.reset_target = prtFirmware;
+#endif
+
     init_api_shared();
 
     blit_update_volume();

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -155,12 +155,6 @@ int main(void)
 
   blit_init();
 
-#if (INITIALISE_QSPI==1)
-  // don't switch to game if it crashed, or menu is held
-  if(persist.reset_target == prtGame && (!HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port,  BUTTON_MENU_Pin) || persist.reset_error))
-    persist.reset_target = prtFirmware;
-#endif
-
   // add CDC handler to reset device on receiving "_RST" and "SWIT"
 	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'_', 'R', 'S', 'T'>::value, &g_resetHandler);
 	g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'S', 'W', 'I', 'T'>::value, &g_resetHandler);


### PR DESCRIPTION
Broken in 71195ae as that check happens after the firmware has done the switch.

(Though somehow still seemed to work sometimes...)