### PR TITLE
Make sdl2-config.cmake auto-fetch libraries

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -82,7 +82,6 @@ jobs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        ci/install_sdl_vs.sh
         python -m pip install 32blit
 
     - name: MinGW deps

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -81,12 +81,10 @@ target_link_libraries(BlitHalSDL PUBLIC BlitEngine ${SDL2_LIBRARIES} ${SDL2_IMAG
 
 # copy SDL2.dll to build/install dir for windows users
 if(SDL2_DLL)
-	configure_file(${SDL2_DLL} ${CMAKE_BINARY_DIR}/SDL2.dll COPYONLY)
 	install(FILES ${SDL2_DLL} DESTINATION bin)
 endif()
 
 if(SDL2_IMAGE_DLL)
-	configure_file(${SDL2_IMAGE_DLL} ${CMAKE_BINARY_DIR}/SDL2_image.dll COPYONLY)
 	install(FILES ${SDL2_IMAGE_DLL} DESTINATION bin)
 endif()
 
@@ -140,6 +138,15 @@ function(blit_executable NAME SOURCES)
 	else()
   		target_link_libraries(${NAME} -Wl,--whole-archive BlitHalSDL -Wl,--no-whole-archive)
 	endif()
+
+    # windows dll fun
+    if(SDL2_DLL)
+        configure_file(${SDL2_DLL} ${CMAKE_CURRENT_BINARY_DIR}/SDL2.dll COPYONLY)
+    endif()
+
+    if(SDL2_IMAGE_DLL)
+        configure_file(${SDL2_IMAGE_DLL} ${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.dll COPYONLY)
+    endif()
 
 	if(EMSCRIPTEN)
 		set_target_properties(${NAME} PROPERTIES

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -1,6 +1,6 @@
 function(fetch_sdl2_library directory url filename hash)
     if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/${filename})
-        message(STATUS "Downloading ${url}")
+        message(STATUS "Downloading ${filename}")
         file(DOWNLOAD ${url}${filename} ${CMAKE_CURRENT_LIST_DIR}/${filename}
             SHOW_PROGRESS
             TIMEOUT 120
@@ -12,13 +12,13 @@ function(fetch_sdl2_library directory url filename hash)
         # tar -xf should work on Windows 10 build 17063 or later (Dec 2017)
         execute_process(COMMAND tar -xf ${filename}
                         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-        # in future we might be able to use: 
-        # file(ARCHIVE_EXTRACT INPUT ${filename})
-        file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/include
-            DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
-        file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/lib
-            DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
     endif()
+    # in future we might be able to use:
+    # file(ARCHIVE_EXTRACT INPUT ${filename})
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/include
+        DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/lib
+        DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
 endfunction(fetch_sdl2_library)
 
 
@@ -28,7 +28,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include)
         SDL2-2.0.12
         https://www.libsdl.org/release/
         SDL2-devel-2.0.12-VC.zip
-        bd40f726fbcb1430709eaa671ec6f6b5b36e2e4a
+        6839b6ec345ef754a6585ab24f04e125e88c3392
     )
 
     fetch_sdl2_library(

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -1,3 +1,45 @@
+function(fetch_sdl2_library directory url filename hash)
+    if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/${filename})
+        message(STATUS "Downloading ${url}")
+        file(DOWNLOAD ${url}${filename} ${CMAKE_CURRENT_LIST_DIR}/${filename}
+            SHOW_PROGRESS
+            TIMEOUT 120
+            EXPECTED_HASH SHA1=${hash}
+            TLS_VERIFY ON)
+        message(STATUS "Extracting ${filename}")
+    endif()
+    if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/${directory})
+        # tar -xf should work on Windows 10 build 17063 or later (Dec 2017)
+        execute_process(COMMAND tar -xf ${filename}
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+        # in future we might be able to use: 
+        # file(ARCHIVE_EXTRACT INPUT ${filename})
+        file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/include
+            DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
+        file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/lib
+            DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
+    endif()
+endfunction(fetch_sdl2_library)
+
+
+if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include)
+
+    fetch_sdl2_library(
+        SDL2-2.0.12
+        https://www.libsdl.org/release/
+        SDL2-devel-2.0.12-VC.zip
+        bd40f726fbcb1430709eaa671ec6f6b5b36e2e4a
+    )
+
+    fetch_sdl2_library(
+        SDL2_image-2.0.5
+        https://www.libsdl.org/projects/SDL_image/release/
+        SDL2_image-devel-2.0.5-VC.zip
+        137f86474691f4e12e76e07d58d5920c8d844d5b
+    )
+
+endif()
+
 set(SDL2_INCLUDE_DIRS "${SDL2_DIR}/include")
 
 if(CMAKE_GENERATOR_PLATFORM)


### PR DESCRIPTION
Rather than assuming the user has read the docs, this update to `sdl2-config.cmake` will auto-fetch the required SDL2 libraries for a Visual Studio CMake build when first configured.

If the user already has an `include` directory, it will do nothing.

May not be totally robust and catch all edge cases, and also does things outside of the build dir (which is potentially really bad) so:

TODO: suggestions for making this a better CMake citizen.