### PR TITLE
Display 128x128 spritesheets (or other images) at correct aspect

### DIFF
--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -122,7 +122,7 @@ namespace blit {
     auto ext = std::string_view(filename).substr(dot + 1);
 
     bool is_bmp = ext == "bmp";
-    bool is_spriterw = ext == "spriterw";
+    bool is_spriterw = ext == "spriterw" || ext == "ssrw";
 
     if(!is_bmp && !is_spriterw)
       return false;

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -122,7 +122,7 @@ namespace blit {
     auto ext = std::string_view(filename).substr(dot + 1);
 
     bool is_bmp = ext == "bmp";
-    bool is_spriterw = ext == "spriterw" || ext == "ssrw";
+    bool is_spriterw = ext == "blim";
 
     if(!is_bmp && !is_spriterw)
       return false;
@@ -148,7 +148,7 @@ namespace blit {
       file.write(0, sizeof(head), reinterpret_cast<char *>(&head));
       offset = sizeof(head);
     } else {
-      // spriterw
+      // spriterw (.blim file)
       packed_image head;
       memcpy(head.type, "SPRITERW", 8);
       head.byte_count = sizeof(packed_image) + data_size + palette_size * 4;

--- a/32blit/types/size.hpp
+++ b/32blit/types/size.hpp
@@ -33,5 +33,6 @@ namespace blit {
   inline Size operator* (Size lhs, const float a) { lhs *= a; return lhs; }
   inline Size operator* (Size lhs, const int a) {  lhs *= a; return lhs; }
   inline bool operator== (Size lhs, Size rhs) { return lhs.w == rhs.w && lhs.h == rhs.h; }
+  inline bool operator!= (Size lhs, Size rhs) { return lhs.w != rhs.w || lhs.h != rhs.h; }
 
 }

--- a/32blit/types/size.hpp
+++ b/32blit/types/size.hpp
@@ -32,5 +32,6 @@ namespace blit {
   inline Size operator/ (Size lhs, const int a) { lhs /= a; return lhs; }
   inline Size operator* (Size lhs, const float a) { lhs *= a; return lhs; }
   inline Size operator* (Size lhs, const int a) {  lhs *= a; return lhs; }
+  inline bool operator== (Size lhs, Size rhs) { return lhs.w == rhs.w && lhs.h == rhs.h; }
 
 }

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -196,8 +196,7 @@ void load_file_list(std::string directory) {
       continue;
     }
 
-    // spritepk and spriterw are old, transitional long exts, sspk and ssrw are the file-association compatible short names
-    if(ext == "bmp" || ext == "spritepk" || ext == "spriterw" || ext == "sspk" || ext == "ssrw") {
+    if(ext == "bmp" || ext == "blim") {
       GameInfo game;
       game.type = GameType::screenshot;
       game.title = file.name.substr(0, file.name.length() - ext.length() - 1);

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -196,10 +196,10 @@ void load_file_list(std::string directory) {
       continue;
     }
 
-    if(ext == "bmp") {
+    if(ext == "bmp" || ext == "spritepk" || ext == "spriterw") {
       GameInfo game;
       game.type = GameType::screenshot;
-      game.title = file.name.substr(0, file.name.length() - 4);
+      game.title = file.name.substr(0, file.name.length() - ext.length() - 1);
       game.filename = directory == "/" ? file.name : directory + "/" + file.name;
       game.size = file.size;
       game_list.push_back(game);
@@ -397,6 +397,10 @@ void render(uint32_t time) {
   if(!game_list.empty() && selected_game.type == GameType::screenshot && screenshot) {
     if(screenshot->bounds.w == screen.bounds.w) {
       screen.blit(screenshot, Rect(Point(0, 0), screenshot->bounds), Point(0, 0));
+    } else if(screenshot->bounds == Size(128, 128)) {
+      screen.pen = Pen(0, 0, 0, 255);
+      screen.rectangle(Rect(game_info_offset, Size(128, 128)));
+      screen.blit(screenshot, Rect(Point(0, 0), screenshot->bounds), game_info_offset);
     } else {
       screen.stretch_blit(screenshot, Rect(Point(0, 0), screenshot->bounds), Rect(Point(0, 0), screen.bounds));
     }

--- a/launcher/launcher.hpp
+++ b/launcher/launcher.hpp
@@ -29,6 +29,8 @@ struct GameInfo {
   std::string title;
   uint32_t size, checksum = 0;
 
+  bool can_launch = true; // use in future to flag games with an API mismatch
+
   std::string filename, ext;
 };
 


### PR DESCRIPTION
Zoomed "view" somewhat sucks here, but I'd like to implement file association support so I can hijack 128x128 spritesheets and open them in the Sprite Editor. This is step 1.