### PR TITLE
SDL_net related things

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -23,12 +23,12 @@ else()
 	# attempt to find the framework (find_package won't work as there's no config file)
 	if(APPLE)
 		find_library(SDL2_LIBRARIES NAMES SDL2)
-		
+
 		find_path(SDL2_INCLUDE_DIRS NAMES SDL.h
 			PATHS ~/Library/Frameworks /Library/Frameworks
 		)
 	endif()
-	
+
 	# fallback guess for SDL location on Windows
 	if(WIN32 AND NOT SDL2_DIR AND 32BLIT_PATH)
 		set(SDL2_DIR "${32BLIT_PATH}/vs/sdl")
@@ -112,7 +112,6 @@ if(SDL2_IMAGE_DLL)
 endif()
 
 if(SDL2_NET_DLL)
-	configure_file(${SDL2_NET_DLL} ${CMAKE_BINARY_DIR}/SDL2_net.dll COPYONLY)
 	install(FILES ${SDL2_NET_DLL} DESTINATION bin)
 endif()
 
@@ -166,7 +165,11 @@ function(blit_executable NAME SOURCES)
 
     if(SDL2_IMAGE_DLL)
         configure_file(${SDL2_IMAGE_DLL} ${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.dll COPYONLY)
-    endif()
+	endif()
+
+	if(SDL2_NET_DLL)
+		configure_file(${SDL2_NET_DLL} ${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.dll COPYONLY)
+	endif()
 
 	if(EMSCRIPTEN)
 		set_target_properties(${NAME} PROPERTIES

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -12,7 +12,7 @@ These instructions cover building 32blit on Linux.
 First install the required tools:
 
 ```
-sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev unzip
+sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev libsdl2-net-dev unzip
 
 pip3 install 32blit
 ```

--- a/docs/Windows-VisualStudio.md
+++ b/docs/Windows-VisualStudio.md
@@ -13,13 +13,14 @@ See [Building & Running On 32Blit](32blit.md) if you want to compile examples/pr
 
 ## Requirements
 
-You will need Visual Studio 2019 (preferably version 16.4). 
+You will need Visual Studio 2019 (preferably version 16.4).
 
 Make sure you install C++ desktop development support.
 
-You will also need to download SDL2 development libraries from the [SDL homepage](https://www.libsdl.org/download-2.0.php). Here find the latest version of the VC development libraries (at the time of this writing SDL2-devel-2.0.10-VC.zip). Additionally, download SDL2_image from [here](https://www.libsdl.org/projects/SDL_image/) (SDL2_image-devel-2.0.5-VC.zip).
+You will also need to download SDL2 development libraries from the [SDL homepage](https://www.libsdl.org/download-2.0.php). Here find the latest version of the VC development libraries (at the time of this writing SDL2-devel-2.0.10-VC.zip). Additionally, download SDL2_image from [here](https://www.libsdl.org/projects/SDL_image/) (SDL2_image-devel-2.0.5-VC.zip) and SDL2_net from [here](https://www.libsdl.org/projects/SDL_net/) (SDL2_net-devel-2.0.1-VC.zip).
 
-Place these in the `vs\sdl\` folder. You will need to merge the include/lib directories.
+Place these in the `vs\sdl\` folder. You will need to merge the include/lib directories. If you are using CMake/Open Folder, these are downloaded automatically.
+
 
 There are two methods of building with Visual Studio:
 
@@ -29,7 +30,7 @@ This should be the most familiar option for existing Visual Studio users.
 
 The solutions and projects are made to use toolset version c142.
 
-The solution file is located at `vs\32blit.sln`. It contains two static linked libraries, _32blit_ and _32blit-sdl_ and all the examples that will compile to .EXE. 
+The solution file is located at `vs\32blit.sln`. It contains two static linked libraries, _32blit_ and _32blit-sdl_ and all the examples that will compile to .EXE.
 
 ### Get started with your own game
 

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -11,9 +11,10 @@ A basic knowledge of the Linux command-line, installing tools and compiling code
 - [Building & Running on 32Blit](#building--running-on-32blit)
 - [Building & Running Locally](#building--running-locally)
   - [Installing the MinGW compiler/tools](#installing-the-mingw-compiler-tools)
-  - [Installing SDL2 & SDL2_image](#installing-sdl2--sdl2_image)
+  - [Installing SDL2, SDL2_image and SDL2_net](#installing-sdl2-sdl2_image-and-sdl2_net)
     - [SDL2](#sdl2)
     - [SDL2_image](#sdl2_image)
+    - [SDL2_net](#sdl2_net)
   - [Building](#building)
     - [Single Example](#single-example)
     - [Build Everything](#build-everything)
@@ -65,7 +66,7 @@ sudo apt install gcc-mingw-w64 g++-mingw-w64
 ```
 
 
-### Installing SDL2 & SDL2_image
+### Installing SDL2, SDL2_image and SDL2_net
 
 This will install the SDL2 64bit mingw development headers and libraries into `/opt/local/x86_64-w64-mingw32/`.
 
@@ -95,6 +96,16 @@ Grab and install the SDL2_image mingw development package:
 wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz
 tar xzf SDL2_image-devel-2.0.5-mingw.tar.gz
 sudo cp -r SDL2_image-2.0.5/x86_64-w64-mingw32 /opt/local/
+```
+
+#### SDL2_net
+
+Grab and install the SDL2_net mingw development package:
+
+```shell
+wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-mingw.tar.gz
+tar xzf SDL2_net-devel-2.0.1-mingw.tar.gz
+sudo cp -r SDL2_net-2.0.1/x86_64-w64-mingw32 /opt/local/
 ```
 
 ### Building

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -45,11 +45,11 @@ python3 --version
 ```
 (expected output `Python 3.7.x`)
 
-and 
+and
 ``` shell
 pip3 --version
 ```
-(expected output `pip x.x.x from /usr/local/lib/python3.7/site-packages/pip (python 3.7)` or similar)  
+(expected output `pip x.x.x from /usr/local/lib/python3.7/site-packages/pip (python 3.7)` or similar)
 
 <a name="gcc"/></a>
 ## Installing `gcc-arm-none-eabi`
@@ -72,10 +72,10 @@ If you want to run code on 32Blit, you should now refer to [Building & Running O
 
 ## Building & Running Locally
 
-You'll need to install `SDL2` and `SDL2 Image`
+You'll need to install `SDL2`, `SDL2 Image` and `SDL2 Net`
 
 ``` shell
-brew install sdl2 sdl2_image
+brew install sdl2 sdl2_image sdl2_net
 ```
 
 Then, set up the 32Blit Makefile from the root of the repository with the following commands:


### PR DESCRIPTION
Update some docs and fixup the windows DLL copy. (I should really test that...)

Though macOS docs install SDL+friends through `brew`, while we use the frameworks for CI... May want to cover that in the docs too (since it's currently the easiest way to create a redistributable binary)