### PR TITLE
Small game launch related fixes

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -656,6 +656,8 @@ void blit_switch_execution(uint32_t address, bool force_game)
       user_render = (BlitRenderFunction) ((uint8_t *)game_header->render + address);
       user_tick = (BlitTickFunction) ((uint8_t *)game_header->tick + address);
 
+      persist.last_game_offset = address;
+
       if(!init(address)) {
         user_render = nullptr;
         user_tick = nullptr;
@@ -665,8 +667,6 @@ void blit_switch_execution(uint32_t address, bool force_game)
         NVIC_SystemReset();
         return;
       }
-
-      persist.last_game_offset = address;
 
       blit::render = user_render;
       do_tick = user_tick;

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -282,6 +282,8 @@ void launch_game(uint32_t address) {
 
 bool launch_game_from_sd(const char *path) {
 
+  persist.launch_path[0] = 0;
+
   if(strncmp(path, "flash:/", 7) == 0) {
     blit_switch_execution(atoi(path + 7) * qspi_flash_sector_size, true);
     return true;
@@ -294,7 +296,6 @@ bool launch_game_from_sd(const char *path) {
 
   uint32_t launch_offset = 0xFFFFFFFF;
   uint32_t flash_offset = launch_offset;
-  persist.launch_path[0] = 0;
 
   // get the extension (assume there is one)
   std::string_view sv(path);


### PR DESCRIPTION
First one makes sure the save path is for the current game, instead of the previous one in `init`. Fixes a bug where if you exited a game with saves, the launcher would load that as it's theme...

Second one prevents games launched from flash from getting whatever that least launch path was... or junk...