### PR TITLE
Improve stdlibs download/unzip

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -48,12 +48,28 @@ set(STDLIB_PATH ${CMAKE_CURRENT_LIST_DIR}/stdlib)
 set(STDLIB_URL https://get.pimoroni.com/stdlibs.zip)
 set(STDLIB_HASH "SHA256=867eb82d2329c962a5aa389f3b5a4a2efd6d75e5c7d464c92ed7b595f76eb90f")
 
-if(NOT EXISTS ${STDLIB_PATH}/stdlibs.zip)
-    file(DOWNLOAD ${STDLIB_URL} ${STDLIB_PATH}/stdlibs.zip EXPECTED_HASH ${STDLIB_HASH} SHOW_PROGRESS)
+message("Downloading stdlibs...")
+file(DOWNLOAD ${STDLIB_URL} ${STDLIB_PATH}/stdlibs.zip EXPECTED_HASH ${STDLIB_HASH} SHOW_PROGRESS STATUS DOWNLOAD_STATUS)
+
+list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+
+# check for non-0 status
+if(${STATUS_CODE})
+    list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+    message(FATAL_ERROR "Failed to download stdlibs: ${ERROR_MESSAGE}\n")
+endif()
+
+if(NOT EXISTS ${STDLIB_PATH}/pic)
+    message("Extracting stdlibs...")
 
     # CMake 3.18
     #file(ARCHIVE_EXTRACT INPUT ${STDLIB_PATH}/stdlibs.zip DESTINATION ${STDLIB_PATH})
-    execute_process(COMMAND unzip -u ${STDLIB_PATH}/stdlibs.zip -d ${STDLIB_PATH})
+
+    execute_process(COMMAND unzip -u ${STDLIB_PATH}/stdlibs.zip -d ${STDLIB_PATH} RESULT_VARIABLE UNZIP_STATUS)
+
+    if(NOT ${UNZIP_STATUS} EQUAL 0)
+        message(FATAL_ERROR "Failed to extract stdlibs: ${UNZIP_STATUS}\n")
+    endif()
 endif()
 
 set(PIC_STDLIBS "-nodefaultlibs -L ${STDLIB_PATH}/pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -12,7 +12,7 @@ These instructions cover building 32blit on Linux.
 First install the required tools:
 
 ```
-sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev
+sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev unzip
 
 pip3 install 32blit
 ```


### PR DESCRIPTION
Check that the download/unzip succeeded, always do the download (it exits early if the file exists with the expected hash) and move the EXISTS check to the extracted files. Still not the most helpful message if `unzip` isn't installed. "No such file or directory"