### PR TITLE
Patch cmake to make moar noise

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -116,6 +116,7 @@ if(DEFINED VIDEO_CAPTURE AND VIDEO_CAPTURE)
 endif()
 
 function(blit_executable NAME SOURCES)
+	message(STATUS "Processing ${NAME}")
 	add_executable(${NAME} MACOSX_BUNDLE ${SOURCES} ${ARGN})
 
 	install(TARGETS ${NAME}

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -15,6 +15,7 @@ function(blit_executable_common NAME)
 endfunction()
 
 function(blit_executable NAME SOURCES)
+	message(STATUS "Processing ${NAME}")
 	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
 	add_executable(${NAME} ${USER_STARTUP} ${SOURCES} ${ARGN})
 

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -44,11 +44,24 @@ set(CMAKE_CXX_FLAGS_DEBUG_INIT "-g -Og")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nosys.specs -Wl,--gc-sections,--no-wchar-size-warning")
 
 # stdlibs
+set(STDLIB_HASHTYPE "SHA256")
 set(STDLIB_PATH ${CMAKE_CURRENT_LIST_DIR}/stdlib)
 set(STDLIB_URL https://get.pimoroni.com/stdlibs.zip)
-set(STDLIB_HASH "SHA256=867eb82d2329c962a5aa389f3b5a4a2efd6d75e5c7d464c92ed7b595f76eb90f")
+set(STDLIB_HASH "${STDLIB_HASHTYPE}=867eb82d2329c962a5aa389f3b5a4a2efd6d75e5c7d464c92ed7b595f76eb90f")
 
-message("Downloading stdlibs...")
+find_program(UNZIP NAMES unzip)
+if(NOT UNZIP)
+    message(FATAL_ERROR "Failed to find required program: \"unzip\"\n(maybe you need to \"apt install unzip\")\n")
+endif()
+
+# file() is great, but it doesn't tell the user what it's downloading
+if(EXISTS ${STDLIB_PATH}/stdlibs.zip)
+    file(${STDLIB_HASHTYPE} ${STDLIB_PATH}/stdlibs.zip FOUND_HASH)
+endif()
+if(NOT EXISTS ${STDLIB_PATH}/stdlibs.zip OR NOT STDLIB_HASH STREQUAL "${STDLIB_HASHTYPE}=${FOUND_HASH}")
+    message("Downloading stdlibs...")
+endif()
+
 file(DOWNLOAD ${STDLIB_URL} ${STDLIB_PATH}/stdlibs.zip EXPECTED_HASH ${STDLIB_HASH} SHOW_PROGRESS STATUS DOWNLOAD_STATUS)
 
 list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
@@ -65,7 +78,7 @@ if(NOT EXISTS ${STDLIB_PATH}/pic)
     # CMake 3.18
     #file(ARCHIVE_EXTRACT INPUT ${STDLIB_PATH}/stdlibs.zip DESTINATION ${STDLIB_PATH})
 
-    execute_process(COMMAND unzip -u ${STDLIB_PATH}/stdlibs.zip -d ${STDLIB_PATH} RESULT_VARIABLE UNZIP_STATUS)
+    execute_process(COMMAND ${UNZIP} -u ${STDLIB_PATH}/stdlibs.zip -d ${STDLIB_PATH} RESULT_VARIABLE UNZIP_STATUS)
 
     if(NOT ${UNZIP_STATUS} EQUAL 0)
         message(FATAL_ERROR "Failed to extract stdlibs: ${UNZIP_STATUS}\n")


### PR DESCRIPTION
Adds a status output to the SDL and STM32 executables, since I just notice CMake had a long, quiet period of contemplating during which it wasn't obvious what on earth it was doing. This is just a gentle affirmation to users that Something Is Happening.

I have also tweaked the `stdlib.zip` download message, frustratingly recreating some of the logic that `file` uses to avoid spamming the message repeatedly during the build process.