### PR TITLE
Fix some nasty leaks from the API + other API changes

### DIFF
--- a/32blit-sdl/File.cpp
+++ b/32blit-sdl/File.cpp
@@ -86,16 +86,14 @@ uint32_t get_file_length(void *fh)
   return (uint32_t)SDL_RWtell(file);
 }
 
-std::vector<blit::FileInfo> list_files(const std::string &path) {
-  std::vector<blit::FileInfo> ret;
-
+void list_files(const std::string &path, std::function<void(blit::FileInfo &)> callback) {
 #ifdef WIN32
   HANDLE file;
   WIN32_FIND_DATAA findData;
   file = FindFirstFileA((basePath + path + "\\*").c_str(), &findData);
 
   if(file == INVALID_HANDLE_VALUE)
-    return ret;
+    return;
 
   do
   {
@@ -111,7 +109,7 @@ std::vector<blit::FileInfo> list_files(const std::string &path) {
     if(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
       info.flags |= blit::FileFlags::directory;
 
-    ret.push_back(info);
+    callback(info);
   }
   while(FindNextFileA(file, &findData) != 0);
 
@@ -121,7 +119,7 @@ std::vector<blit::FileInfo> list_files(const std::string &path) {
   auto dir = opendir((basePath + path).c_str());
 
   if(!dir)
-    return ret;
+    return;
 
   struct dirent *ent;
 
@@ -144,13 +142,11 @@ std::vector<blit::FileInfo> list_files(const std::string &path) {
     if(S_ISDIR(stat_buf.st_mode))
       info.flags |= blit::FileFlags::directory;
 
-    ret.push_back(info);
+    callback(info);
   }
 
   closedir(dir);
 #endif
-
-  return ret;
 }
 
 bool file_exists(const std::string &path) {

--- a/32blit-sdl/File.cpp
+++ b/32blit-sdl/File.cpp
@@ -195,3 +195,7 @@ const char *get_save_path() {
 
   return save_path.c_str();
 }
+
+bool is_storage_available() {
+  return true;
+}

--- a/32blit-sdl/File.cpp
+++ b/32blit-sdl/File.cpp
@@ -40,7 +40,7 @@ void *open_file(const std::string &name, int mode) {
 
   if(!file) {
     // check if the path is under the save path
-    auto save_path = get_save_path();
+    std::string save_path = get_save_path();
     if(name.compare(0, save_path.length(), save_path) == 0)
       file = SDL_RWFromFile(name.c_str(), str_mode);
   }
@@ -189,11 +189,13 @@ bool remove_file(const std::string &path) {
   return remove((basePath + path).c_str()) == 0;
 }
 
-std::string get_save_path() {
+static std::string save_path;
+
+const char *get_save_path() {
   auto tmp = SDL_GetPrefPath(metadata_author, metadata_title);
-  std::string ret(tmp);
+  save_path = std::string(tmp);
 
   SDL_free(tmp);
 
-  return ret;
+  return save_path.c_str();
 }

--- a/32blit-sdl/File.hpp
+++ b/32blit-sdl/File.hpp
@@ -19,3 +19,4 @@ bool create_directory(const std::string &path);
 bool rename_file(const std::string &old_name, const std::string &new_name);
 bool remove_file(const std::string &path);
 const char *get_save_path();
+bool is_storage_available();

--- a/32blit-sdl/File.hpp
+++ b/32blit-sdl/File.hpp
@@ -18,4 +18,4 @@ bool directory_exists(const std::string &path);
 bool create_directory(const std::string &path);
 bool rename_file(const std::string &old_name, const std::string &new_name);
 bool remove_file(const std::string &path);
-std::string get_save_path();
+const char *get_save_path();

--- a/32blit-sdl/File.hpp
+++ b/32blit-sdl/File.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
-#include <vector>
 
 #include "engine/file.hpp"
 
@@ -12,7 +12,7 @@ int32_t read_file(void *fh, uint32_t offset, uint32_t length, char *buffer);
 int32_t write_file(void *fh, uint32_t offset, uint32_t length, const char *buffer);
 int32_t close_file(void *fh);
 uint32_t get_file_length(void *fh);
-std::vector<blit::FileInfo> list_files(const std::string &path);
+void list_files(const std::string &path, std::function<void(blit::FileInfo &)> callback);
 bool file_exists(const std::string &path);
 bool directory_exists(const std::string &path);
 bool create_directory(const std::string &path);

--- a/32blit-sdl/JPEG.cpp
+++ b/32blit-sdl/JPEG.cpp
@@ -31,7 +31,7 @@ blit::JPEGImage blit_decode_jpeg_buffer(const uint8_t *ptr, uint32_t len, blit::
   return decode_jpeg_rwops(rwops);
 }
 
-blit::JPEGImage blit_decode_jpeg_file(std::string filename, blit::AllocateCallback alloc) {
+blit::JPEGImage blit_decode_jpeg_file(const std::string &filename, blit::AllocateCallback alloc) {
   auto rwops = SDL_RWFromFile(filename.c_str(), "rb");
   return decode_jpeg_rwops(rwops);
 }

--- a/32blit-sdl/JPEG.hpp
+++ b/32blit-sdl/JPEG.hpp
@@ -3,4 +3,4 @@
 #include "graphics/jpeg.hpp"
 
 blit::JPEGImage blit_decode_jpeg_buffer(const uint8_t *ptr, uint32_t len, blit::AllocateCallback alloc);
-blit::JPEGImage blit_decode_jpeg_file(std::string filename, blit::AllocateCallback alloc);
+blit::JPEGImage blit_decode_jpeg_file(const std::string &filename, blit::AllocateCallback alloc);

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -152,6 +152,7 @@ void System::run() {
 	blit::api.rename_file = ::rename_file;
 	blit::api.remove_file = ::remove_file;
 	blit::api.get_save_path = ::get_save_path;
+	blit::api.is_storage_available = ::is_storage_available;
 
 	blit::api.enable_us_timer = ::enable_us_timer;
 	blit::api.get_us_timer = ::get_us_timer;

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -20,13 +20,8 @@ blit::Surface __fb_lores((uint8_t *)framebuffer, blit::PixelFormat::RGB, blit::S
 static blit::Pen palette[256];
 
 // blit debug callback
-void debug(std::string message) {
-	std::cout << message << std::endl;
-}
-
-int blit_debugf(const char * psFormatString, va_list args)
-{
-	return vprintf(psFormatString, args);
+void blit_debug(const char *message) {
+	std::cout << message;
 }
 
 // blit screenmode callback
@@ -137,8 +132,7 @@ void System::run() {
 
 	blit::api.now = ::now;
 	blit::api.random = ::blit_random;
-	blit::api.debug = ::debug;
-	blit::api.debugf = ::blit_debugf;
+	blit::api.debug = ::blit_debug;
 	blit::api.set_screen_mode = ::set_screen_mode;
 	blit::api.set_screen_palette = ::set_screen_palette;
 	blit::update = ::update;

--- a/32blit-stm32/Inc/file.hpp
+++ b/32blit-stm32/Inc/file.hpp
@@ -17,4 +17,4 @@ bool directory_exists(const std::string &path);
 bool create_directory(const std::string &path);
 bool rename_file(const std::string &old_name, const std::string &new_name);
 bool remove_file(const std::string &path);
-std::string get_save_path();
+const char *get_save_path();

--- a/32blit-stm32/Inc/file.hpp
+++ b/32blit-stm32/Inc/file.hpp
@@ -11,7 +11,7 @@ int32_t read_file(void *fh, uint32_t offset, uint32_t length, char *buffer);
 int32_t write_file(void *fh, uint32_t offset, uint32_t length, const char *buffer);
 int32_t close_file(void *fh);
 uint32_t get_file_length(void *fh);
-std::vector<blit::FileInfo> list_files(const std::string &path);
+void list_files(const std::string &path, std::function<void(blit::FileInfo &)> callback);
 bool file_exists(const std::string &path);
 bool directory_exists(const std::string &path);
 bool create_directory(const std::string &path);

--- a/32blit-stm32/Inc/jpeg.hpp
+++ b/32blit-stm32/Inc/jpeg.hpp
@@ -3,4 +3,4 @@
 #include "graphics/jpeg.hpp"
 
 blit::JPEGImage blit_decode_jpeg_buffer(const uint8_t *ptr, uint32_t len, blit::AllocateCallback alloc);
-blit::JPEGImage blit_decode_jpeg_file(std::string filename, blit::AllocateCallback alloc);
+blit::JPEGImage blit_decode_jpeg_file(const std::string &filename, blit::AllocateCallback alloc);

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -422,6 +422,7 @@ void blit_init() {
     blit::api.rename_file = ::rename_file;
     blit::api.remove_file = ::remove_file;
     blit::api.get_save_path = ::get_save_path;
+    blit::api.is_storage_available = blit_sd_mounted;
 
     blit::api.enable_us_timer = ::enable_us_timer;
     blit::api.get_us_timer = ::get_us_timer;

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -96,15 +96,8 @@ static void init_api_shared() {
   api.LED = Pen();
 }
 
-int blit_debugf(const char * psFormatString, va_list args)
-{
-	return vprintf(psFormatString, args);
-}
-
-void blit_debug(std::string message) {
-	printf(message.c_str());
-  screen.pen = Pen(255, 255, 255);
-  screen.text(message, minimal_font, Point(0, 0));
+void blit_debug(const char *message) {
+	printf("%s", message);
 }
 
 void blit_exit(bool is_error) {
@@ -407,7 +400,6 @@ void blit_init() {
     }
     bq24295_init(&hi2c4);
     blit::api.debug = blit_debug;
-    blit::api.debugf = blit_debugf;
     blit::api.now = HAL_GetTick;
     blit::api.random = HAL_GetRandom;
     blit::api.exit = blit_exit;

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -139,7 +139,9 @@ bool remove_file(const std::string &path) {
   return f_unlink(path.c_str()) == FR_OK;
 }
 
-std::string get_save_path() {
+static char save_path[32]; // max game title length is 24 + ".blit/" + "/"
+
+const char *get_save_path() {
   std::string app_name;
 
   if(!directory_exists(".blit"))
@@ -167,9 +169,12 @@ std::string get_save_path() {
     }
   }
 
-  // make sure it exists
-  if(!directory_exists(".blit/" + app_name))
-    create_directory(".blit/" + app_name);
+  snprintf(save_path, sizeof(save_path), ".blit/%s/", app_name.c_str());
 
-  return ".blit/" + app_name + "/";
+  // make sure it exists
+  if(!directory_exists(save_path))
+    create_directory(save_path);
+
+
+  return save_path;
 }

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <map>
 
 #include "fatfs.h"
@@ -81,13 +82,11 @@ uint32_t get_file_length(void *fh)
   return f_size((FIL *)fh);
 }
 
-std::vector<blit::FileInfo> list_files(const std::string &path) {
-  std::vector<blit::FileInfo> ret;
-
+void list_files(const std::string &path, std::function<void(blit::FileInfo &)> callback) {
   auto dir = new DIR();
 
   if(f_opendir(dir, path.c_str()) != FR_OK)
-    return ret;
+    return;
 
   FILINFO ent;
 
@@ -101,12 +100,10 @@ std::vector<blit::FileInfo> list_files(const std::string &path) {
     if(ent.fattrib & AM_DIR)
       info.flags |= blit::FileFlags::directory;
 
-    ret.push_back(info);
+    callback(info);
   }
 
   f_closedir(dir);
-
-  return ret;
 }
 
 bool file_exists(const std::string &path) {

--- a/32blit-stm32/Src/jpeg.cpp
+++ b/32blit-stm32/Src/jpeg.cpp
@@ -79,7 +79,7 @@ blit::JPEGImage blit_decode_jpeg_buffer(const uint8_t *ptr, uint32_t len, blit::
   return {blit::Size(conf.ImageWidth, conf.ImageHeight), jpeg_out_buf};
 }
 
-blit::JPEGImage blit_decode_jpeg_file(std::string filename, blit::AllocateCallback alloc) {
+blit::JPEGImage blit_decode_jpeg_file(const std::string &filename, blit::AllocateCallback alloc) {
   auto file = open_file(filename, blit::OpenMode::read);
 
   if(!file)

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -53,7 +53,7 @@ namespace blit {
     bool (*create_directory) (const std::string &path);
     bool (*rename_file) (const std::string &old_name, const std::string &new_name);
     bool (*remove_file) (const std::string &path);
-    std::string (*get_save_path)();
+    const char *(*get_save_path)();
 
     // profiler
     void (*enable_us_timer)();

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -54,6 +54,7 @@ namespace blit {
     bool (*rename_file) (const std::string &old_name, const std::string &new_name);
     bool (*remove_file) (const std::string &path);
     const char *(*get_save_path)();
+    bool (*is_storage_available)();
 
     // profiler
     void (*enable_us_timer)();

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -47,7 +47,7 @@ namespace blit {
     int32_t (*write_file)(void *fh, uint32_t offset, uint32_t length, const char* buffer);
     int32_t (*close_file)(void *fh);
     uint32_t (*get_file_length)(void *fh);
-    std::vector<FileInfo> (*list_files) (const std::string &path);
+    void (*list_files) (const std::string &path, std::function<void(FileInfo &)> callback);
     bool (*file_exists) (const std::string &path);
     bool (*directory_exists) (const std::string &path);
     bool (*create_directory) (const std::string &path);

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -62,7 +62,7 @@ namespace blit {
 
     // jepg
     JPEGImage (*decode_jpeg_buffer)(const uint8_t *ptr, uint32_t len, AllocateCallback alloc);
-    JPEGImage (*decode_jpeg_file)(std::string filename, AllocateCallback alloc);
+    JPEGImage (*decode_jpeg_file)(const std::string &filename, AllocateCallback alloc);
 
   };
   #pragma pack(pop)

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -39,8 +39,7 @@ namespace blit {
     void (*exit)(bool is_error);
 
     // serial debug
-    void (*debug)(std::string message);
-    int  (*debugf)(const char * psFormatString, va_list args);
+    void (*debug)(const char *message);
 
     // files
     void *(*open_file)(const std::string &file, int mode);

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -32,14 +32,25 @@ namespace blit {
   }
 
   void debug(std::string message) {
-    api.debug(message);
+    api.debug(message.c_str());
   }
 
   int debugf(const char * psFormatString, ...) {
     va_list args;
     va_start(args, psFormatString);
-    int ret = api.debugf(psFormatString, args);
+    
+    // get length
+    va_list tmp_args;
+    va_copy(tmp_args, args);
+    int len = vsnprintf(nullptr, 0, psFormatString, tmp_args) + 1;
+    va_end(tmp_args);
+
+    auto buf = new char[len];
+    int ret = vsnprintf(buf, len, psFormatString, args);
+    api.debug(buf);
     va_end(args);
+
+    delete[] buf;
     return ret;
   }
 

--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -21,7 +21,10 @@ namespace blit {
    * \return Vector of files/directories
    */
   std::vector<FileInfo> list_files(const std::string &path) {
-    auto ret = api.list_files(path);
+    std::vector<FileInfo> ret;
+    api.list_files(path, [&ret](FileInfo &file){
+      ret.push_back(file);
+    });
 
     for(auto &buf_file : buf_files) {
       auto slash_pos = buf_file.first.find_last_of('/');

--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -14,6 +14,15 @@ namespace blit {
   static std::map<std::string, BufferFile> buf_files;
 
   /**
+   * Check if it is possible to read/write files, for SDL this is always true.
+   *
+   * \return true if an SD card is inserted and usable, false otherwise
+   */
+  bool is_storage_available() {
+    return api.is_storage_available();
+  }
+
+  /**
    * Lists files on the SD card (device), the game directory (SDL) or in memory.
    *
    * \param path Path to list files at, relative to the root of the SD card or game directory (SDL).

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -28,6 +28,8 @@ namespace blit {
     uint32_t size;
   };
 
+  bool is_storage_available();
+
   std::vector<FileInfo> list_files(const std::string &path);
   bool file_exists(const std::string &path);
   bool directory_exists(const std::string &path);

--- a/32blit/engine/save.cpp
+++ b/32blit/engine/save.cpp
@@ -13,7 +13,7 @@ namespace blit {
    * \return `true` if a save exists and contains enough data
    */
   bool read_save(char *data, uint32_t length, int slot) {
-    File file(api.get_save_path() + "save" + std::to_string(slot));
+    File file(std::string(api.get_save_path()) + "save" + std::to_string(slot));
 
     return file.is_open() && uint32_t(file.read(0, length, data)) == length;
   }
@@ -26,6 +26,6 @@ namespace blit {
    * \param slot Save slot to write to, can be any number
    */
   void write_save(const char *data, uint32_t length, int slot) {
-    File(api.get_save_path() + "save" + std::to_string(slot), OpenMode::write).write(0, length, data);
+    File(std::string(api.get_save_path()) + "save" + std::to_string(slot), OpenMode::write).write(0, length, data);
   }
 }

--- a/32blit/graphics/jpeg.cpp
+++ b/32blit/graphics/jpeg.cpp
@@ -27,7 +27,7 @@ namespace blit {
    *
    * \return Decoded image.
    */
-  JPEGImage decode_jpeg_file(std::string filename) {
+  JPEGImage decode_jpeg_file(const std::string &filename) {
     return api.decode_jpeg_file(filename, alloc_func);
   }
 }

--- a/32blit/graphics/jpeg.hpp
+++ b/32blit/graphics/jpeg.hpp
@@ -13,5 +13,5 @@ namespace blit {
   };
 
   JPEGImage decode_jpeg_buffer(const uint8_t *ptr, uint32_t len);
-  JPEGImage decode_jpeg_file(std::string filename);
+  JPEGImage decode_jpeg_file(const std::string &filename);
 }

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -121,7 +121,7 @@ void sort_file_list() {
 void load_directory_list(std::string directory) {
   directory_list.clear();
 
-  for(auto &folder : ::list_files(directory)) {
+  for(auto &folder : blit::list_files(directory)) {
     if(folder.flags & blit::FileFlags::directory) {
       if(folder.name.compare("System Volume Information") == 0 || folder.name[0] == '.') continue;
       directory_list.push_back({folder.name, 0, 0});
@@ -151,7 +151,7 @@ void load_file_list(std::string directory) {
 
   game_list.clear();
 
-  for(auto &file : ::list_files(directory)) {
+  for(auto &file : blit::list_files(directory)) {
     if(file.flags & blit::FileFlags::directory)
       continue;
 


### PR DESCRIPTION
This started as me discovering that calling `list_files` repeatedly would kill the firmware. This was because the data for the `vector` containing the file list was allocated from one heap, and deallocated from the other (well, it _attempted_ to do that, nothing actually gets deallocated...). `get_save_path` had a similar issue.

Since this is already breaking the API, this also adds `blit::is_storage_available`, cleans up `decode_jpeg_file` a bit and merges the two "debug" functions (`debugf` also gets float support by doing the formatting outside of the firmware).