### PR TITLE
Avoid passing basic types by reference

### DIFF
--- a/32blit/graphics/blend.cpp
+++ b/32blit/graphics/blend.cpp
@@ -14,19 +14,19 @@
 
 namespace blit {
 
-  __attribute__((always_inline)) inline uint32_t alpha(const uint32_t &a1, const uint32_t &a2) {
+  __attribute__((always_inline)) inline uint32_t alpha(uint32_t a1, uint32_t a2) {
     return ((a1 + 1) * (a2 + 1)) >> 8;
   }
 
-  __attribute__((always_inline)) inline uint32_t alpha(const uint32_t &a1, const uint32_t &a2, const uint32_t &a3) {
+  __attribute__((always_inline)) inline uint32_t alpha(uint32_t a1, uint32_t a2, uint32_t a3) {
     return ((a1 + 1) * (a2 + 1) * (a3 + 1)) >> 16;
   }
 
-  __attribute__((always_inline)) inline uint8_t blend(const uint8_t &s, const uint8_t &d, const uint8_t &a) {
+  __attribute__((always_inline)) inline uint8_t blend(uint8_t s, uint8_t d, uint8_t a) {
     return d + ((a * (s - d) + 127) >> 8);    
   }
 
-  __attribute__((always_inline)) inline void blend_rgba_rgb(const Pen *s, uint8_t *d, const uint8_t &a, uint32_t c) {      
+  __attribute__((always_inline)) inline void blend_rgba_rgb(const Pen *s, uint8_t *d, uint8_t a, uint32_t c) {      
     if (c == 1) { 
       // fast case for single pixel draw
       *d = blend(s->r, *d, a); d++;

--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -72,7 +72,7 @@ namespace blit {
    * \param[in] index Index of the sprite in the sheet
    * \return `rect` sprite x/y location (always a multiple of 8) and size (always 8x8)
    */
-  Rect SpriteSheet::sprite_bounds(const uint16_t &index) {
+  Rect SpriteSheet::sprite_bounds(uint16_t index) {
     return Rect((index % cols) * 8, (index / cols) * 8, 8, 8);    
   }
 
@@ -112,7 +112,7 @@ namespace blit {
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] transform to apply
    */
-  void Surface::sprite(const uint16_t &sprite, const Point &position, const uint8_t &transform) {
+  void Surface::sprite(uint16_t sprite, const Point &position, uint8_t transform) {
     blit_sprite(
       sprites->sprite_bounds(sprite), 
       position, 
@@ -126,7 +126,7 @@ namespace blit {
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Point &sprite, const Point &position, const uint8_t &transform) {
+  void Surface::sprite(const Point &sprite, const Point &position, uint8_t transform) {
     blit_sprite(
       sprites->sprite_bounds(sprite),
       position,
@@ -140,7 +140,7 @@ namespace blit {
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Rect &sprite, const Point &position, const uint8_t &transform) {        
+  void Surface::sprite(const Rect &sprite, const Point &position, uint8_t transform) {        
     blit_sprite(
       sprites->sprite_bounds(sprite),
       position,
@@ -157,7 +157,7 @@ namespace blit {
    * \param[in] origin `point` around which to transform the sprite
    * \param[in] transform to apply
    */
-  void Surface::sprite(const uint16_t &sprite, const Point &position, const Point &origin, const uint8_t &transform) {
+  void Surface::sprite(uint16_t sprite, const Point &position, const Point &origin, uint8_t transform) {
     Surface::sprite(sprite, position - origin, transform);
   }
 
@@ -169,7 +169,7 @@ namespace blit {
    * \param[in] origin `point` around which to transform the sprite
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Point &sprite, const Point &position, const Point &origin, const uint8_t &transform) {
+  void Surface::sprite(const Point &sprite, const Point &position, const Point &origin, uint8_t transform) {
     Surface::sprite(sprite, position - origin, transform);
   }
 
@@ -181,7 +181,7 @@ namespace blit {
    * \param[in] origin `point` around which to transform the sprite
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Rect &sprite, const Point &position, const Point &origin, const uint8_t &transform) {
+  void Surface::sprite(const Rect &sprite, const Point &position, const Point &origin, uint8_t transform) {
     Surface::sprite(sprite, position - origin, transform);
   }
 
@@ -196,7 +196,7 @@ namespace blit {
    * \param[in] scale `vec2` x/y scale factor
    * \param[in] transform to apply
    */
-  void Surface::sprite(const uint16_t &sprite, const Point &position, const Point &origin, const Vec2 &scale, const uint8_t &transform) {
+  void Surface::sprite(uint16_t sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform) {
     Rect dest_rect(
       roundf(position.x - float(origin.x * scale.x)),
       roundf(position.y - float(origin.y * scale.y)),
@@ -219,7 +219,7 @@ namespace blit {
    * \param[in] scale `vec2` x/y scale factor
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Point &sprite, const Point &position, const Point &origin, const Vec2 &scale, const uint8_t &transform) {
+  void Surface::sprite(const Point &sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform) {
     Rect dest_rect(
       roundf(position.x - float(origin.x * scale.x)),
       roundf(position.y - float(origin.y * scale.y)),
@@ -242,7 +242,7 @@ namespace blit {
    * \param[in] scale `vec2` x/y scale factor
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Rect &sprite, const Point &position, const Point &origin, const Vec2 &scale, const uint8_t &transform) {
+  void Surface::sprite(const Rect &sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform) {
     Rect dest_rect(
       roundf(position.x - float(origin.x * scale.x)),
       roundf(position.y - float(origin.y * scale.y)),
@@ -265,7 +265,7 @@ namespace blit {
    * \param[in] scale `float` x/y scale factor
    * \param[in] transform to apply
    */
-  void Surface::sprite(const uint16_t &sprite, const Point &position, const Point &origin, const float &scale, const uint8_t &transform) {
+  void Surface::sprite(uint16_t sprite, const Point &position, const Point &origin, float scale, uint8_t transform) {
     Surface::sprite(sprite, position, origin, Vec2(scale, scale), transform);
   }
 
@@ -278,7 +278,7 @@ namespace blit {
    * \param[in] scale `float` x/y scale factor
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Point &sprite, const Point &position, const Point &origin, const float &scale, const uint8_t &transform) {
+  void Surface::sprite(const Point &sprite, const Point &position, const Point &origin, float scale, uint8_t transform) {
     Surface::sprite(sprite, position, origin, Vec2(scale, scale), transform);
   }
 
@@ -291,18 +291,18 @@ namespace blit {
    * \param[in] scale `float` x/y scale factor
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Rect &sprite, const Point &position, const Point &origin, const float &scale, const uint8_t &transform) {
+  void Surface::sprite(const Rect &sprite, const Point &position, const Point &origin, float scale, uint8_t transform) {
     Surface::sprite(sprite, position, origin, Vec2(scale, scale), transform);
   }
 
 
   // unscaled sprites with origin and scale - optional transform (mirror/rotate)
-  //void surface::sprite(const rect &source, const point &position, const point &origin, const float &scale, const uint8_t &transform = 0);
-  //void surface::sprite(const point &source, const point &position, const point &origin, const float &scale, const uint8_t &transform = 0);
+  //void surface::sprite(const rect &source, const point &position, const point &origin, float scale, uint8_t transform = 0);
+  //void surface::sprite(const point &source, const point &position, const point &origin, float scale, uint8_t transform = 0);
 
   // unscaled sprites with origin and scale (x/y) - optional transform (mirror/rotate)
-  //void surface::sprite(const rect &source, const point &position, const point &origin, const vec2 &scale, const uint8_t &transform = 0);
-  //void surface::sprite(const point &source, const point &position, const point &origin, const vec2 &scale, const uint8_t &transform = 0);
+  //void surface::sprite(const rect &source, const point &position, const point &origin, const vec2 &scale, uint8_t transform = 0);
+  //void surface::sprite(const point &source, const point &position, const point &origin, const vec2 &scale, uint8_t transform = 0);
 
   /*
   void surface::sprite(const spritesheet &ss, const rect &sprite, const point &position, const sprite_p &properties) {

--- a/32blit/graphics/sprite.hpp
+++ b/32blit/graphics/sprite.hpp
@@ -35,7 +35,7 @@ namespace blit {
     static SpriteSheet *load(const packed_image *image, uint8_t *buffer = nullptr);
     static SpriteSheet *load(const std::string& filename, uint8_t* buffer = nullptr);
 
-    Rect sprite_bounds(const uint16_t &index);          
+    Rect sprite_bounds(uint16_t index);          
     Rect sprite_bounds(const Point &p);
     Rect sprite_bounds(const Rect &r);
   };

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -285,7 +285,7 @@ namespace blit {
    * \param p
    * \param t
    */
-  void Surface::blit_sprite(const Rect &sprite, const Point &p, const uint8_t &t) {
+  void Surface::blit_sprite(const Rect &sprite, const Point &p, uint8_t t) {
     Rect dr = clip.intersection(Rect(p.x, p.y, sprite.w, sprite.h));  // clipped destination rect
 
     if (dr.empty())
@@ -340,7 +340,7 @@ namespace blit {
    * \param p
    * \param t
    */
-  void Surface::stretch_blit_sprite(const Rect &sprite, const Rect &r, const uint8_t &t) {
+  void Surface::stretch_blit_sprite(const Rect &sprite, const Rect &r, uint8_t t) {
     Rect dr = clip.intersection(r);  // clipped destination rect
 
     if (dr.empty())

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -130,11 +130,11 @@ namespace blit {
     // helpers to retrieve pointer to pixel
     __attribute__((always_inline)) inline uint8_t* ptr(const Rect &r)   { return data + r.x * pixel_stride + r.y * row_stride; }
     __attribute__((always_inline)) inline uint8_t* ptr(const Point &p)  { return data + p.x * pixel_stride + p.y * row_stride; }
-    __attribute__((always_inline)) inline uint8_t* ptr(const int32_t &x, const int32_t &y) { return data + x * pixel_stride + y * row_stride; }
+    __attribute__((always_inline)) inline uint8_t* ptr(int32_t x, int32_t y) { return data + x * pixel_stride + y * row_stride; }
 
     __attribute__((always_inline)) inline uint32_t offset(const Rect &r) { return r.x + r.y * bounds.w; }
     __attribute__((always_inline)) inline uint32_t offset(const Point &p) { return p.x + p.y * bounds.w; }
-    __attribute__((always_inline)) inline uint32_t offset(const int32_t &x, const int32_t &y) { return x + y * bounds.w; }
+    __attribute__((always_inline)) inline uint32_t offset(int32_t x, int32_t y) { return x + y * bounds.w; }
 
     void generate_mipmaps(uint8_t depth);
 
@@ -174,24 +174,24 @@ namespace blit {
     //void sprite(spritesheet &ss, point sprite, point position, sprite_p &properties);
 
 
-    void blit_sprite(const Rect &src, const Point &p, const uint8_t &t = 0);
-    void stretch_blit_sprite(const Rect&src, const Rect &r, const uint8_t &t = 0);
+    void blit_sprite(const Rect &src, const Point &p, uint8_t t = 0);
+    void stretch_blit_sprite(const Rect&src, const Rect &r, uint8_t t = 0);
 
-    void sprite(const Rect &sprite, const Point &position, const uint8_t &transform = 0);
-    void sprite(const Point &sprite, const Point &position, const uint8_t &transform = 0);
-    void sprite(const uint16_t &sprite, const Point &position, const uint8_t &transform = 0);
+    void sprite(const Rect &sprite, const Point &position, uint8_t transform = 0);
+    void sprite(const Point &sprite, const Point &position, uint8_t transform = 0);
+    void sprite(uint16_t sprite, const Point &position, uint8_t transform = 0);
 
-    void sprite(const Rect &sprite, const Point &position, const Point &origin, const uint8_t &transform = 0);
-    void sprite(const Point &sprite, const Point &position, const Point &origin, const uint8_t &transform = 0);
-    void sprite(const uint16_t &sprite, const Point &position, const Point &origin, const uint8_t &transform = 0);
+    void sprite(const Rect &sprite, const Point &position, const Point &origin, uint8_t transform = 0);
+    void sprite(const Point &sprite, const Point &position, const Point &origin, uint8_t transform = 0);
+    void sprite(uint16_t sprite, const Point &position, const Point &origin, uint8_t transform = 0);
 
-    void sprite(const Rect &sprite, const Point &position, const Point &origin, const Vec2 &scale, const uint8_t &transform = 0);
-    void sprite(const Point &sprite, const Point &position, const Point &origin, const Vec2 &scale, const uint8_t &transform = 0);
-    void sprite(const uint16_t &sprite, const Point &position, const Point &origin, const Vec2 &scale, const uint8_t &transform = 0);
+    void sprite(const Rect &sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform = 0);
+    void sprite(const Point &sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform = 0);
+    void sprite(uint16_t sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform = 0);
 
-    void sprite(const Rect &sprite, const Point &position, const Point &origin, const float &scale, const uint8_t &transform = 0);
-    void sprite(const Point &sprite, const Point &position, const Point &origin, const float &scale, const uint8_t &transform = 0);
-    void sprite(const uint16_t &sprite, const Point &position, const Point &origin, const float &scale, const uint8_t &transform = 0);
+    void sprite(const Rect &sprite, const Point &position, const Point &origin, float scale, uint8_t transform = 0);
+    void sprite(const Point &sprite, const Point &position, const Point &origin, float scale, uint8_t transform = 0);
+    void sprite(uint16_t sprite, const Point &position, const Point &origin, float scale, uint8_t transform = 0);
 
     //extern void texture_triangle(int32_t x1, int32_t y1, int32_t u1, int32_t v1, int32_t x2, int32_t y2, int32_t u2, int32_t v2, int32_t x3, int32_t y3, int32_t u3, int32_t v3);
 

--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -46,7 +46,7 @@ namespace blit {
    * \param[in] x
    * \param[in] y
    */
-  int32_t TileMap::offset(const int16_t &x, const int16_t &y) {
+  int32_t TileMap::offset(int16_t x, int16_t y) {
     int32_t cx = ((uint16_t)x) & (bounds.w - 1);
     int32_t cy = ((uint16_t)y) & (bounds.h - 1);
 

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -29,7 +29,7 @@ namespace blit {
     TileMap(uint8_t *tiles, uint8_t *transforms, Size bounds, SpriteSheet *sprites);
 
     inline int32_t offset(const Point &p); // __attribute__((always_inline));
-    int32_t offset(const int16_t &x, const int16_t &y); // __attribute__((always_inline));
+    int32_t offset(int16_t x, int16_t y); // __attribute__((always_inline));
     uint8_t tile_at(const Point &p); // __attribute__((always_inline));
     uint8_t transform_at(const Point &p); // __attribute__((always_inline));
 

--- a/32blit/types/vec2.cpp
+++ b/32blit/types/vec2.cpp
@@ -7,7 +7,7 @@
 
 namespace blit {
 
-  void Vec2::rotate(const float &a) {
+  void Vec2::rotate(float a) {
     float c = cosf(a);
     float s = sinf(a);
     float rx = this->x * c - this->y * s;

--- a/32blit/types/vec2.hpp
+++ b/32blit/types/vec2.hpp
@@ -74,7 +74,7 @@ namespace blit {
      *
      * \param a `float` angle of rotation (radians)
      */
-    void   rotate(const float &a);
+    void   rotate(float a);
 
     /**
      * Get the angle between two vectors


### PR DESCRIPTION
Unless I'm missing some case this is _less_ efficient than passing by value... Probably only by a few instructions. Shaves about 300 bytes off Babble. (Lots of calls to `sprite`)

This charge was a find/replace of `const (u?int[12368]+_t|int|float) &` -> `$1 `