### PR TITLE
Update WSL docs a bit

### DIFF
--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -1,16 +1,16 @@
 # Building & Running on Win32 (WSL and MinGW) <!-- omit in toc -->
 
-These instructions cover setting up Windows Subsystem for Linux so that you can cross-compile Windows-compatible binaries with MinGW. This approach is included for completeness but not recommended, since MinGW binaries are statically linked and much larger than the Visual Studio output.
+These instructions cover setting up Windows Subsystem for Linux so that you can cross-compile for 32Blit.
 
 A basic knowledge of the Linux command-line, installing tools and compiling code from source is assumed.
 
-If you're more familiar with Visual Studio then you should [follow the instructions in Windows-VisualStudio.md](Windows-VisualStudio.md)
 
 - [Setting Up](#setting-up)
   - [Windows Subsystem for Linux (WSL)](#windows-subsystem-for-linux-wsl)
   - [Installing requirements inside WSL](#installing-requirements-inside-wsl)
 - [Building & Running on 32Blit](#building--running-on-32blit)
 - [Building & Running Locally](#building--running-locally)
+  - [Installing the MinGW compiler/tools](#installing-the-mingw-compiler-tools)
   - [Installing SDL2 & SDL2_image](#installing-sdl2--sdl2_image)
     - [SDL2](#sdl2)
     - [SDL2_image](#sdl2_image)
@@ -29,15 +29,18 @@ After that, proceed to the Microsoft Store to download Ubuntu for WSL.
 
 ### Installing requirements inside WSL
 
-The following requirements enable cross-compile to 32Blit via ARM GCC and to Windows via MinGW:
+The following requirements enable cross-compile to 32Blit via ARM GCC:
 
+```
+sudo apt install gcc gcc-arm-none-eabi unzip cmake make python3 python3-pip
+pip3 install 32blit construct bitstring
+```
+
+If you are using the older Ubuntu 18.04-based WSL, you will need a newer toolchain than the one provided:
 ```shell
-# Ubuntu 18.04's gcc-arm-none-eabi is too old, this repo backports the one from 19.10
+# This repo backports the toolchain from Ubuntu 19.10
 sudo add-apt-repository ppa:daft-freak/arm-gcc
 sudo apt update
-
-sudo apt install gcc gcc-arm-none-eabi gcc-mingw-w64 g++-mingw-w64 unzip cmake make python3 python3-pip
-pip3 install 32blit construct bitstring
 ```
 
 ## Building & Running on 32Blit
@@ -46,9 +49,21 @@ If you want to run code on 32Blit, you should now refer to [Building & Running O
 
 ## Building & Running Locally
 
-You can use WSL on Windows to cross-compile your project (or any 32Blit example) into a Windows .exe for testing locally.
+You can use WSL on Windows to cross-compile your project (or any 32Blit example) into a Windows .exe for testing locally. This approach is included for completeness but not recommended, since MinGW binaries are statically linked and much larger than the Visual Studio output.
+
+If you're more familiar with Visual Studio then you should [follow the instructions in Windows-VisualStudio.md](Windows-VisualStudio.md)
 
 You will need to cross-compile SDL2 for MinGW and install both it, and SDL2-image.
+
+### Installing the MinGW compiler/tools
+
+The following packages enable cross-compiling to Windows via MinGW:
+(Assuming you have installed the tools for building to 32Blit above.)
+
+```shell
+sudo apt install gcc-mingw-w64 g++-mingw-w64
+```
+
 
 ### Installing SDL2 & SDL2_image
 


### PR DESCRIPTION
Adjust the WSL docs a bit based on some recent questions/comments on Discord.

- Move the MinGW warnings down to when we start talking about MinGW
- Split the package lists for MinGW/ARM
- Update toolchain install to be clearer that you don't need any 3rd party packages on Ubuntu 20.04