### PR TITLE
Fix time going negative in the MP3 example

### DIFF
--- a/32blit/audio/mp3-stream.cpp
+++ b/32blit/audio/mp3-stream.cpp
@@ -95,7 +95,7 @@ namespace blit {
     }    
   }
 
-  int MP3Stream::get_current_sample() const {
+  unsigned int MP3Stream::get_current_sample() const {
     return buffered_samples + blit::channels[channel].wave_buf_pos;
   }
 

--- a/32blit/audio/mp3-stream.hpp
+++ b/32blit/audio/mp3-stream.hpp
@@ -20,7 +20,7 @@ namespace blit {
 
     void update();
 
-    int get_current_sample() const;
+    unsigned int get_current_sample() const;
     int get_duration_ms() const;
 
   private:
@@ -52,7 +52,7 @@ namespace blit {
     int data_size[2]{};
     int cur_audio_buf = 0;
 
-    int buffered_samples = 0;
+    unsigned int buffered_samples = 0;
     int duration_ms = 0;
   };
 }

--- a/site/examples/index.html
+++ b/site/examples/index.html
@@ -45,7 +45,7 @@
         <script type="text/javascript">
             const examples = [
                 "audio-test", "audio-wave", "doom-fire", "fizzlefade", "flight", "geometry", "hardware-test", "logo", 
-                "matrix-test", "palette-cycle", "palette-swap", "particle", "platformer", "profiler-test", "raycaster", 
+                "matrix-test", "mp3", "palette-cycle", "palette-swap", "particle", "platformer", "profiler-test", "raycaster", 
                 "rotozoom", "saves", "scrolly-tile", "serial-debug", "shmup", "sprite-test", "text", "tilemap-test",
                 "tilt", "timer-test", "tunnel", "tween-demo", "tween-test", "voxel"
             ];


### PR DESCRIPTION
Switches the sample position to unsigned to avoid `(stream.get_current_sample() * 1000) / 22050` wrapping to negative at the `* 1000`.