### PR TITLE
Rework toolchain PIC handling

### DIFF
--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -168,6 +168,7 @@ target_compile_definitions(BlitHalSTM32
 target_compile_options(BlitHalSTM32 PUBLIC "$<$<CONFIG:RELEASE>:-Os>")
 target_compile_options(BlitHalSTM32 PUBLIC "$<$<CONFIG:Debug>:-finline-functions-called-once>") # need at least some inlining, otherwise build is too big
 set_target_properties(BlitHalSTM32 PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+set_target_properties(BlitHalSTM32 PROPERTIES POSITION_INDEPENDENT_CODE OFF)
 
 function(blit_executable_int_flash NAME SOURCES)
 	add_executable(${NAME} $<TARGET_OBJECTS:BlitHalSTM32> ${SOURCES} ${ARGN})
@@ -178,6 +179,7 @@ function(blit_executable_int_flash NAME SOURCES)
 
 	set_target_properties(${NAME} PROPERTIES LINK_FLAGS "-specs=nano.specs -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_INT}")
 	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")
+	set_target_properties(${NAME} PROPERTIES POSITION_INDEPENDENT_CODE OFF)
 
 	blit_executable_common(${NAME})
 	target_link_libraries(${NAME} ${NOPIC_STDLIBS})

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -32,7 +32,6 @@ function(blit_executable NAME SOURCES)
 	)
 
 	set_target_properties(${NAME} PROPERTIES
-		COMPILE_FLAGS "-fPIC"
 		LINK_FLAGS "-specs=nano.specs -u _printf_float -fPIC -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT} -Wl,--emit-relocs"
 	)
 	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -20,7 +20,7 @@ function(blit_executable NAME SOURCES)
 	add_executable(${NAME} ${USER_STARTUP} ${SOURCES} ${ARGN})
 
 	# Ideally we want the .blit filename to match the .elf, but TARGET_FILE_BASE_NAME isn't always available
-	# (This only affects the firmware updater as it's the only thing setting a custom OUTPUT_NAME) 
+	# (This only affects the firmware updater as it's the only thing setting a custom OUTPUT_NAME)
 	if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
 		set(BLIT_FILENAME ${NAME}.blit)
 	else()
@@ -32,7 +32,7 @@ function(blit_executable NAME SOURCES)
 	)
 
 	set_target_properties(${NAME} PROPERTIES
-		COMPILE_FLAGS "-fPIC -mno-pic-data-is-text-relative -mno-single-pic-base"
+		COMPILE_FLAGS "-fPIC"
 		LINK_FLAGS "-specs=nano.specs -u _printf_float -fPIC -T ${MCU_LINKER_SCRIPT} ${MCU_LINKER_FLAGS_EXT} -Wl,--emit-relocs"
 	)
 	set_target_properties(${NAME} PROPERTIES LINK_DEPENDS ${MCU_LINKER_SCRIPT} SUFFIX ".elf")

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -33,7 +33,7 @@ set(EXTERNAL_LOAD_ADDRESS_EXT 0x08000000)
 set(INITIALISE_QSPI_EXT 0)
 set(CDC_FIFO_BUFFERS_EXT 4)
 
-set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Werror=double-promotion -Wno-unused-variable -Wno-write-strings")
+set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Werror=double-promotion -Wno-unused-variable -Wno-write-strings -mno-pic-data-is-text-relative -mno-single-pic-base")
 
 set(CMAKE_C_FLAGS_INIT "${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS} -fno-exceptions")

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -87,8 +87,10 @@ if(NOT EXISTS ${STDLIB_PATH}/pic)
     endif()
 endif()
 
-set(PIC_STDLIBS "-nodefaultlibs -L ${STDLIB_PATH}/pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
-set(NONPIC_STDLIBS "-nodefaultlibs -L ${STDLIB_PATH}/no-pic -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
+set(CMAKE_CXX_STANDARD_LIBRARIES_INIT "-nodefaultlibs -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
+
+set(PIC_STDLIBS "-L ${STDLIB_PATH}/pic")
+set(NONPIC_STDLIBS "-L ${STDLIB_PATH}/no-pic")
 
 add_definitions(-DTARGET_32BLIT_HW)
 set(32BLIT_HW 1)

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -43,6 +43,8 @@ set(CMAKE_CXX_FLAGS_DEBUG_INIT "-g -Og")
 
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nosys.specs -Wl,--gc-sections,--no-wchar-size-warning")
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # stdlibs
 set(STDLIB_HASHTYPE "SHA256")
 set(STDLIB_PATH ${CMAKE_CURRENT_LIST_DIR}/stdlib)

--- a/32blit/CMakeLists.txt
+++ b/32blit/CMakeLists.txt
@@ -68,5 +68,5 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
-	set_target_properties(BlitEngine PROPERTIES COMPILE_FLAGS "-fPIC -mno-pic-data-is-text-relative -mno-single-pic-base")
+	set_target_properties(BlitEngine PROPERTIES COMPILE_FLAGS "-fPIC")
 endif()

--- a/32blit/CMakeLists.txt
+++ b/32blit/CMakeLists.txt
@@ -66,7 +66,3 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
     -wd4244 # conversions
   )
 endif()
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
-	set_target_properties(BlitEngine PROPERTIES COMPILE_FLAGS "-fPIC")
-endif()

--- a/launcher-shared/CMakeLists.txt
+++ b/launcher-shared/CMakeLists.txt
@@ -3,7 +3,3 @@
 add_library(LauncherShared metadata.cpp)
 target_link_libraries(LauncherShared BlitEngine)
 target_include_directories(LauncherShared PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
-	set_target_properties(LauncherShared PROPERTIES COMPILE_FLAGS "-fPIC")
-endif()

--- a/launcher-shared/CMakeLists.txt
+++ b/launcher-shared/CMakeLists.txt
@@ -5,5 +5,5 @@ target_link_libraries(LauncherShared BlitEngine)
 target_include_directories(LauncherShared PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
-	set_target_properties(LauncherShared PROPERTIES COMPILE_FLAGS "-fPIC -mno-pic-data-is-text-relative -mno-single-pic-base")
+	set_target_properties(LauncherShared PROPERTIES COMPILE_FLAGS "-fPIC")
 endif()


### PR DESCRIPTION
To make libraries work without needing to add the PIC flags manually. Also fixes undefined symbol errors due to linking the stdlibs in the wrong place.