### PR TITLE
VS docs + VS cross-build

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -51,9 +51,11 @@ set(STDLIB_PATH ${CMAKE_CURRENT_LIST_DIR}/stdlib)
 set(STDLIB_URL https://github.com/32blit/stdlibs/releases/download/newlib-3.3.0-gcc-9.2.0/stdlibs.zip)
 set(STDLIB_HASH "${STDLIB_HASHTYPE}=0431fa7b3fe5e463424078546560b06490890abf4967745ac85b8b6b430d1941")
 
-find_program(UNZIP NAMES unzip)
-if(NOT UNZIP)
-    message(FATAL_ERROR "Failed to find required program: \"unzip\"\n(maybe you need to \"apt install unzip\")\n")
+if(${CMAKE_VERSION} VERSION_LESS "3.18")
+    find_program(UNZIP NAMES unzip)
+    if(NOT UNZIP)
+        message(FATAL_ERROR "Failed to find required program: \"unzip\"\n(maybe you need to \"apt install unzip\")\n")
+    endif()
 endif()
 
 # file() is great, but it doesn't tell the user what it's downloading
@@ -77,10 +79,12 @@ endif()
 if(NOT EXISTS ${STDLIB_PATH}/pic)
     message("Extracting stdlibs...")
 
-    # CMake 3.18
-    #file(ARCHIVE_EXTRACT INPUT ${STDLIB_PATH}/stdlibs.zip DESTINATION ${STDLIB_PATH})
-
-    execute_process(COMMAND ${UNZIP} -u ${STDLIB_PATH}/stdlibs.zip -d ${STDLIB_PATH} RESULT_VARIABLE UNZIP_STATUS)
+    if(${CMAKE_VERSION} VERSION_LESS "3.18")
+        execute_process(COMMAND ${UNZIP} -u ${STDLIB_PATH}/stdlibs.zip -d ${STDLIB_PATH} RESULT_VARIABLE UNZIP_STATUS)
+    else()
+        file(ARCHIVE_EXTRACT INPUT ${STDLIB_PATH}/stdlibs.zip DESTINATION ${STDLIB_PATH})
+        set(UNZIP_STATUS 0)
+    endif()
 
     if(NOT ${UNZIP_STATUS} EQUAL 0)
         message(FATAL_ERROR "Failed to extract stdlibs: ${UNZIP_STATUS}\n")

--- a/docs/Windows-VisualStudio.md
+++ b/docs/Windows-VisualStudio.md
@@ -8,7 +8,8 @@ See [Building & Running On 32Blit](32blit.md) if you want to compile examples/pr
 - [Option 1: Use the solution file](#option-1-use-the-solution-file)
   - [Get started with your own game](#get-started-with-your-own-game)
 - [Option 2: Use Visual Studio's built-in CMake support](#option-2-use-visual-studios-built-in-cmake-support)
-  - [Building your own game](#building-with-your-own-game)
+  - [Building your own game](#building-your-own-game)
+  - [Building for 32Blit](#building-for-32blit)
 - [Troubleshooting](#troubleshooting)
 
 ## Requirements
@@ -69,6 +70,22 @@ To find the built files use `Project` > `CMake Cache` > `Open in Explorer`.
 9. Build!
 
 [More info about using CMake with Visual Studio](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019)
+
+### Building for 32Blit
+
+1. Make sure the "Embedded and IoT development tools" component is installed.
+
+2. Open the CMake Settings (see above).
+
+3. Press "Add a new configuration..." and select "IoT-Release".
+
+4. Scroll down to "CMake toolchain file" and browse to `32blit.toolchain`
+
+5. (Optional) Change configuration name to something like "32Blit-Release"
+
+6. Save.
+
+7. Select the new config and build!
 
 ## Troubleshooting
 

--- a/docs/Windows-VisualStudio.md
+++ b/docs/Windows-VisualStudio.md
@@ -62,9 +62,11 @@ To find the built files use `Project` > `CMake Cache` > `Open in Explorer`.
 
 6. Browse to the folder containing the 32blit repo.
 
-7. Save. It should configure successfully.
+7. To add a release configuration, press "Add a new configuration..." (the plus button under "Configurations"), select "x64-Release" and repeat steps 4-6 on the new configuration.
 
-8. Build!
+8. Save. It should configure successfully.
+
+9. Build!
 
 [More info about using CMake with Visual Studio](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019)
 


### PR DESCRIPTION
Mentions adding a release config in the setup docs and adds some info about doing a cross-build (I've tested that this at least builds...). Had to patch the toolchain to work around the lack of `unzip` though.

(Maybe the boilerplate should have a CMakeSettings.json with a reasonable set of configs and placehholder paths?)