### PR TITLE
Fix building with older CMake

### DIFF
--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -19,7 +19,13 @@ function(blit_executable NAME SOURCES)
 	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
 	add_executable(${NAME} ${USER_STARTUP} ${SOURCES} ${ARGN})
 
-	set(BLIT_FILENAME $<TARGET_FILE_BASE_NAME:${NAME}>.blit)
+	# Ideally we want the .blit filename to match the .elf, but TARGET_FILE_BASE_NAME isn't always available
+	# (This only affects the firmware updater as it's the only thing setting a custom OUTPUT_NAME) 
+	if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
+		set(BLIT_FILENAME ${NAME}.blit)
+	else()
+		set(BLIT_FILENAME $<TARGET_FILE_BASE_NAME:${NAME}>.blit)
+	endif()
 
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME}
 		DESTINATION bin

--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -4,7 +4,7 @@ include (../32blit.cmake)
 
 # embed the built firmware
 add_custom_command(
-    COMMAND ${PYTHON_EXECUTABLE} -m ttblit raw --force --input_file $<TARGET_FILE_DIR:firmware>/$<TARGET_FILE_BASE_NAME:firmware>.bin --symbol_name firmware_data  --output_file firmware.hpp
+    COMMAND ${PYTHON_EXECUTABLE} -m ttblit raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp
     OUTPUT firmware.hpp
 )
 


### PR DESCRIPTION
`TARGET_FILE_BASE_NAME` requires CMake 3.15, we only require 3.8 and debian buster only has 3.13. It's only used for building the updater and the output filename only matters in releases so fallback to the old way if it's not available.