### PR TITLE
Fixes/cleanups for the firmware 

### DIFF
--- a/32blit-stm32/Inc/32blit.h
+++ b/32blit-stm32/Inc/32blit.h
@@ -4,6 +4,7 @@
 #include "32blit.hpp"
 #include "fatfs.h"
 #include "persistence.h"
+#include "executable.hpp"
 
 extern bool is_beta_unit;
 
@@ -36,6 +37,7 @@ extern bool blit_user_code_running();
 extern "C" void blit_reset_with_error();
 extern void blit_enable_user_code();
 extern void blit_disable_user_code();
+extern RawMetadata *blit_get_running_game_metadata();
 
 void blit_menu_update(uint32_t time);
 void blit_menu_render(uint32_t time);

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -161,20 +161,11 @@ const char *get_save_path() {
   if(!blit_user_code_running())
     app_name = "_firmware";
   else {
-    // TODO: this probably can be used for other things
-    auto game_ptr = reinterpret_cast<uint8_t *>(0x90000000 + persist.last_game_offset);
+    auto meta = blit_get_running_game_metadata();
 
-    auto header = reinterpret_cast<BlitGameHeader *>(game_ptr);
-
-    if(header->magic == blit_game_magic) {
-      auto end_ptr = game_ptr + (header->end - 0x90000000);
-      if(memcmp(end_ptr, "BLITMETA", 8) == 0) {
-        auto meta = reinterpret_cast<RawMetadata *>(end_ptr + 10);
-        app_name = meta->title;
-      }
-    }
-
-    if(app_name.empty()) {
+    if(meta)
+      app_name = meta->title;
+    else {
       // fallback to offset
       app_name = std::to_string(persist.last_game_offset);
     }

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -65,7 +65,9 @@ namespace blit {
     JPEGImage (*decode_jpeg_buffer)(const uint8_t *ptr, uint32_t len, AllocateCallback alloc);
     JPEGImage (*decode_jpeg_file)(const std::string &filename, AllocateCallback alloc);
 
+    // launcher APIs - only intended for use by launchers and only available on device
     bool (*launch)(const char *filename);
+    void (*erase_game)(uint32_t offset);
   };
   #pragma pack(pop)
 

--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -112,6 +112,11 @@ namespace blit {
    * \return true if file removed successfully
    */
   bool remove_file(const std::string &path) {
+    auto it = buf_files.find(path);
+    if(it != buf_files.end()) {
+      buf_files.erase(it);
+      return true;
+    }
     return api.remove_file(path);
   }
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -240,7 +240,6 @@ bool launch_game_from_sd(const char *path) {
     blit_disable_user_code(); // assume user running
   }
 
-  scan_flash();
   uint32_t offset = 0xFFFFFFFF;
 
   BlitGameMetadata meta;
@@ -856,7 +855,6 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
                       // clean up old version(s)
                       BlitGameMetadata meta;
                       if(parse_flash_metadata(flash_start_offset, meta)) {
-                        scan_flash();
                         for(auto &game : game_list) {
                           if(game.title == meta.title && game.author == meta.author && game.offset != flash_start_offset)
                             erase_qspi_flash(game.offset / qspi_flash_sector_size, game.size);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -313,6 +313,7 @@ static void start_launcher() {
 
 void init() {
   api.launch = launch_game_from_sd;
+  api.erase_game = erase_flash_game;
 
   set_screen_mode(ScreenMode::hires);
   screen.clear();

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -564,9 +564,12 @@ CDCCommandHandler::StreamResult CDCEraseHandler::StreamData(CDCDataStream &dataS
 
   // attempt to get size, falling back to a single sector
   int erase_size = 1;
-  BlitGameHeader header;
-  if(read_flash_game_header(offset, header))
-    erase_size = calc_num_blocks(header.end - qspi_flash_address); // TODO: this does not include metadata, may result in some leftover junk
+  for(auto &game : game_list) {
+    if(game.offset == offset) {
+      erase_size = calc_num_blocks(game.size);
+      break;
+    }
+  }
 
   erase_qspi_flash(offset / qspi_flash_sector_size, erase_size * qspi_flash_sector_size);
 

--- a/launcher-shared/dialog.hpp
+++ b/launcher-shared/dialog.hpp
@@ -37,7 +37,7 @@ struct Dialog {
     screen.pen = button == Button::Y ? active_col : col;
     screen.rectangle(r);
 
-    screen.pen = button == Button::B ? active_col : col;
+    screen.pen = button == Button::A ? active_col : col;
     r.x += 6;
     screen.rectangle(r);
 
@@ -45,7 +45,7 @@ struct Dialog {
     r.x -= 3; r.y = pos.y;
     screen.rectangle(r);
 
-    if(button == Button::A) screen.pen = active_col;
+    if(button == Button::B) screen.pen = active_col;
     r.y += 6;
     screen.rectangle(r);
   }

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -478,6 +478,9 @@ void update(uint32_t time) {
     dialog.show("Confirm", "Really delete " + game.title + "?", [](bool yes){
       if(yes) {
         auto &game = game_list[persist.selected_menu_item];
+        if(game.filename.compare(0, 7, "flash:/") == 0)
+          api.erase_game(std::stoi(game.filename.substr(7)) * qspi_flash_sector_size);
+        
         ::remove_file(game.filename);
 
         load_file_list(current_directory->name);


### PR DESCRIPTION
 - Removes some now unneeded flash scanning and metadata parsing from the firmware (saving near 3k, mostly from dropping image unpacking)
 - Fixes a few minor bugs (including A/B being backwards on the dialogs)
 - Brings back deleting games from flash (`api.erase_game`)
 - Makes part of the save handling reusable for getting the metadata of whatever is running