### PR TITLE
Fix SDL2_net.framework installation on Mac

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -179,6 +179,7 @@ function(blit_executable NAME SOURCES)
 	    # install the SDL frameworks
 		install(DIRECTORY ${SDL2_LIBRARIES} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
 		install(DIRECTORY ${SDL2_IMAGE_LIBRARY} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
+		install(DIRECTORY ${SDL2_NET_LIBRARY} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
 	endif()
 endfunction()
 


### PR DESCRIPTION
When installing on a Mac, copy `SDL2_net.framework` into the `Game.app/Contents/Frameworks` directory.