### PR TITLE
Assorted tweaks to firmware->launcher behaviour

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -253,7 +253,7 @@ void scan_flash() {
         launcher_offset = offset;
 
       // remove old firmware updates
-      if(strcmp(game.title, "Firmware Updater") == 0) {
+      if(strcmp(game.title, "Firmware Updater") == 0 && persist.reset_target == 0) {
         int size_blocks = calc_num_blocks(game.size);
 
         erase_qspi_flash(offset / qspi_flash_sector_size, size_blocks * qspi_flash_sector_size);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -399,9 +399,6 @@ static void *get_type_handler_metadata(const char *filetype) {
 static void start_launcher() {
   if(launcher_offset != 0xFFFFFFFF)
     launch_game(launcher_offset);
-  // no launcher flashed, try to find one on the SD card
-  else if(::file_exists("launcher.blit"))
-    launch_game_from_sd("launcher.blit");
 }
 
 // used for updates

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -502,7 +502,7 @@ void render(uint32_t time) {
 
     screen.pen = Pen(255, 255, 255);
     screen.text(
-      "No launcher found!\n\nFlash one with 32blit flash\n or place launcher.blit on your SD card.",
+      "Please flash a launcher!\n\nUse \"32blit flash launcher.blit\"\nor place launcher.blit on your SD card.",
       minimal_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center
     );
   }
@@ -991,8 +991,13 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
                       meta.size = header.end - qspi_flash_address;
                       if(parse_flash_metadata(flash_start_offset, meta)) {
                         for(auto &game : game_list) {
-                          if(strcmp(game.title, meta.title) == 0 && strcmp(game.author, meta.author) == 0 && game.offset != flash_start_offset)
+                          if(strcmp(game.title, meta.title) == 0 && strcmp(game.author, meta.author) == 0 && game.offset != flash_start_offset) {
                             erase_qspi_flash(game.offset / qspi_flash_sector_size, game.size);
+                          }
+                          else if(strcmp(game.category, "launcher") == 0 && strcmp(meta.category, "launcher") == 0) {
+                            // flashing a launcher, remove previous launchers
+                            erase_qspi_flash(game.offset / qspi_flash_sector_size, game.size);
+                          }
                         }
                       }
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -33,6 +33,7 @@ extern USBManager g_usbManager;
 
 struct GameInfo {
   char title[25], author[17];
+  char category[17];
   uint32_t size = 0, checksum = 0;
 
   uint32_t offset = ~0;
@@ -98,6 +99,8 @@ bool parse_flash_metadata(uint32_t offset, GameInfo &info) {
   RawTypeMetadata type_meta;
   if(qspi_read_buffer(offset + 8, reinterpret_cast<uint8_t *>(&type_meta), sizeof(RawTypeMetadata)) != QSPI_OK)
     return false;
+
+  memcpy(info.category, type_meta.category, sizeof(info.category));
 
   offset += 8 + sizeof(RawTypeMetadata);
 
@@ -249,7 +252,7 @@ void scan_flash() {
     // check for valid metadata
     if(parse_flash_metadata(offset, game)) {
       // find the launcher
-      if(strcmp(game.title, "Launcher") == 0)
+      if(strcmp(game.category, "launcher") == 0)
         launcher_offset = offset;
 
       // remove old firmware updates
@@ -450,9 +453,9 @@ void init() {
 
   // then launcher updates
   if(::file_exists("launcher.blit")) {
-    // erase old launcher
+    // erase old launcher(s)
     for(auto &flash_game : game_list) {
-      if(strcmp(flash_game.title, "Launcher") == 0)
+      if(strcmp(flash_game.category, "launcher") == 0)
         erase_qspi_flash(flash_game.offset / qspi_flash_sector_size, flash_game.size);
     }
 


### PR DESCRIPTION
This drops some code that was rendered obsolete by #545 and switches launcher identification from `title` to `category`.

If you want to write a custom launcher, it *must* have a category of "launcher". Subsequent to this change the title can be anything, so swapping in new launcher should be slightly easier.

We might need a special case for "launcher" type apps, expanding on the "delete old launcher" behaviour to *always* delete and replace a launcher when any other launcher is flashed. While it would be fine to have *multiple* launchers flashed at once, it would always be the first one in Flash that wins so it's a little redundant.