### PR TITLE
Misc tilemap-related changes

### DIFF
--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -10,7 +10,7 @@ namespace blit {
    * 
    * \param[in] tiles
    * \param[in] transforms
-   * \param[in] bounds
+   * \param[in] bounds Map bounds, must be a power of two
    * \param[in] sprites
    */
   TileMap::TileMap(uint8_t *tiles, uint8_t *transforms, Size bounds, SpriteSheet *sprites) : bounds(bounds), tiles(tiles), transforms(transforms), sprites(sprites) {

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -33,7 +33,7 @@ namespace blit {
     uint8_t tile_at(const Point &p); // __attribute__((always_inline));
     uint8_t transform_at(const Point &p); // __attribute__((always_inline));
 
-    void draw(Surface *dest, Rect viewport, std::function<Mat3(uint8_t)> scanline_callback);
+    void draw(Surface *dest, Rect viewport, std::function<Mat3(uint8_t)> scanline_callback = nullptr);
 
   //  void mipmap_texture_span(surface *dest, point s, uint16_t c, vec2 swc, vec2 ewc);
     void texture_span(Surface *dest, Point s, uint16_t c, Vec2 swc, Vec2 ewc);

--- a/32blit/types/point.hpp
+++ b/32blit/types/point.hpp
@@ -10,8 +10,8 @@ namespace blit {
 
     Point() = default;
     Point(const Point &p) = default;
-    Point(int32_t x, int32_t y) : x(x), y(y) {}
-    Point(Vec2 v) : x(int32_t(v.x)), y(int32_t(v.y)) {}
+    constexpr Point(int32_t x, int32_t y) : x(x), y(y) {}
+    constexpr Point(Vec2 v) : x(int32_t(v.x)), y(int32_t(v.y)) {}
 
     inline Point& operator-= (const Point &a) { x -= a.x; y -= a.y; return *this; }
     inline Point& operator+= (const Point &a) { x += a.x; y += a.y; return *this; }

--- a/32blit/types/rect.hpp
+++ b/32blit/types/rect.hpp
@@ -13,9 +13,9 @@ namespace blit {
     int32_t x = 0, y = 0, w = 0, h = 0;
 
     Rect() = default;
-    Rect(Point tl, Point br) : x(tl.x), y(tl.y), w(br.x - tl.x), h(br.y - tl.y) {}
-    Rect(Point tl, Size s) : x(tl.x), y(tl.y), w(s.w), h(s.h) {}
-    Rect(int32_t x, int32_t y, int32_t w, int32_t h) : x(x), y(y), w(w), h(h) {}
+    constexpr Rect(Point tl, Point br) : x(tl.x), y(tl.y), w(br.x - tl.x), h(br.y - tl.y) {}
+    constexpr Rect(Point tl, Size s) : x(tl.x), y(tl.y), w(s.w), h(s.h) {}
+    constexpr Rect(int32_t x, int32_t y, int32_t w, int32_t h) : x(x), y(y), w(w), h(h) {}
 
     inline Rect& operator*= (const float a) { x = static_cast<int32_t>(x * a); y = static_cast<int32_t>(y * a); w = static_cast<int32_t>(w * a); h = static_cast<int32_t>(h * a); return *this; }
 

--- a/32blit/types/size.hpp
+++ b/32blit/types/size.hpp
@@ -11,7 +11,7 @@ namespace blit {
     int32_t w = 0, h = 0;
 
     Size() = default;
-    Size(int32_t w, int32_t h) : w(w), h(h) {}
+    constexpr Size(int32_t w, int32_t h) : w(w), h(h) {}
 
     inline Size& operator*= (const float a) { w = static_cast<int32_t>(w * a); h = static_cast<int32_t>(h * a); return *this; }
 

--- a/32blit/types/vec2.hpp
+++ b/32blit/types/vec2.hpp
@@ -11,7 +11,7 @@ namespace blit {
     float y;
 
     Vec2(const Vec2 &v) = default;
-    explicit Vec2(const float x = 0, const float y = 0) : x(x), y(y) {}
+    explicit constexpr Vec2(const float x = 0, const float y = 0) : x(x), y(y) {}
 
     inline Vec2& operator-= (const Vec2 &a) { x -= a.x; y -= a.y; return *this; }
     inline Vec2& operator+= (const Vec2 &a) { x += a.x; y += a.y; return *this; }

--- a/32blit/types/vec3.cpp
+++ b/32blit/types/vec3.cpp
@@ -14,8 +14,6 @@ extern "C" {
 
 namespace blit {
 
-  Vec3::Vec3(const float x, const float y, const float z) : x(x), y(y), z(z) {}
-
   void Vec3::transform(const Mat4 &m) {
     float w = m.v30 * this->x + m.v31 * this->y + m.v32 * -this->z + m.v33;
     float tx = x; float ty = y; float tz = z;

--- a/32blit/types/vec3.hpp
+++ b/32blit/types/vec3.hpp
@@ -16,7 +16,7 @@ namespace blit {
     float z;
 
     Vec3(const Vec3 &v) = default;
-    Vec3(const float x = 0, const float y = 0, const float z = 0);
+    constexpr Vec3(const float x = 0, const float y = 0, const float z = 0) : x(x), y(y), z(z) {}
 
     inline Vec3& operator-= (const Vec3 &a) { x -= a.x; y -= a.y;  z -= a.z; return *this; }
     inline Vec3& operator+= (const Vec3 &a) { x += a.x; y += a.y;  z += a.z; return *this; }


### PR DESCRIPTION
Was attempting to use TileMap for something and forgot about the restriction on the bounds. `constexpr` patch allows doing stuff like
```c++
constexpr blit::Size bg_size(64, 32);
uint8_t bg_tiles[bgSize.w * bgSize.h];
```


Also noticed that the transform flags for TileMap don't match the ones for sprites (horizontal flip and x/y swap are swapped)... (didn't change that here)