### PR TITLE
Remove the dma2d busy check in do_render

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -124,9 +124,10 @@ static void do_render() {
       //if framebuff still occupied by last dma2d flip
     }
     blit::render(blit::now());
-    while (display::is_dma2d_occupied()){
-      //if framebuff still occupied by last dma2d flip
-    }
+    //while (display::is_dma2d_occupied()){
+      //Even in the lowest render work load, we still don't need to check the dma2d statement
+      //Because the dma2d will always finished much earlier than next vblank interrupt
+    //}
     display::enable_vblank_interrupt();
   }
 }


### PR DESCRIPTION
Even in the lowest render work load, we still don't need to check the dma2d statement. Because the dma2d will always finished much earlier than next vblank interrupt. So we could trigger next vblank directly. When next v blank happen, the dma2d is already ready to use.

![image](https://user-images.githubusercontent.com/23138225/103392455-f84e0500-4b58-11eb-85be-c2d521646715.png)


