### PR TITLE
Flash tmp area/cache

### DIFF
--- a/32blit-stm32/Inc/sound.hpp
+++ b/32blit-stm32/Inc/sound.hpp
@@ -7,13 +7,15 @@ extern DAC_HandleTypeDef hdac1;
 
 extern "C" {
   void TIM6_DAC_IRQHandler(void);
-  void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim);  
+  void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
 }
 
 
 using namespace blit;
 
 namespace sound {
+
+  extern bool enabled;
 
   void init();
 

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -749,6 +749,7 @@ void blit_enable_user_code() {
   do_tick = user_tick;
   blit::render = user_render;
   user_code_disabled = false;
+  sound::enabled = true;
 }
 
 void blit_disable_user_code() {
@@ -757,6 +758,7 @@ void blit_disable_user_code() {
 
   do_tick = blit::tick;
   blit::render = ::render;
+  sound::enabled = false;
   user_code_disabled = true;
 }
 

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -77,6 +77,9 @@ namespace blit {
     void (*set_multiplayer_enabled)(bool enabled);
     void (*send_message)(const uint8_t *data, uint16_t len);
     void (*message_received)(const uint8_t *data, uint16_t len); // set by user
+
+    const uint8_t *(*flash_to_tmp)(const std::string &filename, uint32_t &size);
+    void (*tmp_file_closed)(const uint8_t *ptr);
   };
   #pragma pack(pop)
 

--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -26,7 +26,7 @@ namespace blit {
    * Lists files on the SD card (device), the game directory (SDL) or in memory.
    *
    * \param path Path to list files at, relative to the root of the SD card or game directory (SDL).
-   * 
+   *
    * \return Vector of files/directories
    */
   std::vector<FileInfo> list_files(const std::string &path) {
@@ -37,7 +37,7 @@ namespace blit {
 
     for(auto &buf_file : buf_files) {
       auto slash_pos = buf_file.first.find_last_of('/');
-      
+
       bool match = false;
       if(slash_pos == std::string::npos) // file in root
         match = path.empty() || path == "/";
@@ -63,7 +63,7 @@ namespace blit {
    * Check if the specified path exists and is a file
    *
    * \param path Path to check existence of, relative to the root of the SD card (device) or game directory (SDL).
-   * 
+   *
    * \return true if file exists
    */
   bool file_exists(const std::string &path) {
@@ -74,7 +74,7 @@ namespace blit {
    * Check if the specified path exists and is a directory
    *
    * \param path Path to check existence of, relative to the root of the SD card (device) or game directory (SDL).
-   * 
+   *
    * \return true if directory exists
    */
   bool directory_exists(const std::string &path) {
@@ -85,7 +85,7 @@ namespace blit {
    * Create a directory
    *
    * \param path Path to create, relative to the root of the SD card (device) or game directory (SDL).
-   * 
+   *
    * \return true if directory created successfully
    */
   bool create_directory(const std::string &path) {
@@ -97,7 +97,7 @@ namespace blit {
    *
    * \param old_name Path to rename, relative to the root of the SD card (device) or game directory (SDL).
    * \param new_name New name
-   * 
+   *
    * \return true if file renamed successfully
    */
   bool rename_file(const std::string &old_name, const std::string &new_name) {
@@ -108,7 +108,7 @@ namespace blit {
    * Remove a file
    *
    * \param path Path to remove, relative to the root of the SD card (device) or game directory (SDL).
-   * 
+   *
    * \return true if file removed successfully
    */
   bool remove_file(const std::string &path) {
@@ -133,7 +133,7 @@ namespace blit {
    *
    * \param file Path to open.
    * \param mode ::OpenMode to open file as. Cannot contain ::write for in-memory files.
-   * 
+   *
    * \return true if file opened successfully
    */
   bool File::open(const std::string &file, int mode) {
@@ -148,6 +148,16 @@ namespace blit {
       return true;
     }
 
+    // flash cache
+    if(mode == (OpenMode::read | OpenMode::cached) && api.flash_to_tmp) {
+      buf = api.flash_to_tmp(file, buf_len);
+
+      if(buf) {
+        is_cached = true;
+        return true;
+      }
+    }
+
     fh = api.open_file(file, mode);
     return fh != nullptr;
   }
@@ -158,7 +168,7 @@ namespace blit {
    * \param offset Offset to read from
    * \param length Length to read
    * \param buffer Pointer to buffer to store data into, should be at least `length` bytes
-   * 
+   *
    * \return Number of bytes read successfully or -1 if an error occurred.
    */
   int32_t File::read(uint32_t offset, uint32_t length, char *buffer) {
@@ -178,7 +188,7 @@ namespace blit {
    * \param offset Offset to write to
    * \param length Length to write
    * \param buffer Pointer to data to write, should be at least `length` bytes
-   * 
+   *
    * \return Number of bytes written successfully or -1 if an error occurred.
    */
   int32_t File::write(uint32_t offset, uint32_t length, const char *buffer) {
@@ -189,6 +199,11 @@ namespace blit {
    * Close the file. Also called automatically by the destructor.
    */
   void File::close() {
+    if(is_cached) {
+      api.tmp_file_closed(buf);
+      is_cached = false;
+    }
+
     buf = nullptr;
 
     if(!fh)
@@ -212,28 +227,28 @@ namespace blit {
 
   /**
    * Creates an in-memory file, which can be used like a regular (read-only) file.
-   * 
+   *
    * This is useful for porting code which assumes files, or for transparently moving data to flash
    * for extra performance.
-   * 
+   *
    * Example using a packed asset:
    * ```
    * File::add_buffer_file("asset_name.bin", asset_name, asset_name_length);
    * ```
-   * 
+   *
    * Notes:
    * The directory part of the path is not created if it does not exist, so ::list_files/::directory_exists
    * may not work as expected in that case: (Assuming `path/to` does not exist on the SD card)
    * ```
    * File::add_buffer_file("path/to/a.file");
-   * 
+   *
    * file_exists("path/to/a.file"); // true
    * directory_exists("path/to"); // false!
    *
    * list_files("path/to"); // vector containing info for "a.file"
    * list_files("path"); // empty!
    * ```
-   * 
+   *
    * \param path Path for the file
    * \param ptr Pointer to file data
    * \param len Length of file data

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -11,7 +11,9 @@ namespace blit {
     /// Open file for reading
     read  = 1 << 0,
     /// Open file for writing
-    write = 1 << 1
+    write = 1 << 1,
+    /// Copy file to the temp area in flash for faster access
+    cached = 1 << 2
   };
 
   enum FileFlags {
@@ -38,9 +40,9 @@ namespace blit {
 
   bool rename_file(const std::string &old_name, const std::string &new_name);
   bool remove_file(const std::string &path);
-  
+
   /**
-   * Class for accessing files on the SD card (device), the game directory (SDL) or in memory. 
+   * Class for accessing files on the SD card (device), the game directory (SDL) or in memory.
    */
   class File final {
   public:
@@ -93,5 +95,6 @@ namespace blit {
       // buffer "files"
       const uint8_t *buf = nullptr;
       uint32_t buf_len;
+      bool is_cached = false;
   };
 }

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -17,6 +17,9 @@ constexpr uint32_t qspi_flash_sector_size = 64 * 1024;
 constexpr uint32_t qspi_flash_size = 32768 * 1024;
 constexpr uint32_t qspi_flash_address = 0x90000000;
 
+// resevered space for temp/cached files
+constexpr uint32_t qspi_tmp_reserved = 4 * 1024 * 1024;
+
 extern CDCCommandStream g_commandStream;
 
 FlashLoader flashLoader;
@@ -197,7 +200,7 @@ static void scan_flash() {
   GameInfo game;
   uint32_t free_start = 0xFFFFFFFF;
 
-  for(uint32_t offset = 0; offset < qspi_flash_size;) {
+  for(uint32_t offset = 0; offset < qspi_flash_size - qspi_tmp_reserved;) {
     BlitGameHeader header;
 
     if(!read_flash_game_header(offset, header)) {
@@ -245,7 +248,7 @@ static void scan_flash() {
   // final free
   if(free_start != 0xFFFFFFFF) {
     auto start_block = free_start / qspi_flash_sector_size;
-    auto end_block = qspi_flash_size / qspi_flash_sector_size;
+    auto end_block = (qspi_flash_size - qspi_tmp_reserved) / qspi_flash_sector_size;
 
     free_space.emplace_back(start_block, end_block - start_block);
   }


### PR DESCRIPTION
Reserves some space at the end of flash for temporary files and adds some API for using it (only handles one file in there, could be improved).

```c++
File f("path/to/thing", OpenMode::read | OpenMode::cached);
// file has been copied to flash if possible
// cache space is reserved until close
```

Also, stops audio while ext flash is unavailable to prevent games using audio callbacks from crashing.

(WIP?, at least I don't feel like I've spent enough time on this...)