### PR TITLE
Fix the dependency between the firmware updater and the firmware

### DIFF
--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -6,6 +6,7 @@ include (../32blit.cmake)
 add_custom_command(
     COMMAND ${PYTHON_EXECUTABLE} -m ttblit raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp
     OUTPUT firmware.hpp
+    DEPENDS firmware
 )
 
 blit_executable(firmware-update firmware-update.cpp firmware.hpp)
@@ -21,5 +22,4 @@ configure_file(metadata.yml.in metadata.yml)
 
 blit_metadata(firmware-update ${CMAKE_CURRENT_BINARY_DIR}/metadata.yml)
 
-add_dependencies(firmware-update firmware)
 target_include_directories(firmware-update PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.9)
-project (firmware-update)
-include (../32blit.cmake)
-
 # embed the built firmware
 add_custom_command(
     COMMAND ${PYTHON_EXECUTABLE} -m ttblit raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp


### PR DESCRIPTION
This should make sure that the embedded firmware is regenerated whenever the firmware changes.