### PR TITLE
Run length encoded packed sprites

### DIFF
--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -34,7 +34,7 @@ namespace blit {
   }
 
   SpriteSheet *SpriteSheet::load(const packed_image *image, uint8_t *buffer) {
-    if(memcmp(image->type, "SPRITEPK", 8) != 0 && memcmp(image->type, "SPRITERW", 8) != 0)
+    if(memcmp(image->type, "SPRITEPK", 8) != 0 && memcmp(image->type, "SPRITERW", 8) != 0 && memcmp(image->type, "SPRITERL", 8) != 0)
       return nullptr;
 
     if(image->format > (uint8_t)PixelFormat::M)


### PR DESCRIPTION
Adds a new `SPRITERL` format which is an RLE version of the packed format. The tool falls back to `SPRITEPK` if the result is larger.

Size difference on most of the default assets/metadata + the spritesheet from my game:

```
tunnel                          18678    7755    -10923
gadgetoid_raycaster             19474    9756     -9718
flight                          10386    1279     -9107
s4m_ur4i_space_shooter_ships    10386    4544     -5842
s4m_ur4i_space_shooter_backdrop 10386    4597     -5789
s4m_ur4i_top_down_shooter       10374    5268     -5106
no_image                         6206    1289     -4917
s4m_ur4i_pirate_tilemap         10386    6778     -3608
s4m_ur4i_dingbads               12438    9000     -3438
babblesheet                      3250     754     -2496
s4m_ur4i_pirate_characters      12450    9958     -2492
s4m_ur4i_platformer             10386    7896     -2490
fire                             3226    1583     -1643
ship                             1106     558      -548
palette_swap                      838     494      -344
no_icon                            34      42         8
water                            2706    3024       318
```