### PR TITLE
Make Vec2(float, float) explicit

### DIFF
--- a/32blit/types/vec2.hpp
+++ b/32blit/types/vec2.hpp
@@ -11,7 +11,7 @@ namespace blit {
     float y;
 
     Vec2(const Vec2 &v) = default;
-    Vec2(const float x = 0, const float y = 0) : x(x), y(y) {}
+    explicit Vec2(const float x = 0, const float y = 0) : x(x), y(y) {}
 
     inline Vec2& operator-= (const Vec2 &a) { x -= a.x; y -= a.y; return *this; }
     inline Vec2& operator+= (const Vec2 &a) { x += a.x; y += a.y; return *this; }


### PR DESCRIPTION
Currently if you do `Point(1)` what that actually does is `Point(Vec2(float(1), 0.0f))` which is... unexpected. Make the `Vec2` constructor that takes one/two floats `explicit` to avoid that.

There are probably more constructors that could be marked explicit, but I've hit this one a few times.