### PR TITLE
Display SD card status and free space in the about menu

### DIFF
--- a/32blit-stm32/Src/SystemMenu/about_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/about_menu.cpp
@@ -8,6 +8,7 @@
 
 #include "32blit.h"
 #include "32blit.hpp"
+#include "ff.h"
 
 using namespace blit;
 
@@ -23,6 +24,7 @@ enum MenuItem {
   FIRMWARE_VERSION,
   FIRMWARE_DATE,
   BLIT_DEVICE_TYPE,
+  SD_CARD
 };
 
 static Menu::Item menu_items[]{
@@ -30,6 +32,7 @@ static Menu::Item menu_items[]{
   { FIRMWARE_DATE, "Date" },
   { Menu::Separator, nullptr },
   { BLIT_DEVICE_TYPE, "Device" },
+  { SD_CARD, "SD Card"}
 };
 
 void AboutMenu::render_item(const Item &item, int y, int index) const {
@@ -52,10 +55,32 @@ void AboutMenu::render_item(const Item &item, int y, int index) const {
   case BLIT_DEVICE_TYPE:
     if(is_beta_unit) {
       screen.text("Beta unit", minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
-    }
-    else {
+    } else {
       screen.text("Retail unit", minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
     }
+    break;
+  case SD_CARD:
+    if(blit_sd_mounted()) {
+      FATFS *fs;
+      DWORD free_clusters;
+      char buf[100];
+
+      auto res = f_getfree("", &free_clusters, &fs);
+
+      if(res == 0) {
+        // assuming 512b sectors
+        uint32_t total_mb = ((fs->n_fatent - 2) * fs->csize) / 2048;
+        uint32_t free_mb = (free_clusters * fs->csize) / 2048;
+
+        snprintf(buf, 100, "%lu/%lu MB free", free_mb, total_mb);
+      } else
+        snprintf(buf, 100, "Unknown %i", res);
+
+      screen.text(buf, minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
+    } else if(blit_sd_detected())
+      screen.text("Not mounted", minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
+    else
+      screen.text("Not inserted", minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);
     break;
   default:
     screen.pen = foreground_colour;


### PR DESCRIPTION
For @lenardg :smile: (Okay, I had a rough idea how to do this and had to do it before I forgot...)

Displays if there is an SD card inserted and if it is, the free/total space (in megabytes). Will also display "not mounted" if it was detected but failed to mount.