### PR TITLE
Mass storage menu rework

### DIFF
--- a/32blit-stm32/Inc/USBManager.h
+++ b/32blit-stm32/Inc/USBManager.h
@@ -74,6 +74,34 @@ public:
 
 	State GetState(void)
 	{
+		return m_state;
+	}
+
+	const char *GetStateName(void)
+	{
+		return m_stateNames[GetState()];
+	}
+
+	bool IsMSCReady(void)
+	{
+		 return m_state == usbsMSCInititalising || m_state == usbsMSCMounting || m_state == usbsMSCMounted;
+	}
+
+	bool HasHadActivity(void)
+	{
+		bool bHasActivity = m_bHasActivity;
+		m_bHasActivity = false;
+		return bHasActivity;
+	}
+
+	void LogActivity(void)
+	{
+		m_bHasActivity = true;
+		m_bHasHadSomeActivity = true;
+	}
+
+	void Update()
+	{
 		// On linux we seem to get many start/stops so use a timer to set mount status.
 		const uint32_t uMountUnmountTime = 500;
 
@@ -105,31 +133,6 @@ public:
 			default:
 			break;
 		}
-
-		return m_state;
-	}
-
-	const char *GetStateName(void)
-	{
-		return m_stateNames[GetState()];
-	}
-
-	bool IsMSCReady(void)
-	{
-		 return m_state == usbsMSCInititalising || m_state == usbsMSCMounting || m_state == usbsMSCMounted;
-	}
-
-	bool HasHadActivity(void)
-	{
-		bool bHasActivity = m_bHasActivity;
-		m_bHasActivity = false;
-		return bHasActivity;
-	}
-
-	void LogActivity(void)
-	{
-		m_bHasActivity = true;
-		m_bHasHadSomeActivity = true;
 	}
 
 private:

--- a/32blit-stm32/Inc/USBManager.h
+++ b/32blit-stm32/Inc/USBManager.h
@@ -64,6 +64,9 @@ public:
 				m_unmountStartTime = HAL_GetTick();
 			break;
 
+			case usbsMSCUnmounted:
+				SetType(usbtCDC);
+
 			default:
 			break;
 		}
@@ -96,7 +99,7 @@ public:
 
 			case usbsMSCUnmounting :
 				if(HAL_GetTick() > m_unmountStartTime  + uMountUnmountTime)
-					m_state = usbsMSCUnmounted;
+					SetState(usbsMSCUnmounted);
 			break;
 
 			default:

--- a/32blit-stm32/Inc/USBManager.h
+++ b/32blit-stm32/Inc/USBManager.h
@@ -76,7 +76,7 @@ public:
 
 		// can't be mounted if there's no usb connection
 		// maybe show some kind of warning if previously mounted?
-		if(hUsbDeviceHS.dev_state != USBD_STATE_CONFIGURED)
+		if(m_type == usbtMSC && hUsbDeviceHS.dev_state != USBD_STATE_CONFIGURED)
 		{
 			m_state = usbsMSCInititalising;
 			m_bHasHadSomeActivity = false;

--- a/32blit-stm32/Inc/file.hpp
+++ b/32blit-stm32/Inc/file.hpp
@@ -6,6 +6,8 @@
 
 #include "engine/file.hpp"
 
+extern int num_open_files;
+
 void *open_file(const std::string &file, int mode);
 int32_t read_file(void *fh, uint32_t offset, uint32_t length, char *buffer);
 int32_t write_file(void *fh, uint32_t offset, uint32_t length, const char *buffer);

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -523,6 +523,18 @@ protected:
       case VOLUME:
         draw_slider(Point(bar_x, y + bar_margin), bar_width, persist.volume, foreground_colour);
         break;
+      case STORAGE:
+        screen.pen = foreground_colour;
+        const char *label;
+        if(num_open_files)
+          label = "Files Open";
+        else if(g_usbManager.GetType() == USBManager::usbtMSC)
+          label = g_usbManager.GetStateName() + 4; // trim the "MSC "
+        else
+          label = "Disabled";
+        
+        screen.text(label, minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
+        break;
       default:
         screen.pen = foreground_colour;
         screen.text("Press A", minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
@@ -569,8 +581,6 @@ protected:
           g_usbManager.SetType(USBManager::usbtCDC);
         else if(num_open_files == 0)
           g_usbManager.SetType(USBManager::usbtMSC);
-
-        blit_menu(); // close the menu
         break;
     }
   }

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -204,7 +204,7 @@ bool blit_sd_detected() {
 }
 
 bool blit_sd_mounted() {
-  return fs_mounted;
+  return fs_mounted && g_usbManager.GetType() != USBManager::usbtMSC;
 }
 
 void hook_render(uint32_t time) {
@@ -567,7 +567,7 @@ protected:
         // switch back manually if not mounted
         if(g_usbManager.GetState() == USBManager::usbsMSCInititalising)
           g_usbManager.SetType(USBManager::usbtCDC);
-        else
+        else if(num_open_files == 0)
           g_usbManager.SetType(USBManager::usbtMSC);
 
         blit_menu(); // close the menu

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -23,6 +23,7 @@
 #include "fatfs.h"
 #include "quadspi.h"
 #include "usbd_core.h"
+#include "USBManager.h"
 
 #include "32blit.hpp"
 #include "engine/api_private.hpp"
@@ -38,7 +39,9 @@ extern char __fb_start;
 extern char itcm_text_start;
 extern char itcm_text_end;
 extern char itcm_data;
+
 extern USBD_HandleTypeDef hUsbDeviceHS;
+extern USBManager g_usbManager;
 
 #define ADC_BUFFER_SIZE 32
 
@@ -451,6 +454,7 @@ enum MenuItem {
     DFU,
     SHIPPING,
     SWITCH_EXE,
+    STORAGE,
     LAST_COUNT // leave me last pls
 };
 
@@ -559,6 +563,15 @@ protected:
       case SWITCH_EXE:
         blit_switch_execution(persist.last_game_offset);
         break;
+      case STORAGE:
+        // switch back manually if not mounted
+        if(g_usbManager.GetState() == USBManager::usbsMSCInititalising)
+          g_usbManager.SetType(USBManager::usbtCDC);
+        else
+          g_usbManager.SetType(USBManager::usbtMSC);
+
+        blit_menu(); // close the menu
+        break;
     }
   }
 
@@ -571,7 +584,8 @@ static Menu::Item firmware_menu_items[]{
   {SCREENSHOT, "Take Screenshot"},
   {DFU, "DFU Mode"},
   {SHIPPING, "Power Off"},
-  {SWITCH_EXE, ""} // label depends on if a game is running
+  {SWITCH_EXE, ""}, // label depends on if a game is running
+  {STORAGE, "Storage Mode"},
 };
 
 FirmwareMenu firmware_menu("System Menu", firmware_menu_items, MenuItem::LAST_COUNT);

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -94,6 +94,9 @@ uint32_t get_file_length(void *fh)
 }
 
 void list_files(const std::string &path, std::function<void(blit::FileInfo &)> callback) {
+  if(g_usbManager.GetType() == USBManager::usbtMSC)
+    return;
+
   auto dir = new DIR();
 
   if(f_opendir(dir, path.c_str()) != FR_OK)

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -8,10 +8,16 @@
 #include "file.hpp"
 #include "32blit.h"
 #include "executable.hpp"
+#include "USBManager.h"
+
+extern USBManager g_usbManager;
 
 int num_open_files = 0;
 
 void *open_file(const std::string &file, int mode) {
+  if(g_usbManager.GetType() == USBManager::usbtMSC)
+    return nullptr;
+
   FIL *f = new FIL();
 
   BYTE ff_mode = 0;

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -9,6 +9,8 @@
 #include "32blit.h"
 #include "executable.hpp"
 
+int num_open_files = 0;
+
 void *open_file(const std::string &file, int mode) {
   FIL *f = new FIL();
 
@@ -25,8 +27,10 @@ void *open_file(const std::string &file, int mode) {
 
   FRESULT r = f_open(f, file.c_str(), ff_mode);
 
-  if(r == FR_OK)
+  if(r == FR_OK) {
+    num_open_files++;
     return f;
+  }
   
   delete f;
   return nullptr;
@@ -73,6 +77,7 @@ int32_t close_file(void *fh) {
 
   r = f_close((FIL *)fh);
 
+  num_open_files--;
   delete (FIL *)fh;
   return r == FR_OK ? 0 : -1;
 }

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -65,6 +65,7 @@
 /* Private variables ---------------------------------------------------------*/
 
 /* USER CODE BEGIN PV */
+extern USBManager g_usbManager;
 extern CDCCommandStream g_commandStream;
 CDCResetHandler g_resetHandler;
 CDCInfoHandler g_infoHandler;
@@ -178,6 +179,9 @@ int main(void)
 
     blit_tick();
     //HAL_Delay(1000);
+    // USB
+    g_usbManager.Update();
+  
     // handle CDC input
     g_commandStream.Stream();
 

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -88,7 +88,7 @@ namespace blit {
         repeat_start_time = time;
       }
 
-      if(buttons.pressed & Button::A)
+      if(buttons.released & Button::A)
         item_activated(items[current_item]);
 
       // scrolling

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -252,32 +252,6 @@ void launch_game(uint32_t address) {
   blit_switch_execution(address);
 }
 
-void mass_storage_overlay(uint32_t time)
-{
-  static uint8_t uActivityAnim = 0;
-
-  screen.pen = Pen(0, 0, 0, 200);
-  screen.clear();
-
-  screen.pen = Pen(255, 255, 255);
-  char buffer[128];
-  snprintf(buffer, 128, "Mass Storage mode (%s)", g_usbManager.GetStateName());
-  screen.text(buffer, minimal_font, Rect(Point(0), screen.bounds), true, TextAlign::center_center);
-
-  if(uActivityAnim)
-  {
-    screen.pen = Pen(0, 255, 0, uActivityAnim);
-    screen.circle(Point(320-6, 6), 6);
-    uActivityAnim = uActivityAnim>>1;
-
-  }
-  else
-  {
-    if(g_usbManager.HasHadActivity())
-      uActivityAnim = 255;
-  }
-}
-
 void init_lists() {
   load_directory_list("/");
   current_directory = directory_list.begin();
@@ -410,10 +384,6 @@ void render(uint32_t time) {
     else
       screen.text("No Games Found.", minimal_font, Point(60, screen.bounds.h / 2), true, TextAlign::center_center);
   }
-
-  // overlays
-  if(state == stMassStorage)
-    mass_storage_overlay(time);
 
   progress.draw();
   dialog.draw();

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -589,14 +589,6 @@ void update(uint32_t time) {
   {
     if(g_usbManager.GetType() == USBManager::usbtCDC)
       state = stFlashFile;
-
-    if(g_usbManager.GetState() == USBManager::usbsMSCUnmounted)
-    {
-      // Switch back to CDC
-      g_usbManager.SetType(USBManager::usbtCDC);
-      load_file_list(current_directory->name);
-      state = stFlashFile;
-    }
   }
 }
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -480,13 +480,8 @@ void update(uint32_t time) {
 
 
 
-    if(button_home)
-    {
-      // switch to mass media
-      g_usbManager.SetType(USBManager::usbtMSC);
+    if(g_usbManager.GetType() == USBManager::usbtMSC)
       state = stMassStorage;
-
-    }
 
     auto total_items = game_list.size();
 
@@ -592,13 +587,10 @@ void update(uint32_t time) {
   }
   else if(state == stMassStorage)
   {
-    bool switch_back = g_usbManager.GetState() == USBManager::usbsMSCUnmounted;
+    if(g_usbManager.GetType() == USBManager::usbtCDC)
+      state = stFlashFile;
 
-    // allow switching back manually if it was never mounted
-    if(button_home && g_usbManager.GetState() == USBManager::usbsMSCInititalising)
-      switch_back = true;
-
-    if(switch_back)
+    if(g_usbManager.GetState() == USBManager::usbsMSCUnmounted)
     {
       // Switch back to CDC
       g_usbManager.SetType(USBManager::usbtCDC);


### PR DESCRIPTION
Moves mass storage mode enabling to the menu... which was easier said than done. Split from #450.

Adds "Storage Mode" to the menu, with the current status on the right. Since this means that it con now be enabled _anywhere_, also add some checks to prevent enabling storage while files are open... and the other way around.

I haven't tested the auto-disable on eject yet (still broken on my Ubuntu, Windows laptop a bit dead...)