### PR TITLE
Rearrange the signals in render process

### DIFF
--- a/32blit-stm32/Inc/display.hpp
+++ b/32blit-stm32/Inc/display.hpp
@@ -1,4 +1,3 @@
-  
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
@@ -30,11 +29,7 @@ namespace display {
   void screen_init();
   void ltdc_init();
 	
-	bool is_dma2d_occupied(void);
-	bool is_frameBuff_occupied(void);
-	uint32_t get_dma2d_count(void);
-	void set_dma2d_state(bool occupied);
-	void set_frameBuff_state(bool occupied);
+  uint32_t get_dma2d_count(void);
   
   void dma2d_lores_flip_Step2(void);
   void dma2d_lores_flip_Step3(void);

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -120,13 +120,7 @@ uint32_t get_max_us_timer()
 
 static void do_render() {
   if(display::needs_render) {
-    while (display::is_frameBuff_occupied()){
-      //if framebuff still occupied by last dma2d flip
-    }
     blit::render(blit::now());
-    while (display::is_dma2d_occupied()){
-      //if framebuff still occupied by last dma2d flip
-    }
     display::enable_vblank_interrupt();
   }
 }

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -333,7 +333,7 @@ namespace display {
 
     // configure ltdc layer        
     LTDC_Layer1->WHPCR &= ~(LTDC_LxWHPCR_WHSTPOS | LTDC_LxWHPCR_WHSPPOS);
-    LTDC_Layer1->WHPCR = ((1 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U) + 1U) | ((321 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U)) << 16U));
+    LTDC_Layer1->WHPCR = ((0 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U) + 1U) | ((320 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U)) << 16U));
     LTDC_Layer1->WVPCR &= ~(LTDC_LxWVPCR_WVSTPOS | LTDC_LxWVPCR_WVSPPOS);
     LTDC_Layer1->WVPCR  = ((0 + (LTDC->BPCR & LTDC_BPCR_AVBP) + 1U) | ((240 + (LTDC->BPCR & LTDC_BPCR_AVBP)) << 16U));  
     LTDC_Layer1->PFCR   = LTDC_PIXEL_FORMAT_RGB565;  


### PR DESCRIPTION
Now we don't need to use need_render / framebuff busy / dma2d busy three signal in controlling. Only one need_render signal! And current setup could avoid any waste in cpu time in flip operation. 
Sorry I need to modified the file one by one in web page. The git cli to github in China is really slow :(