### PR TITLE
Dim LED using SysTick_Handler

### DIFF
--- a/32blit-stm32/Inc/main.h
+++ b/32blit-stm32/Inc/main.h
@@ -54,6 +54,12 @@ extern "C" {
 /* Exported functions prototypes ---------------------------------------------*/
 void Error_Handler(void);
 
+
+extern uint8_t charge_led_counter;
+extern uint8_t charge_led_r;
+extern uint8_t charge_led_g;
+extern uint8_t charge_led_b;
+
 /* USER CODE BEGIN EFP */
 
 /* USER CODE END EFP */

--- a/32blit-stm32/Inc/tim.h
+++ b/32blit-stm32/Inc/tim.h
@@ -30,7 +30,6 @@
 
 /* USER CODE END Includes */
 
-extern TIM_HandleTypeDef htim16;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim4;

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -63,10 +63,6 @@ uint8_t battery_status = 0;
 uint8_t battery_fault = 0;
 uint16_t accel_address = LIS3DH_DEVICE_ADDRESS;
 
-uint16_t charge_led_counter = 0;
-uint8_t charge_led_r = 0;
-uint8_t charge_led_g = 0;
-uint8_t charge_led_b = 0;
 
 const uint32_t long_press_exit_time = 1000;
 
@@ -738,24 +734,24 @@ void blit_update_led() {
     // TODO we don't want to do this too often!
     switch((battery_status >> 4) & 0b11){
       case 0b00: // Not charging
-        charge_led_r = 128;
+        charge_led_r = 1;
         charge_led_b = 0;
         charge_led_g = 0;
         break;
       case 0b01: // Pre-charge
-        charge_led_r = 128;
-        charge_led_b = 128;
+        charge_led_r = 1;
+        charge_led_b = 1;
         charge_led_g = 0;
         break;
       case 0b10: // Fast Charging
         charge_led_r = 0;
-        charge_led_b = 128;
+        charge_led_b = 1;
         charge_led_g = 0;
         break;
       case 0b11: // Charge Done
         charge_led_r = 0;
         charge_led_b = 0;
-        charge_led_g = 128;
+        charge_led_g = 1;
         break;
     }
 }
@@ -788,11 +784,6 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
     HAL_TIM_Base_Stop(&htim2);
     HAL_TIM_Base_Stop_IT(&htim2);
   } else if(htim == &htim16) {
-    charge_led_counter += 1;
-    charge_led_counter &= 0x3ff;
-    HAL_GPIO_WritePin(LED_CHG_RED_Port, LED_CHG_RED_Pin, charge_led_r > charge_led_counter ? GPIO_PIN_RESET : GPIO_PIN_SET);
-    HAL_GPIO_WritePin(LED_CHG_GREEN_Port, LED_CHG_GREEN_Pin, charge_led_g > charge_led_counter ? GPIO_PIN_RESET : GPIO_PIN_SET);
-    HAL_GPIO_WritePin(LED_CHG_BLUE_Port, LED_CHG_BLUE_Pin, charge_led_b > charge_led_counter ? GPIO_PIN_RESET : GPIO_PIN_SET);
   }
 }
 

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -375,8 +375,6 @@ void blit_init() {
 
     blit_update_volume();
 
-    HAL_TIM_Base_Start_IT(&htim16);
-
     // enable cycle counting
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
     DWT->CYCCNT = 0;
@@ -783,7 +781,6 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
     }
     HAL_TIM_Base_Stop(&htim2);
     HAL_TIM_Base_Stop_IT(&htim2);
-  } else if(htim == &htim16) {
   }
 }
 
@@ -1011,7 +1008,6 @@ void blit_switch_execution(uint32_t address)
 
   // Stop system button timer
   HAL_TIM_Base_Stop_IT(&htim2);
-  HAL_TIM_Base_Stop_IT(&htim16);
 
   // stop USB
   USBD_Stop(&hUsbDeviceHS);

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -72,6 +72,10 @@ CDCInfoHandler g_infoHandler;
 bool is_beta_unit = false;
 
 
+uint8_t charge_led_counter = 0;
+uint8_t charge_led_r = 0;
+uint8_t charge_led_g = 0;
+uint8_t charge_led_b = 0;
 
 /* USER CODE END PV */
 
@@ -142,7 +146,7 @@ int main(void)
   MX_SPI4_Init();
   //MX_TIM6_Init();
   MX_TIM15_Init();
-  MX_TIM16_Init();
+  //MX_TIM16_Init();
   MX_FATFS_Init();  
   MX_RNG_Init();
   MX_USB_DEVICE_Init();

--- a/32blit-stm32/Src/stm32h7xx_it.c
+++ b/32blit-stm32/Src/stm32h7xx_it.c
@@ -72,7 +72,6 @@ extern PCD_HandleTypeDef hpcd_USB_OTG_HS;
 extern DMA_HandleTypeDef hdma_dac1_ch2;
 extern TIM_HandleTypeDef htim2;
 extern I2C_HandleTypeDef hi2c4;
-extern TIM_HandleTypeDef htim16;
 
 /* USER CODE BEGIN EV */
 
@@ -109,20 +108,6 @@ void HardFault_Handler(void)
     /* USER CODE BEGIN W1_HardFault_IRQn 0 */
     /* USER CODE END W1_HardFault_IRQn 0 */
   }
-}
-
-/**
-  * @brief This function handles TIM16 update interrupt.
-  */
-void TIM16_IRQHandler(void)
-{
-  /* USER CODE BEGIN TIM16_UP_IRQn 0 */
-
-  /* USER CODE END TIM16_UP_IRQn 0 */
-  HAL_TIM_IRQHandler(&htim16);
-  /* USER CODE BEGIN TIM16_UP_IRQn 1 */
-
-  /* USER CODE END TIM16_UP_IRQn 1 */
 }
 
 /**

--- a/32blit-stm32/Src/stm32h7xx_it.c
+++ b/32blit-stm32/Src/stm32h7xx_it.c
@@ -22,6 +22,7 @@
 #include "main.h"
 #include "stm32h7xx_it.h"
 #include "fatfs.h"
+#include "gpio_defs.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 /* USER CODE END Includes */
@@ -218,7 +219,11 @@ void SysTick_Handler(void)
   /* USER CODE END SysTick_IRQn 0 */
   HAL_IncTick();
   /* USER CODE BEGIN SysTick_IRQn 1 */
+  uint32_t currentCycle = HAL_GetTick() & 0x0000000f;
 
+  HAL_GPIO_WritePin(LED_CHG_RED_Port, LED_CHG_RED_Pin, charge_led_r > currentCycle ? GPIO_PIN_RESET : GPIO_PIN_SET);
+  HAL_GPIO_WritePin(LED_CHG_GREEN_Port, LED_CHG_GREEN_Pin, charge_led_g > currentCycle ? GPIO_PIN_RESET : GPIO_PIN_SET);
+  HAL_GPIO_WritePin(LED_CHG_BLUE_Port, LED_CHG_BLUE_Pin, charge_led_b > currentCycle ? GPIO_PIN_RESET : GPIO_PIN_SET);
   /* USER CODE END SysTick_IRQn 1 */
 }
 

--- a/32blit-stm32/Src/tim.c
+++ b/32blit-stm32/Src/tim.c
@@ -31,26 +31,7 @@ TIM_HandleTypeDef htim3;
 TIM_HandleTypeDef htim4;
 
 TIM_HandleTypeDef htim15;
-TIM_HandleTypeDef htim16;
 
-
-/* TIM16 init function */
-void MX_TIM16_Init(void)
-{
-
-  htim16.Instance = TIM16;
-  htim16.Init.Prescaler = 2000;
-  htim16.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim16.Init.Period = 1;
-  htim16.Init.ClockDivision = TIM_CLOCKDIVISION_DIV4;
-  htim16.Init.RepetitionCounter = 0;
-  htim16.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_Base_Init(&htim16) != HAL_OK)
-  {
-    Error_Handler();
-  }
-
-}
 
 /* TIM2 init function */
 void MX_TIM2_Init(void)


### PR DESCRIPTION
Dims the system LED using the solution as explained by @zenodante in #464
Avoids extra timer setup, but - let's say deliberately - does not support any fancy fading LED effects.

System LED states are limited to 3bit colour, or 8 possible states:
* Black, White
* Red, Green, Blue
* Teal, Purple, Yellow

Right now:
* Red = Discharging
* Green = Fully Charged
* Blue = Fast Charging
* Purple = Pre-charge
* Yellow = ?? (Maybe battery low?)
* Teal = ?? (Busy status for system actions?)
* Black = Your blit is probably off or in DFU mode =D
* White = ??