### PR TITLE
Feature/fix 512 - Moved location of TimerCallback execution.

### DIFF
--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -47,7 +47,6 @@ namespace blit {
       if (t->state == Timer::RUNNING){
         if (time > (t->started + t->duration)) { // timer triggered
           if(t->loops == -1){
-            t->callback(*t);
             t->started = time; // reset the start time correcting for any error
           }
           else
@@ -57,8 +56,8 @@ namespace blit {
             if (t->loops == 0){
               t->state = Timer::FINISHED;
             }
-            t->callback(*t);
           }
+          t->callback(*t);
         }
       }
     }

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -46,9 +46,8 @@ namespace blit {
     for (auto t: timers) {
       if (t->state == Timer::RUNNING){
         if (time > (t->started + t->duration)) { // timer triggered
-          t->callback(*t);
-
           if(t->loops == -1){
+            t->callback(*t);
             t->started = time; // reset the start time correcting for any error
           }
           else
@@ -58,6 +57,7 @@ namespace blit {
             if (t->loops == 0){
               t->state = Timer::FINISHED;
             }
+            t->callback(*t);
           }
         }
       }


### PR DESCRIPTION
Proposed Fix #512 

TimerCallback is now executed after t->started set for infinite timers, or after timer has transitioned to FINISHED state for non infinite timers.

This allows the timer callback function to change timer params and restart the timer without it immediately transitioning to FINISHED.

This could be a breaking change for other developers.