### PR TITLE
Only delete old firmware when not launching something

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -253,7 +253,7 @@ void scan_flash() {
         launcher_offset = offset;
 
       // remove old firmware updates
-      if(strcmp(game.title, "Firmware Updater") == 0) {
+      if(strcmp(game.title, "Firmware Updater") == 0 && persist.reset_target == 0) {
         int size_blocks = calc_num_blocks(game.size);
 
         erase_qspi_flash(offset / qspi_flash_sector_size, size_blocks * qspi_flash_sector_size);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -253,7 +253,7 @@ void scan_flash() {
         launcher_offset = offset;
 
       // remove old firmware updates
-      if(strcmp(game.title, "Firmware Updater") == 0 && persist.reset_target == 0) {
+      if(strcmp(game.title, "Firmware Updater") == 0 && persist.reset_target == prtFirmware) {
         int size_blocks = calc_num_blocks(game.size);
 
         erase_qspi_flash(offset / qspi_flash_sector_size, size_blocks * qspi_flash_sector_size);


### PR DESCRIPTION
I was having an issue where running firmware-update-v0.1.8.blit, or `make firmware-update.flash` would jump my 32blit into a semi broken state.

I believe - when not launching `firmware-update.blit` from SD card - that the firmware updater was being deleted from flash before it had a chance to be run.

This patch changes that behaviour so old updates are only deleted when the reset_target is 0.

Users on v0.1.8 will have to copy `firmware-update.blit` to SD card and reset to update, either via `32blit firmware-update.blit` or just a file copy over MSD/direct onto the card.