### PR TITLE
Misc BMP/screenshot/surface fixes

### DIFF
--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -768,12 +768,15 @@ namespace blit {
 
     auto ret = new Surface(data, format, bounds);
 
-    if(top_down)
+    int bmp_stride = header.w * (header.bpp / 8);
+    bmp_stride = (bmp_stride + 3) & ~3; // round to a multiple of 4;
+
+    if(top_down && bmp_stride == ret->row_stride)
       file.read(header.data_offset, header.image_size, (char *)data);
     else {
       for(int y = 0; y < bounds.h; y++) {
-        int off = (bounds.h - 1 - y) * ret->row_stride;
-        file.read(header.data_offset + y * ret->row_stride, ret->row_stride, (char *)data + off);
+        int off = top_down ? y * ret->row_stride : (bounds.h - 1 - y) * ret->row_stride;
+        file.read(header.data_offset + y * bmp_stride, ret->row_stride, (char *)data + off);
       }
     }
 

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -620,10 +620,11 @@ namespace blit {
     if (is_raw) {
       if(readonly) // just read/copy the data
         ret->data = (uint8_t *)file.get_ptr() + offset;
-      else
+      else {
         if(!ret->data)
           ret->data = new uint8_t[pixel_format_stride[image.format] * image.width * image.height];
         file.read(offset, image.width * image.height * pixel_format_stride[image.format], (char *)ret->data);
+      }
 
       return ret;
     }

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -67,7 +67,7 @@ namespace blit {
       return nullptr;
 
     File file((const uint8_t *)image, image->byte_count);
-    return load_from_packed(file, data, true);
+    return load_from_packed(file, data);
   }
 
   /**

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -73,15 +73,6 @@ namespace blit {
   /**
    * \overload
    *
-   * \param data pointer to an image asset
-   */
-  Surface *Surface::load(const uint8_t *image, uint8_t *data, size_t data_size) {
-    return load((const packed_image *)image, data, data_size);
-  }
-
-  /**
-   * \overload
-   *
    * \param filename string filename
    */
   Surface *Surface::load(const std::string &filename, uint8_t *data, size_t data_size) {
@@ -119,15 +110,6 @@ namespace blit {
 
     File file((const uint8_t *)image, image->byte_count);
     return load_from_packed(file, nullptr, 0, true);
-  }
-
-  /**
-   * \overload
-   *
-   * \param data pointer to an image asset
-   */
-  Surface *Surface::load_read_only(const uint8_t *image) {
-    return load_read_only((const packed_image *)image);
   }
 
   bool Surface::save(const std::string &filename) {
@@ -594,7 +576,7 @@ namespace blit {
     Size bounds = Size(image.width, image.height);
 
     auto needed_size = pixel_format_stride[image.format] * image.width * image.height;
-    if(data_size && needed_size > data_size)
+    if(data && needed_size > data_size)
       return nullptr;
 
     auto ret = new Surface(data, format, bounds);
@@ -765,7 +747,7 @@ namespace blit {
     bool top_down = header.h < 0;
     Size bounds(header.w, top_down ? -header.h : header.h);
 
-    if(data_size && header.image_size > data_size)
+    if(data && header.image_size > data_size)
       return nullptr;
 
     // bitfields

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -119,13 +119,16 @@ namespace blit {
   public:
     Surface(uint8_t *data, const PixelFormat &format, const Size &bounds);
 
-    static Surface *load(const std::string &filename, uint8_t *data = nullptr, size_t data_size = 0);
+    static Surface *load(const std::string &filename, uint8_t *data, size_t data_size);
+    static Surface *load(const std::string &filename) {return load(filename, nullptr, 0);};
 
-    static Surface *load(const packed_image *image, uint8_t *data = nullptr, size_t data_size = 0);
-    static Surface *load(const uint8_t *image, uint8_t *data = nullptr, size_t data_size = 0);
+    static Surface *load(const packed_image *image, uint8_t *data, size_t data_size);
+    static Surface *load(const packed_image *image) {return load(image, nullptr, 0);};
+    static Surface *load(const uint8_t *image, uint8_t *data, size_t data_size) {return load((packed_image *)image, data, data_size);};
+    static Surface *load(const uint8_t *image) {return load((packed_image *)image, nullptr, 0);};
 
     static Surface *load_read_only(const packed_image *image);
-    static Surface *load_read_only(const uint8_t *image);
+    static Surface *load_read_only(const uint8_t *image) {return load_read_only((packed_image *)image);};
 
     bool save(const std::string &filename);
 

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -113,16 +113,16 @@ namespace blit {
   private:
     void init();
 
-    static Surface *load_from_bmp(File &file, uint8_t *data=nullptr);
-    static Surface *load_from_packed(File &file, uint8_t *data=nullptr, bool readonly=false);
+    static Surface *load_from_bmp(File &file, uint8_t *data, size_t data_size);
+    static Surface *load_from_packed(File &file, uint8_t *data, size_t data_size, bool readonly);
 
   public:
     Surface(uint8_t *data, const PixelFormat &format, const Size &bounds);
-  
-    static Surface *load(const std::string &filename, uint8_t *data=nullptr);
-  
-    static Surface *load(const packed_image *image, uint8_t *data=nullptr);
-    static Surface *load(const uint8_t *image, uint8_t *data=nullptr);
+
+    static Surface *load(const std::string &filename, uint8_t *data = nullptr, size_t data_size = 0);
+
+    static Surface *load(const packed_image *image, uint8_t *data = nullptr, size_t data_size = 0);
+    static Surface *load(const uint8_t *image, uint8_t *data = nullptr, size_t data_size = 0);
 
     static Surface *load_read_only(const packed_image *image);
     static Surface *load_read_only(const uint8_t *image);
@@ -175,7 +175,7 @@ namespace blit {
     //void sprite(spritesheet &ss, uint16_t index, point pos, size span = size(1, 1), point origin = point(0, 0), float scale = 1.0f);
     //void sprite(spritesheet &ss, point sprite, point position, sprite_p &properties);
 
-    Rect sprite_bounds(uint16_t index);          
+    Rect sprite_bounds(uint16_t index);
     Rect sprite_bounds(const Point &p);
     Rect sprite_bounds(const Rect &r);
 

--- a/examples/flight/flight.cpp
+++ b/examples/flight/flight.cpp
@@ -71,10 +71,10 @@ void init() {
   map.layers["ground"].transforms = layer_transforms;
 
   // Load our map sprites into the __sprites space we've reserved
-  sprites = Surface::load(packed_data, __sprites);
+  sprites = Surface::load(packed_data, __sprites, sizeof(__sprites));
   sprites->generate_mipmaps(3);
 
-  water = Surface::load(water_packed_data, __water);
+  water = Surface::load(water_packed_data, __water, sizeof(__water));
 
   // extract information about objects from the map data
   Point p;

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -261,7 +261,7 @@ void load_current_game_metadata() {
         screenshot = nullptr;
       }
       // Load the new screenshot
-      screenshot = Surface::load(selected_game.filename, screenshot_buf);
+      screenshot = Surface::load(selected_game.filename, screenshot_buf, sizeof(screenshot_buf));
     }
   } else {
     // Not showing a screenshot, free the buffers

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -394,7 +394,7 @@ void render(uint32_t time) {
     swoosh(time, 5100.0f, 3900.0f, 900.0f, 1100.0f, 5000);
   }
 
-  if(!game_list.empty() && selected_game.type == GameType::screenshot) {
+  if(!game_list.empty() && selected_game.type == GameType::screenshot && screenshot) {
     if(screenshot->bounds.w == screen.bounds.w) {
       screen.blit(screenshot, Rect(Point(0, 0), screenshot->bounds), Point(0, 0));
     } else {


### PR DESCRIPTION
Mostly discovered by all the random junk on my SD... First two are the most important, the other two just expand BMP support a little.

Not fixed:
- Having an image that doesn't fit in the static buffer on your SD card explodes.
- Paletted BMPs can't have alpha, which is not really a problem for screenshots, but the "alpha" field is written as 0 from most editors...