### PR TITLE
More CMake version fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,7 +68,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install ${{matrix.apt-packages}}
-        pip3 install 32blit pyelftools
+        pip3 install 32blit
 
     # macOS deps
     - name: Install deps

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -60,9 +60,15 @@ function(blit_metadata TARGET FILE)
 	execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
 	include(${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
 
+	if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
+		set(BLIT_FILENAME ${TARGET}.blit)
+	else()
+		set(BLIT_FILENAME $<TARGET_FILE_BASE_NAME:${TARGET}>.blit)
+	endif()
+
 	add_custom_command(
 		TARGET ${TARGET} POST_BUILD
-		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --config ${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_BASE_NAME:${TARGET}>.blit
+		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --config ${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME}
 	)
 
 	# force relink on change so that the post-build commands are rerun

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
-cmake_policy(SET CMP0069 NEW)
+cmake_minimum_required(VERSION 3.9)
 project(32blit)
 
 if(CMAKE_C_COMPILER_ID MATCHES "MSVC")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (examples)
 include (../32blit.cmake)
 add_subdirectory(another-world)

--- a/examples/another-world/CMakeLists.txt
+++ b/examples/another-world/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (another-world)
 include (../../32blit.cmake)
 blit_executable (another-world another-world.cpp virtual-machine.cpp resource.cpp)

--- a/examples/audio-test/CMakeLists.txt
+++ b/examples/audio-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (audio-test)
 include (../../32blit.cmake)
 blit_executable (audio-test audio-test.cpp)

--- a/examples/audio-wave/CMakeLists.txt
+++ b/examples/audio-wave/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (audio-wave)
 include (../../32blit.cmake)
 blit_executable (audio-wave audio-wave.cpp)

--- a/examples/doom-fire/CMakeLists.txt
+++ b/examples/doom-fire/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (doom-fire)
 include (../../32blit.cmake)
 blit_executable (doom-fire doom-fire.cpp)

--- a/examples/fizzlefade/CMakeLists.txt
+++ b/examples/fizzlefade/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (fizzlefade)
 include (../../32blit.cmake)
 blit_executable (fizzlefade fizzlefade.cpp)

--- a/examples/flight/CMakeLists.txt
+++ b/examples/flight/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (flight)
 include (../../32blit.cmake)
 blit_executable (flight flight.cpp)

--- a/examples/geometry/CMakeLists.txt
+++ b/examples/geometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (geometry)
 include (../../32blit.cmake)
 blit_executable (geometry geometry.cpp)

--- a/examples/hardware-test/CMakeLists.txt
+++ b/examples/hardware-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (hardware-test)
 include (../../32blit.cmake)
 blit_executable (hardware-test hardware-test.cpp)

--- a/examples/jpeg/CMakeLists.txt
+++ b/examples/jpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (jpeg)
 include (../../32blit.cmake)
 blit_executable (jpeg jpeg.cpp)

--- a/examples/logo/CMakeLists.txt
+++ b/examples/logo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (logo)
 include (../../32blit.cmake)
 blit_executable (logo logo.cpp)

--- a/examples/matrix-test/CMakeLists.txt
+++ b/examples/matrix-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (matrix-test)
 include (../../32blit.cmake)
 blit_executable (matrix-test matrix-test.cpp)

--- a/examples/mp3/CMakeLists.txt
+++ b/examples/mp3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (mp3)
 include (../../32blit.cmake)
 blit_executable (mp3 mp3.cpp)

--- a/examples/palette-cycle/CMakeLists.txt
+++ b/examples/palette-cycle/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (palette-cycle)
 include (../../32blit.cmake)
 blit_executable (palette-cycle palette-cycle.cpp)

--- a/examples/palette-swap/CMakeLists.txt
+++ b/examples/palette-swap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (palette-swap)
 include (../../32blit.cmake)
 blit_executable (palette-swap palette-swap.cpp)

--- a/examples/particle/CMakeLists.txt
+++ b/examples/particle/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (particle)
 include (../../32blit.cmake)
 blit_executable (particle particle.cpp)

--- a/examples/platformer/CMakeLists.txt
+++ b/examples/platformer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (platformer)
 include (../../32blit.cmake)
 blit_executable (platformer platformer.cpp)

--- a/examples/profiler-test/CMakeLists.txt
+++ b/examples/profiler-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (profiler-test)
 include (../../32blit.cmake)
 blit_executable (profiler-test profiler-test.cpp)

--- a/examples/racer/CMakeLists.txt
+++ b/examples/racer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (racer)
 include (../../32blit.cmake)
 blit_executable (racer racer.cpp)

--- a/examples/raycaster/CMakeLists.txt
+++ b/examples/raycaster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (raycaster)
 include (../../32blit.cmake)
 blit_executable (raycaster raycaster.cpp)

--- a/examples/rotozoom/CMakeLists.txt
+++ b/examples/rotozoom/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (rotozoom)
 include (../../32blit.cmake)
 blit_executable (rotozoom rotozoom.cpp)

--- a/examples/saves/CMakeLists.txt
+++ b/examples/saves/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (saves)
 set(32BLIT_PATH "../../" CACHE PATH "Path to 32blit.cmake")
 include (${32BLIT_PATH}/32blit.cmake)

--- a/examples/scrolly-tile/CMakeLists.txt
+++ b/examples/scrolly-tile/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (scrolly-tile)
 include (../../32blit.cmake)
 blit_executable (scrolly-tile scrolly-tile.cpp)

--- a/examples/serial-debug/CMakeLists.txt
+++ b/examples/serial-debug/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (serial-debug)
 include (../../32blit.cmake)
 blit_executable (serial-debug serial-debug.cpp)

--- a/examples/shmup/CMakeLists.txt
+++ b/examples/shmup/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (shmup)
 include (../../32blit.cmake)
 blit_executable (shmup shmup.cpp)

--- a/examples/sprite-test/CMakeLists.txt
+++ b/examples/sprite-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (sprite-test)
 include (../../32blit.cmake)
 blit_executable (sprite-test sprite-test.cpp)

--- a/examples/text/CMakeLists.txt
+++ b/examples/text/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (text)
 include (../../32blit.cmake)
 blit_executable (text text.cpp)

--- a/examples/tilemap-test/CMakeLists.txt
+++ b/examples/tilemap-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (tilemap-test)
 include (../../32blit.cmake)
 blit_executable (tilemap-test tilemap-test.cpp)

--- a/examples/tilt/CMakeLists.txt
+++ b/examples/tilt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (tilt)
 include (../../32blit.cmake)
 blit_executable (tilt tilt.cpp)

--- a/examples/timer-test/CMakeLists.txt
+++ b/examples/timer-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (timer-test)
 include (../../32blit.cmake)
 blit_executable (timer-test timer-test.cpp)

--- a/examples/tunnel/CMakeLists.txt
+++ b/examples/tunnel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (tunnel)
 include (../../32blit.cmake)
 blit_executable (tunnel tunnel.cpp)

--- a/examples/tween-demo/CMakeLists.txt
+++ b/examples/tween-demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (tween-demo)
 include (../../32blit.cmake)
 blit_executable (tween-demo tween-demo.cpp)

--- a/examples/tween-test/CMakeLists.txt
+++ b/examples/tween-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (tween-test)
 include (../../32blit.cmake)
 blit_executable (tween-test tween-test.cpp)

--- a/examples/voxel/CMakeLists.txt
+++ b/examples/voxel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (voxel)
 include (../../32blit.cmake)
 blit_executable (voxel voxel.cpp)

--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (firmware-update)
 include (../32blit.cmake)
 

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (firmware)
 include (../32blit.cmake)
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (launcher)
 include (../32blit.cmake)
 

--- a/template/CMakeLists.txt
+++ b/template/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
 project (game)
 set(32BLIT_PATH "../" CACHE PATH "Path to 32blit.cmake")
 include (${32BLIT_PATH}/32blit.cmake)


### PR DESCRIPTION
Fix another use of `TARGET_FILE_BASE_NAME` that I missed and bump the required version to 3.9 everywhere. Building with 3.8 would fail with an error about an unrecognised policy immediately. Since nobody seems to have noticed this, it's probably save to increase.

(Tested with an action that configures with a specific version: https://github.com/Daft-Freak/32blit-beta/commit/b65c18cfe559072fda26852ab4923a7db1c27c9e)