### PR TITLE
Helpful things

### DIFF
--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -74,6 +74,7 @@ namespace blit {
     uint8_t b = 0;
     uint8_t a = 0;
 
+    inline bool operator ==(const Pen rhs) {return r == rhs.r && g == rhs.g && b == rhs.b && a == rhs.a;};
     Pen() = default;
     Pen(int a) : a(a) {}
     Pen(float a) : a((uint8_t)(a * 255.0f)) {}

--- a/32blit/types/rect.hpp
+++ b/32blit/types/rect.hpp
@@ -19,6 +19,10 @@ namespace blit {
 
     inline Rect& operator*= (const float a) { x = static_cast<int32_t>(x * a); y = static_cast<int32_t>(y * a); w = static_cast<int32_t>(w * a); h = static_cast<int32_t>(h * a); return *this; }
 
+    Size size() {
+      return Size(w, h);
+    }
+
     bool empty() const {
       return w <= 0 || h <= 0; 
     }

--- a/32blit/types/size.hpp
+++ b/32blit/types/size.hpp
@@ -14,6 +14,7 @@ namespace blit {
     constexpr Size(int32_t w, int32_t h) : w(w), h(h) {}
 
     inline Size& operator*= (const float a) { w = static_cast<int32_t>(w * a); h = static_cast<int32_t>(h * a); return *this; }
+    inline Size operator / (const int a) { return Size(w / a, h / a);}
 
     bool empty() { return w <= 0 || h <= 0; }
 

--- a/32blit/types/size.hpp
+++ b/32blit/types/size.hpp
@@ -14,7 +14,9 @@ namespace blit {
     constexpr Size(int32_t w, int32_t h) : w(w), h(h) {}
 
     inline Size& operator*= (const float a) { w = static_cast<int32_t>(w * a); h = static_cast<int32_t>(h * a); return *this; }
-    inline Size operator / (const int a) { return Size(w / a, h / a);}
+    inline Size& operator/= (const float a) { w = static_cast<int32_t>(w / a); h = static_cast<int32_t>(h / a); return *this; }
+    inline Size& operator*= (const int a) { w = static_cast<int32_t>(w * a); h = static_cast<int32_t>(h * a); return *this; }
+    inline Size& operator/= (const int a) { w = static_cast<int32_t>(w / a); h = static_cast<int32_t>(h / a); return *this; }
 
     bool empty() { return w <= 0 || h <= 0; }
 
@@ -26,6 +28,9 @@ namespace blit {
 
   };
 
-  inline Size operator*  (Size lhs, const float a) { lhs *= a; return lhs; }
+  inline Size operator/ (Size lhs, const float a) { lhs /= a; return lhs;}
+  inline Size operator/ (Size lhs, const int a) { lhs /= a; return lhs; }
+  inline Size operator* (Size lhs, const float a) { lhs *= a; return lhs; }
+  inline Size operator* (Size lhs, const int a) {  lhs *= a; return lhs; }
 
 }


### PR DESCRIPTION
Helpers and additional operator support on some basic types. Probably need to flesh this out a lot more, but I'm adding these as my sprite-editor code demands it because I hate repeating myself.

Is there any drawback to this?

Also strikes me that Pen should cast to a `uint32` and just do a direct comparison, but for love nor money I couldn't get the thing to cast. Maybe the compiler is clever enough to optimize my long-winded comparison. Maybe I should just be casting and comparing pens in my code?