### PR TITLE
hires -> lores mode change fix

### DIFF
--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -88,6 +88,12 @@ namespace display {
   }
 
   void enable_vblank_interrupt() {
+    // set new mode after rendering first frame in it
+    if(mode != requested_mode) {
+      mode = requested_mode;
+      need_ltdc_mode_update = true;
+    }
+
     // trigger interrupt when screen refresh reaches the 252nd scanline
     LTDC->LIPCR = 252;
 
@@ -292,12 +298,6 @@ namespace display {
       dma2d_hires_flip(source);
     } else {
       dma2d_hires_pal_flip(source);
-    }
-
-    // set new mode after displaying last frame in the old one
-    if(mode != requested_mode) {
-      mode = requested_mode;
-      need_ltdc_mode_update = true;
     }
   }
 

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -27,12 +27,12 @@ void LTDC_IRQHandler() {
 
 void DMA2D_IRQHandler(void){
   //clear the flag
-	
+
   DMA2D->IFCR = (uint32_t)(0x1F);
 	uint32_t count = display::get_dma2d_count();
 	switch(count){
 		case 3:
-			display::needs_render = true; 
+			display::needs_render = true;
 			display::dma2d_lores_flip_Step2();
 			break;
 		case 2:
@@ -45,20 +45,17 @@ void DMA2D_IRQHandler(void){
 			CLEAR_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);//disable the DMA2D interrupt
 			//set occupied to free
 			if (display::mode != ScreenMode::lores){
-              display::needs_render = true;
-            }
-             
-	
+        display::needs_render = true;
+      }
 	}
-	
-}
 
+}
 
 namespace display {
 	void update_ltdc_for_mode();
-	
+
   __IO uint32_t dma2d_stepCount = 0;
-  
+
   // lo and hi res screen back buffers
   Surface __fb_hires((uint8_t *)&__fb_start, PixelFormat::RGB, Size(320, 240));
   Surface __fb_hires_pal((uint8_t *)&__fb_start, PixelFormat::P, Size(320, 240));
@@ -87,9 +84,9 @@ namespace display {
     ltdc_init();
     screen_init();
 
-    needs_render = true; 
+    needs_render = true;
   }
-  
+
   void enable_vblank_interrupt() {
     // trigger interrupt when screen refresh reaches the 252nd scanline
     LTDC->LIPCR = 252;
@@ -124,54 +121,54 @@ namespace display {
   }
 
   void dma2d_hires_flip(const Surface &source) {
-    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)(source.data), 320 * 240 * 3); 
+    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)(source.data), 320 * 240 * 3);
     // set the transform type (clear bits 17..16 of control register)
     MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M_PFC);
     // set source pixel format (clear bits 3..0 of foreground format register)
     MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB888);
     // set source buffer address
-    DMA2D->FGMAR = (uintptr_t)source.data; 
+    DMA2D->FGMAR = (uintptr_t)source.data;
     // set target pixel format (clear bits 3..0 of output format register)
     MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_RGB565);
     // set target buffer address
     DMA2D->OMAR = (uintptr_t)&__ltdc_start;
-    // set the number of pixels per line and number of lines    
+    // set the number of pixels per line and number of lines
     DMA2D->NLR = (320 << 16) | (240);
     // set the source offset
     DMA2D->FGOR = 0;
     // set the output offset
     DMA2D->OOR = 0;
 		//enable the DMA2D interrupt
-	SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);
+	  SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);
 		//set DMA2d steps //set occupied
     dma2d_stepCount = 0;
     // trigger start of dma2d transfer
     DMA2D->CR |= DMA2D_CR_START;
   }
-  
+
   void dma2d_hires_pal_flip(const Surface &source) {
     // copy RGBA at quarter width
     // work as 32bit type to save some bandwidth
-    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)(source.data), 320 * 240 * 1);  
+    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)(source.data), 320 * 240 * 1);
     // set the transform type (clear bits 17..16 of control register)
     MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
     // set source pixel format (clear bits 3..0 of foreground format register)
     MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_ARGB8888);
     // set source buffer address
-    DMA2D->FGMAR = (uintptr_t)source.data; 
+    DMA2D->FGMAR = (uintptr_t)source.data;
     // set target pixel format (clear bits 3..0 of output format register)
     MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_ARGB8888);
     // set target buffer address
     DMA2D->OMAR = (uintptr_t)((uint32_t)&__ltdc_start + 320 * 240 * 1);
-    // set the number of pixels per line and number of lines    
+    // set the number of pixels per line and number of lines
     DMA2D->NLR = (80 << 16) | (240);
     // set the source offset
     DMA2D->FGOR = 0;
     // set the output offset
     DMA2D->OOR = 0;
     //enable the DMA2D interrupt
-	SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);
-		//set DMA2d steps //set occupied	
+	  SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);
+		//set DMA2d steps //set occupied
     dma2d_stepCount = 0;
     // trigger start of dma2d transfer
     DMA2D->CR |= DMA2D_CR_START;
@@ -182,49 +179,48 @@ namespace display {
       }
       LTDC->SRCR = LTDC_SRCR_IMR;
       palette_needs_update = 0;
-    }	
+    }
   }
 
   void dma2d_lores_flip(const Surface &source) {
-    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)(source.data), 160 * 120 * 3); 
+    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)(source.data), 160 * 120 * 3);
     //Step 1.
     // set the transform type (clear bits 17..16 of control register)
     MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M_PFC);
     // set source pixel format (clear bits 3..0 of foreground format register)
     MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB888);
     // set source buffer address
-    DMA2D->FGMAR = (uintptr_t)source.data; 
+    DMA2D->FGMAR = (uintptr_t)source.data;
     // set target pixel format (clear bits 3..0 of output format register)
     MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_RGB565);
     // set target buffer address
     DMA2D->OMAR = ((uintptr_t)&__ltdc_start)+320*120*2;
-    // set the number of pixels per line and number of lines    
+    // set the number of pixels per line and number of lines
     DMA2D->NLR = (1 << 16) | (160*120);
     // set the source offset
     DMA2D->FGOR = 0;
     // set the output offset
     DMA2D->OOR = 1;
-	SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);//enable the DMA2D interrupt
+	  SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);//enable the DMA2D interrupt
 		//set DMA2d steps //set occupied
     dma2d_stepCount = 3;
     // trigger start of dma2d transfer
     DMA2D->CR |= DMA2D_CR_START;
   }
-	
-	
+
 	void dma2d_lores_flip_Step2(void){
-		//Step 2.  
+		//Step 2.
 			// set the transform type (clear bits 17..16 of control register)
 		MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
 			// set source pixel format (clear bits 3..0 of foreground format register)
 		MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB565);
 			// set source buffer address
-		DMA2D->FGMAR = ((uintptr_t)&__ltdc_start)+320*120*2; 
+		DMA2D->FGMAR = ((uintptr_t)&__ltdc_start)+320*120*2;
 			// set target pixel format (clear bits 3..0 of output format register)
 		MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_RGB565);
 			// set target buffer address
 		DMA2D->OMAR =  ((uintptr_t)&__ltdc_start)+320*120*2 + 2;
-			// set the number of pixels per line and number of lines    
+			// set the number of pixels per line and number of lines
 		DMA2D->NLR = (1 << 16) | (160*120);
 			// set the source offset
 		DMA2D->FGOR = 1;
@@ -235,27 +231,24 @@ namespace display {
 		DMA2D->CR |= DMA2D_CR_START;
 	}
 
-
-
-
 	void dma2d_lores_flip_Step3(void){
 		//step 3.
 		// set the transform type (clear bits 17..16 of control register)
-        MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
+    MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
     // set source pixel format (clear bits 3..0 of foreground format register)
-        MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_ARGB8888);
+    MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_ARGB8888);
     // set source buffer address
-        DMA2D->FGMAR = ((uintptr_t)&__ltdc_start)+320*120*2; 
+    DMA2D->FGMAR = ((uintptr_t)&__ltdc_start)+320*120*2;
     // set target pixel format (clear bits 3..0 of output format register)
-        MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_ARGB8888);
+    MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_ARGB8888);
     // set target buffer address
-        DMA2D->OMAR =  ((uintptr_t)&__ltdc_start);
-    // set the number of pixels per line and number of lines    
-        DMA2D->NLR = (160 << 16) | (120);
+    DMA2D->OMAR =  ((uintptr_t)&__ltdc_start);
+    // set the number of pixels per line and number of lines
+    DMA2D->NLR = (160 << 16) | (120);
     // set the source offset
-        DMA2D->FGOR = 0;
+    DMA2D->FGOR = 0;
     // set the output offset
-        DMA2D->OOR = 160;
+    DMA2D->OOR = 160;
 		dma2d_stepCount = 1;
 			// trigger start of dma2d transfer
 		DMA2D->CR |= DMA2D_CR_START;
@@ -264,28 +257,27 @@ namespace display {
 
 	void dma2d_lores_flip_Step4(void){
 		// set the transform type (clear bits 17..16 of control register)
-        MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
+    MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
     // set source pixel format (clear bits 3..0 of foreground format register)
-        MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_ARGB8888);//same as step 3, skip it
+    MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_ARGB8888);//same as step 3, skip it
     // set source buffer address
-        DMA2D->FGMAR = ((uintptr_t)&__ltdc_start); 
+    DMA2D->FGMAR = ((uintptr_t)&__ltdc_start);
     // set target pixel format (clear bits 3..0 of output format register)
-        MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_ARGB8888);//same as step 3, skip it
+    MODIFY_REG(DMA2D->OPFCCR, DMA2D_OPFCCR_CM, LL_DMA2D_OUTPUT_MODE_ARGB8888);//same as step 3, skip it
     // set target buffer address
-        DMA2D->OMAR =  ((uintptr_t)&__ltdc_start)+320*2;
-    // set the number of pixels per line and number of lines    
-        DMA2D->NLR = (160 << 16) | (120);
+    DMA2D->OMAR =  ((uintptr_t)&__ltdc_start)+320*2;
+    // set the number of pixels per line and number of lines
+    DMA2D->NLR = (160 << 16) | (120);
     // set the source offset
-        DMA2D->FGOR = 160;
+    DMA2D->FGOR = 160;
     // set the output offset
-        DMA2D->OOR = 160;
+    DMA2D->OOR = 160;
 		dma2d_stepCount = 0;
-			// trigger start of dma2d transfer
+		// trigger start of dma2d transfer
 		DMA2D->CR |= DMA2D_CR_START;
-
 	}
 
-  void flip(const Surface &source) {        
+  void flip(const Surface &source) {
     static uint32_t flip_time = 0;
 
     // switch colour mode if needed
@@ -294,9 +286,9 @@ namespace display {
       need_ltdc_mode_update = false;
     }
 
-    if(mode == ScreenMode::lores) {  
+    if(mode == ScreenMode::lores) {
       dma2d_lores_flip(source);
-    } else if(mode == ScreenMode::hires) {      
+    } else if(mode == ScreenMode::hires) {
       dma2d_hires_flip(source);
     } else {
       dma2d_hires_pal_flip(source);
@@ -316,7 +308,7 @@ namespace display {
 
   // configure ltdc peripheral setting up the clocks, pin states, panel
   // parameters, and layers
-  void ltdc_init() { 
+  void ltdc_init() {
 
     // enable ltdc clock
     __HAL_RCC_LTDC_CLK_ENABLE();
@@ -331,12 +323,12 @@ namespace display {
     // enable ltdc transfer and fifo underrun error interrupts
     LTDC->IER = LTDC_IT_TE | LTDC_IT_FU;
 
-    // configure ltdc layer        
+    // configure ltdc layer
     LTDC_Layer1->WHPCR &= ~(LTDC_LxWHPCR_WHSTPOS | LTDC_LxWHPCR_WHSPPOS);
     LTDC_Layer1->WHPCR = ((0 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U) + 1U) | ((320 + ((LTDC->BPCR & LTDC_BPCR_AHBP) >> 16U)) << 16U));
     LTDC_Layer1->WVPCR &= ~(LTDC_LxWVPCR_WVSTPOS | LTDC_LxWVPCR_WVSPPOS);
-    LTDC_Layer1->WVPCR  = ((0 + (LTDC->BPCR & LTDC_BPCR_AVBP) + 1U) | ((240 + (LTDC->BPCR & LTDC_BPCR_AVBP)) << 16U));  
-    LTDC_Layer1->PFCR   = LTDC_PIXEL_FORMAT_RGB565;  
+    LTDC_Layer1->WVPCR  = ((0 + (LTDC->BPCR & LTDC_BPCR_AVBP) + 1U) | ((240 + (LTDC->BPCR & LTDC_BPCR_AVBP)) << 16U));
+    LTDC_Layer1->PFCR   = LTDC_PIXEL_FORMAT_RGB565;
     LTDC_Layer1->DCCR   = 0xff000000;     // layer default color (back, 100% alpha)
     LTDC_Layer1->CFBAR  = (uint32_t)&__ltdc_start;  // frame buffer start address
     LTDC_Layer1->CFBLR  = ((320 * 2) << LTDC_LxCFBLR_CFBP_Pos) | (((320 * 2) + 7) << LTDC_LxCFBLR_CFBLL_Pos);  // frame buffer line length and pitch
@@ -345,10 +337,10 @@ namespace display {
     LTDC_Layer1->CR    |= LTDC_LxCR_LEN;  // enable layer
 
     // reload shadow registers
-    LTDC->SRCR = LTDC_SRCR_IMR;     
+    LTDC->SRCR = LTDC_SRCR_IMR;
 
-    // enable LTDC      
-    LTDC->GCR |= LTDC_GCR_LTDCEN;   
+    // enable LTDC
+    LTDC->GCR |= LTDC_GCR_LTDCEN;
   }
 
   void update_ltdc_for_mode() {
@@ -366,9 +358,7 @@ namespace display {
 
     LTDC->SRCR = LTDC_SRCR_IMR;
   }
-	
-	
-	
+
 	uint32_t get_dma2d_count(void){
 		return dma2d_stepCount;
 	}


### PR DESCRIPTION
Moves the mode update even later (after the next render), which better matches what I intended to do in the first place. (Not flip in the new mode until something was rendered in it).

Fixes doing a hires -> lores switch.


Also changes a bunch of whitespace since VS Code refuses to leave that alone now...