### PR TITLE
File associations/ extra metadata parsing

### DIFF
--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -89,6 +89,10 @@ uint32_t get_max_us_timer()
 	return UINT32_MAX;
 }
 
+static const char *get_launch_path() {
+  return nullptr; // TODO: argv[1]
+}
+
 // SDL events
 const Uint32 System::timer_event = SDL_RegisterEvents(2);
 const Uint32 System::loop_event = System::timer_event + 1;
@@ -160,6 +164,8 @@ void System::run() {
 
 	blit::api.decode_jpeg_buffer = blit_decode_jpeg_buffer;
 	blit::api.decode_jpeg_file = blit_decode_jpeg_file;
+
+  blit::api.get_launch_path = ::get_launch_path;
 
 	::set_screen_mode(blit::lores);
 

--- a/32blit-stm32/Inc/persistence.h
+++ b/32blit-stm32/Inc/persistence.h
@@ -27,6 +27,8 @@ struct Persist {
   PersistResetTarget reset_target;
   bool reset_error; // last reset was caused by an error
   uint32_t last_game_offset;
+
+  char launch_path[256];
 };
 
 extern Persist persist;

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -118,6 +118,13 @@ uint32_t get_max_us_timer()
 	return UINT32_MAX / uTicksPerUs;
 }
 
+static const char *get_launch_path() {
+  if(!persist.launch_path[0])
+    return nullptr;
+
+  return persist.launch_path;
+}
+
 static void do_render() {
   if(display::needs_render) {
     while (display::is_frameBuff_occupied()){
@@ -231,6 +238,7 @@ void blit_init() {
       persist.reset_target = prtFirmware;
       persist.reset_error = false;
       persist.last_game_offset = 0;
+      memset(persist.launch_path, 0, sizeof(persist.launch_path));
     }
 
 #if (INITIALISE_QSPI==1)
@@ -292,6 +300,7 @@ void blit_init() {
     blit::api.decode_jpeg_buffer = blit_decode_jpeg_buffer;
     blit::api.decode_jpeg_file = blit_decode_jpeg_file;
 
+    blit::api.get_launch_path = ::get_launch_path;
 
   display::init();
 

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -69,6 +69,8 @@ namespace blit {
     bool (*launch)(const char *filename);
     void (*erase_game)(uint32_t offset);
     void *(*get_type_handler_metadata)(const char *filetype);
+
+    const char *(*get_launch_path)();
   };
   #pragma pack(pop)
 

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -68,6 +68,7 @@ namespace blit {
     // launcher APIs - only intended for use by launchers and only available on device
     bool (*launch)(const char *filename);
     void (*erase_game)(uint32_t offset);
+    void *(*get_type_handler_metadata)(const char *filetype);
   };
   #pragma pack(pop)
 

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -38,7 +38,7 @@ namespace blit {
   int debugf(const char * psFormatString, ...) {
     va_list args;
     va_start(args, psFormatString);
-    
+
     // get length
     va_list tmp_args;
     va_copy(tmp_args, args);
@@ -86,6 +86,10 @@ namespace blit {
     last_tick_time = time;
 
     return true;
+  }
+
+  const char *get_launch_path() {
+    return api.get_launch_path();
   }
 
 }

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -27,6 +27,5 @@ namespace blit {
   bool tick(uint32_t time);
   void fast_tick(uint32_t time);
 
-  // hal methods: read_file, reset
-
+  const char *get_launch_path();
 }

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -44,7 +44,8 @@ struct HandlerInfo {
 };
 
 std::vector<GameInfo> game_list;
-std::vector<HandlerInfo> handlers; // flashed games that can "launch" files
+
+std::list<HandlerInfo> handlers; // flashed games that can "launch" files
 
 std::list<std::tuple<uint16_t, uint16_t>> free_space; // block start, count
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -318,6 +318,7 @@ bool launch_game_from_sd(const char *path) {
   }
 
   uint32_t offset = 0xFFFFFFFF;
+  persist.launch_path[0] = 0;
 
   BlitGameMetadata meta;
 
@@ -338,6 +339,9 @@ bool launch_game_from_sd(const char *path) {
 
     if(offset == 0xFFFFFFFF)
       return false;
+
+    // set the path to the file to launch
+    strncpy(persist.launch_path, path, sizeof(persist.launch_path));
 
   } else if(parse_file_metadata(path, meta)) {
     for(auto &flash_game : game_list) {

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -321,7 +321,25 @@ bool launch_game_from_sd(const char *path) {
 
   BlitGameMetadata meta;
 
-  if(parse_file_metadata(path, meta)) {
+  // get the extension (assume there is one)
+  std::string_view sv(path);
+  auto ext = std::string(sv.substr(sv.find_last_of('.') + 1));
+  for(auto &c : ext)
+    c = tolower(c);
+
+  if(ext != "blit") {
+    // find the handler
+    for(auto &handler : handlers) {
+      if(handler.type == ext) {
+        offset = handler.offset;
+        break;
+      }
+    }
+
+    if(offset == 0xFFFFFFFF)
+      return false;
+
+  } else if(parse_file_metadata(path, meta)) {
     for(auto &flash_game : game_list) {
       // if a game with the same name/crc is already installed, launch that one instead of flashing it again
       if(flash_game.checksum == meta.crc32 && flash_game.title == meta.title) {

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -343,6 +343,15 @@ bool launch_game_from_sd(const char *path) {
   return false;
 }
 
+static void *get_type_handler_metadata(const char *filetype) {
+  for(auto &handler : handlers) {
+    if(strncmp(filetype, handler.type, 4) == 0)
+      return (void *)(qspi_flash_address + handler.meta_offset);
+  }
+
+  return nullptr;
+}
+
 static void start_launcher() {
   if(launcher_offset != 0xFFFFFFFF)
     launch_game(launcher_offset);
@@ -354,6 +363,7 @@ static void start_launcher() {
 void init() {
   api.launch = launch_game_from_sd;
   api.erase_game = erase_flash_game;
+  api.get_type_handler_metadata = get_type_handler_metadata;
 
   set_screen_mode(ScreenMode::hires);
   screen.clear();
@@ -385,7 +395,7 @@ void init() {
 
       persist.reset_error = false;
     });
-  } else 
+  } else
     start_launcher();
 }
 

--- a/launcher-shared/CMakeLists.txt
+++ b/launcher-shared/CMakeLists.txt
@@ -3,3 +3,7 @@
 add_library(LauncherShared metadata.cpp)
 target_link_libraries(LauncherShared BlitEngine)
 target_include_directories(LauncherShared PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
+	set_target_properties(LauncherShared PROPERTIES COMPILE_FLAGS "-fPIC -mno-pic-data-is-text-relative -mno-single-pic-base")
+endif()

--- a/launcher-shared/executable.hpp
+++ b/launcher-shared/executable.hpp
@@ -38,6 +38,7 @@ struct RawMetadata {
 // "BLITTYPE"
 struct RawTypeMetadata {
   char category[17];
+  char url[129];
   uint8_t num_filetypes;
   char filetypes[][5];
 };

--- a/launcher-shared/executable.hpp
+++ b/launcher-shared/executable.hpp
@@ -34,3 +34,10 @@ struct RawMetadata {
   char version[17];
   char author[17];
 };
+
+// "BLITTYPE"
+struct RawTypeMetadata {
+  char category[17];
+  uint8_t num_filetypes;
+  char filetypes[][5];
+};

--- a/launcher-shared/metadata.cpp
+++ b/launcher-shared/metadata.cpp
@@ -23,6 +23,17 @@ void parse_metadata(char *data, uint16_t metadata_len, BlitGameMetadata &metadat
   if(unpack_images && metadata.icon)
     metadata.free_surfaces();
 
+  if(offset != metadata_len && memcmp(data + offset, "BLITTYPE", 8) == 0) {
+    auto type_meta = reinterpret_cast<RawTypeMetadata *>(data + offset + 8);
+    offset += sizeof(RawTypeMetadata) + 8 + type_meta->num_filetypes * 5;
+
+    metadata.category = type_meta->category;
+
+    metadata.filetypes.resize(type_meta->num_filetypes);
+    for(int i = 0; i < type_meta->num_filetypes; i++)
+      metadata.filetypes[i] = type_meta->filetypes[i];
+  }
+
   if(offset != metadata_len && unpack_images) {
     // icon/splash
     auto image = reinterpret_cast<packed_image *>(data + offset);

--- a/launcher-shared/metadata.hpp
+++ b/launcher-shared/metadata.hpp
@@ -7,7 +7,9 @@
 struct BlitGameMetadata {
   uint16_t length = 0;
   uint32_t crc32 = 0;
-  std::string title, description, version, author;
+  std::string title, description, version, author, category;
+
+  std::vector<std::string> filetypes;
 
   blit::Surface *icon = nullptr, *splash = nullptr;
 

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -164,13 +164,24 @@ void load_file_list(std::string directory) {
     if (file.name[0] == '.') // hidden file
       continue;
 
-    if(file.name.compare(file.name.length() - 5, 5, ".blit") == 0 || file.name.compare(file.name.length() - 5, 5, ".BLIT") == 0) {
+    auto last_dot = file.name.find_last_of('.');
+
+    // no extension
+    if(last_dot == std::string::npos)
+      continue;
+
+    auto ext = file.name.substr(file.name.find_last_of('.') + 1);
+
+    for(auto &c : ext)
+      c = tolower(c);
+
+    if(ext == "blit") {
 
       GameInfo game;
       game.title = file.name.substr(0, file.name.length() - 5);
       game.filename = directory == "/" ? file.name : directory + "/" + file.name;
       game.size = file.size;
-      
+
       // check for metadata
       BlitGameMetadata meta;
       if(parse_file_metadata(game.filename, meta)) {


### PR DESCRIPTION
Some more stuff related to #435. Adds parsing for the extra metadata from https://github.com/32blit/32blit-tools/pull/51 and support for using a flashed .blit to launch files.

Will conflict with multiplayer as also touching API. Small TODO: use argv for SDL launch path.

Slightly patched emulator I tested with:
[gameboy.zip](https://github.com/pimoroni/32blit-beta/files/5757356/gameboy.zip)

Changes were pretty much:
```c++
auto launchPath = blit::get_launch_path();
if(launchPath)
    openROM(launchPath);
```