### PR TITLE
nullptr check surface.sprites, plus more comprehensive sprite-test

### DIFF
--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -113,6 +113,7 @@ namespace blit {
    * \param[in] transform to apply
    */
   void Surface::sprite(uint16_t sprite, const Point &position, uint8_t transform) {
+    if(sprites == nullptr) return;
     blit_sprite(
       sprites->sprite_bounds(sprite), 
       position, 
@@ -127,6 +128,7 @@ namespace blit {
    * \param[in] transform to apply
    */
   void Surface::sprite(const Point &sprite, const Point &position, uint8_t transform) {
+    if(sprites == nullptr) return;
     blit_sprite(
       sprites->sprite_bounds(sprite),
       position,
@@ -140,7 +142,8 @@ namespace blit {
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Rect &sprite, const Point &position, uint8_t transform) {        
+  void Surface::sprite(const Rect &sprite, const Point &position, uint8_t transform) {       
+    if(sprites == nullptr) return; 
     blit_sprite(
       sprites->sprite_bounds(sprite),
       position,
@@ -197,6 +200,8 @@ namespace blit {
    * \param[in] transform to apply
    */
   void Surface::sprite(uint16_t sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform) {
+    if(sprites == nullptr) return;
+
     Rect dest_rect(
       roundf(position.x - float(origin.x * scale.x)),
       roundf(position.y - float(origin.y * scale.y)),
@@ -220,6 +225,8 @@ namespace blit {
    * \param[in] transform to apply
    */
   void Surface::sprite(const Point &sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform) {
+    if(sprites == nullptr) return;
+
     Rect dest_rect(
       roundf(position.x - float(origin.x * scale.x)),
       roundf(position.y - float(origin.y * scale.y)),
@@ -243,6 +250,8 @@ namespace blit {
    * \param[in] transform to apply
    */
   void Surface::sprite(const Rect &sprite, const Point &position, const Point &origin, const Vec2 &scale, uint8_t transform) {
+    if(sprites == nullptr) return;
+
     Rect dest_rect(
       roundf(position.x - float(origin.x * scale.x)),
       roundf(position.y - float(origin.y * scale.y)),

--- a/examples/sprite-test/sprite-test.cpp
+++ b/examples/sprite-test/sprite-test.cpp
@@ -31,20 +31,28 @@ void render(uint32_t time_ms) {
   screen.pen = Pen(255, 255, 255);
   screen.rectangle(Rect(0, 0, 320, 14));
 
+  // Left Titles
   screen.text("Apple", minimal_font, Point(5, 20));
   screen.text("Skull", minimal_font, Point(5, 40));
   screen.text("Flowers", minimal_font, Point(5, 60));
+  screen.text("Rotate", minimal_font, Point(5, 80));
+  screen.text("Flip", minimal_font, Point(5, 100));
+
+  // Right Titles
+  screen.text("Big", minimal_font, Point(85, 20));
 
   screen.pen = Pen(0, 0, 0);
   screen.text("Sprite demo", minimal_font, Point(5, 4));
 
   uint32_t ms_start = now();
 
+  // Left Examples
+
   // Draw a sprite using its numerical index into the sprite sheet
   // Treats the sprite sheet as a grid of 8x8 sprites numbered from 0 to 63
   // In this case sprite number 1 is the second sprite from the top row.
   // It should be an apple! Munch!
-  screen.sprite(1, Point(60, 20));
+  screen.sprite(1, Point(50, 20));
 
   // Draw a sprite using its X/Y position from the sprite sheet
   // Treats the sprite sheet as a grid of 8x8 sprites
@@ -53,14 +61,38 @@ void render(uint32_t time_ms) {
   // The 10th position across (0 based, remember!)
   // The 3rd position down.
   // It should be a skull! Yarr!
-  screen.sprite(Point(9, 2), Point(60, 40));
+  screen.sprite(Point(9, 2), Point(50, 40));
 
   // Draw a group of sprites starting from an X/Y position, with a width/height
   // Treats the sprite sheet a grid of 8x8 sprites and selects a group of them defined by a Rect(x, y, w, h)
   // The width and height are measured in sprites.
   // In this case we draw three sprites from the 6th column on the 12th row.
   // It should be a row of flowers! Awww!
-  screen.sprite(Rect(5, 11, 3, 1), Point(60, 60));
+  screen.sprite(Rect(5, 11, 3, 1), Point(50, 60));
+
+  // Draw a heart rotated 90, 180 and 270 degrees
+  screen.pen = Pen(40, 60, 80);
+  screen.rectangle(Rect(50, 80, 8, 8));
+  screen.sprite(Point(0, 4), Point(50, 80), SpriteTransform::R90);
+  screen.rectangle(Rect(60, 80, 8, 8));
+  screen.sprite(Point(0, 4), Point(60, 80), SpriteTransform::R180);
+  screen.rectangle(Rect(70, 80, 8, 8));
+  screen.sprite(Point(0, 4), Point(70, 80), SpriteTransform::R270);
+
+  // Draw a heart flipped horiontally and vertically
+  screen.rectangle(Rect(50, 100, 8, 8));
+  screen.sprite(Point(0, 4), Point(50, 100), SpriteTransform::HORIZONTAL);
+  screen.rectangle(Rect(60, 100, 8, 8));
+  screen.sprite(Point(0, 4), Point(60, 100), SpriteTransform::VERTICAL);
+
+  // Right examples
+
+  // Draw a cherry, stretched to 16x16 pixels
+  screen.stretch_blit(
+    screen.sprites,
+    Rect(0, 0, 8, 8),
+    Rect(130, 16, 16, 16)
+  );
 
   uint32_t ms_end = now();
 
@@ -78,6 +110,8 @@ void render(uint32_t time_ms) {
     screen.pen = Pen(i * 5, 255 - (i * 5), 0);
     screen.rectangle(Rect(i * (block_size + 1) + 1 + 13, screen.bounds.h - block_size - 1, block_size, block_size));
   }
+
+  screen.watermark();
 }
 
 void update(uint32_t time) {


### PR DESCRIPTION
Title says it all. Right now the blit functions just bail if `surface.sprites` is a `nullptr`, should probably return some sort of error status (via int return or some errno horror) so that the Lua bindings can detect and report a failure. (Even if C++ can't get that fancy)