### PR TITLE
Prevent duplicate games

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -197,6 +197,9 @@ bool read_flash_game_header(uint32_t offset, BlitGameHeader &header) {
 void scan_flash() {
   game_list.clear();
 
+  BlitGameMetadata meta;
+  GameInfo game;
+
   for(uint32_t offset = 0; offset < qspi_flash_size;) {
     BlitGameHeader header;
 
@@ -205,18 +208,19 @@ void scan_flash() {
       continue;
     }
 
-    GameInfo game;
     game.offset = offset;
     game.size = header.end - qspi_flash_address;
-    game.title = "game @" + std::to_string(game.offset / qspi_flash_sector_size);
 
     // check for valid metadata
-    BlitGameMetadata meta;
     if(parse_flash_metadata(offset, meta)) {
       game.title = meta.title;
       game.author = meta.author;
       game.size += meta.length + 10;
       game.checksum = meta.crc32;
+    } else {
+      // fallback "title"
+      game.title.resize(20);
+      snprintf(game.title.data(), 20, "game@%i", int(game.offset / qspi_flash_sector_size));
     }
 
     game_list.push_back(game);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -167,7 +167,7 @@ void load_file_list(std::string directory) {
       
       // check for metadata
       BlitGameMetadata meta;
-      if(parse_file_metadata(file.name, meta)) {
+      if(parse_file_metadata(game.filename, meta)) {
         game.title = meta.title;
         game.checksum = meta.crc32;
       }

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -1067,6 +1067,17 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
                     if(result != srError)
                     {
                       result = srFinish;
+
+                      // clean up old version(s)
+                      BlitGameMetadata meta;
+                      if(parse_flash_metadata(flash_start_offset, meta)) {
+                        scan_flash();
+                        for(auto &game : game_list) {
+                          if(game.title == meta.title && game.author == meta.author && game.offset != flash_start_offset)
+                            erase_qspi_flash(game.offset / qspi_flash_sector_size, game.size);
+                        }
+                      }
+
                       launch_game(flash_start_offset);
                     }
                     else


### PR DESCRIPTION
When flashing from the SD card:
 - check for flashed games with the same author/title
 - overwrite if the same or greater size (in blocks)
 - delete it otherwise and flash as normal

When flashing through CDC
 - flash as before
 - clean up old copies afterwards

Also, track free space between games and fix a few bugs. Some of this is a little inefficient, will be easier to fix when the launcher is a separate thing.