### PR TITLE
Bring back missing col 319

### DIFF
--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -306,7 +306,7 @@ namespace display {
 
     // configure ltdc layer        
     LTDC_Layer1->WHPCR &= ~(LTDC_LxWHPCR_WHSTPOS | LTDC_LxWHPCR_WHSPPOS);
-    LTDC_Layer1->WHPCR = ((1 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U) + 1U) | ((321 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U)) << 16U));
+    LTDC_Layer1->WHPCR = ((0 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U) + 1U) | ((320 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U)) << 16U));
     LTDC_Layer1->WVPCR &= ~(LTDC_LxWVPCR_WVSTPOS | LTDC_LxWVPCR_WVSPPOS);
     LTDC_Layer1->WVPCR  = ((0 + (LTDC->BPCR & LTDC_BPCR_AVBP) + 1U) | ((241 + (LTDC->BPCR & LTDC_BPCR_AVBP)) << 16U));  
     LTDC_Layer1->PFCR   = LTDC_PIXEL_FORMAT_RGB565;  


### PR DESCRIPTION
Have checked this doesn't horribly explode anything or lose a column from the *left* hand edge (thanks, bug in Doom Fire).

Probably need a bit of a de-magic-numbering on the LTDC config since it's pretty heinous.

I spent far too long tweaking the front/back porch values - missing the off by one error in the LTDC layer config - and I'm pretty sure some of them might not be entirely aligned with the typical values in the datasheet. Changing them doesn't seem to do all that much, though.