### PR TITLE
Added gitignore that ignores asset files for text example when compiled with VS

### DIFF
--- a/vs/examples/.gitignore
+++ b/vs/examples/.gitignore
@@ -1,0 +1,9 @@
+#
+# VS specific gitignore
+#
+
+#
+# Text project asset is named differently
+#
+font_asset.cpp
+font_asset.hpp


### PR DESCRIPTION
The VS build generates some assets for the _text_ example, that were not gitignored. Added a new gitignore file for the VS examples. 