### PR TITLE
Fixed: holding the menu button will not queue exit event if user code was not running

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -771,7 +771,7 @@ void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc) {
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
   if(htim == &htim2) {
     bool pressed = !HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port, BUTTON_MENU_Pin);
-    if(pressed) {
+    if(pressed && blit_user_code_running()) { // if button was pressed and we are inside a game, queue a quit event
       exit_game = true;
     }
     HAL_TIM_Base_Stop(&htim2);

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -771,7 +771,7 @@ void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc) {
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
   if(htim == &htim2) {
     bool pressed = !HAL_GPIO_ReadPin(BUTTON_MENU_GPIO_Port, BUTTON_MENU_Pin);
-    if(pressed && blit_user_code_running()) { // if button was pressed and we are inside a game, queue a quit event
+    if(pressed && blit_user_code_running()) { // if button was pressed and we are inside a game, queue the game exit
       exit_game = true;
     }
     HAL_TIM_Base_Stop(&htim2);


### PR DESCRIPTION
If I hold down the MENU button for a long time in the main menu, it will queue an exit event, even if the user code is not running. Upon launching the next game, it will auto-quit right away, because the flag was set to terminate. 

Fixed it by adding a check to see if user code is running before flipping the flag. 