### PR TITLE
Fix silly broken hack to get sprite size

### DIFF
--- a/examples/palette-swap/palette-swap.cpp
+++ b/examples/palette-swap/palette-swap.cpp
@@ -6,12 +6,6 @@
 
 using namespace blit;
 
-Size boar_ship_size(boar_ship[10], boar_ship[12]);
-
-/*uint8_t __ss[64 * 64];
-surface ss((uint8_t *)__ss, boar_ship_size, pixel_format::P);
-spritesheet ss_boar_ship(ss, 8, 8);*/
-
 Pen alternate_palettes[NUM_PALETTES][5] = {
     {
         Pen(87, 37, 59),
@@ -53,7 +47,6 @@ Point position[NUM_PALETTES] = {
 void init() {
   set_screen_mode(ScreenMode::hires);
 
-  //ss_boar_ship.s.load_from_packed(boar_ship);
   screen.sprites = SpriteSheet::load(boar_ship);
 }
 
@@ -78,8 +71,8 @@ void all_ships_at_once_demo(uint32_t time) {
     pos.y += sinf(time / 500.0f + p) * 10.0f;
 
     screen.stretch_blit(screen.sprites,
-        Rect(0, 0, boar_ship_size.w, boar_ship_size.h),
-        Rect(pos.x, pos.y, boar_ship_size.w * 2, boar_ship_size.h * 2)
+        Rect(0, 0, screen.sprites->bounds.w, screen.sprites->bounds.h),
+        Rect(pos.x, pos.y, screen.sprites->bounds.w * 2, screen.sprites->bounds.h * 2)
     );
   }
 
@@ -103,11 +96,11 @@ void single_ship_cycling_demo(uint32_t time) {
   }
 
   screen.stretch_blit(screen.sprites,
-    Rect(0, 0, boar_ship_size.w, boar_ship_size.h),
+    Rect(0, 0, screen.sprites->bounds.w, screen.sprites->bounds.h),
     Rect(
-        (screen.bounds.w - boar_ship_size.w * 4) / 2,
-        5 + (screen.bounds.h - ((SWATCH_SIZE + 10) * 2) - boar_ship_size.h * 4) / 2,
-        boar_ship_size.w * 4, boar_ship_size.h * 4
+        (screen.bounds.w - screen.sprites->bounds.w * 4) / 2,
+        5 + (screen.bounds.h - ((SWATCH_SIZE + 10) * 2) - screen.sprites->bounds.h * 4) / 2,
+        screen.sprites->bounds.w * 4, screen.sprites->bounds.h * 4
     )
   );
 


### PR DESCRIPTION
For who knows what reason I'd opted to pick the width/height of the spritesheet out of the raw packed sprite buffer, rather than use `screen.sprites->bounds`. That- as you might expect- eventually broke. This fix brings back our lovely ships by giving them a non-zero width.