### PR TITLE
Rework audio wave channel

### DIFF
--- a/32blit/audio/audio.cpp
+++ b/32blit/audio/audio.cpp
@@ -123,10 +123,11 @@ namespace blit {
         }
 
         if(channel.waveforms & Waveform::WAVE) {
-          channel_sample += channel.wave_buffer[channel.wave_buf_pos] << 8;
-          if (++channel.wave_buf_pos == 64) { // If the position is at the end, reset and hit up callback for more.
+          channel_sample += channel.wave_buffer[channel.wave_buf_pos];
+          if (++channel.wave_buf_pos == 64) {
             channel.wave_buf_pos = 0;
-            (*channel.callback_waveBufferRefresh)(channel.wave_callback_arg);
+            if(channel.wave_buffer_callback)
+                channel.wave_buffer_callback(channel);
           }
           waveform_count++;
         }

--- a/32blit/audio/audio.hpp
+++ b/32blit/audio/audio.hpp
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 
-namespace blit {  
+namespace blit {
 
-  // The duration a note is played is determined by the amount of attack, 
+  // The duration a note is played is determined by the amount of attack,
   // decay, and release, combined with the length of the note as defined by
   // the user.
   //
@@ -14,14 +14,14 @@ namespace blit {
   // - Release: number of milliseconds it takes for a note to reduce to zero volume after it has ended
   //
   // Attack (750ms) - Decay (500ms) -------- Sustain ----- Release (250ms)
-  // 
+  //
   //                +         +                                  +    +
   //                |         |                                  |    |
   //                |         |                                  |    |
   //                |         |                                  |    |
   //                v         v                                  v    v
   // 0ms               1000ms              2000ms              3000ms              4000ms
-  //                                                                                  
+  //
   // |              XXXX |                   |                   |                   |
   // |             X    X|XX                 |                   |                   |
   // |            X      |  XXX              |                   |                   |
@@ -45,7 +45,7 @@ namespace blit {
   extern uint16_t volume;
 
   enum Waveform {
-    NOISE     = 128, 
+    NOISE     = 128,
     SQUARE    = 64,
     SAW       = 32,
     TRIANGLE  = 16,
@@ -72,7 +72,7 @@ namespace blit {
       uint16_t  release_ms    = 1;      // release period
       uint16_t  pulse_width   = 0x7fff; // duty cycle of square wave (default 50%)
       int16_t   noise         = 0;      // current noise value
-  
+
       uint32_t  waveform_offset  = 0;   // voice offset (Q8)
 
       int32_t   filter_last_sample = 0;
@@ -85,11 +85,11 @@ namespace blit {
 	    int32_t   adsr_step	    = 0;
       ADSRPhase adsr_phase    = ADSRPhase::OFF;
 
-      uint8_t   wave_buf_pos  = 0;      // 
+      uint8_t   wave_buf_pos  = 0;      //
       int16_t   wave_buffer[64];        // buffer for arbitrary waveforms. small as it's filled by user callback
 
-      void  *wave_callback_arg = nullptr;
-      void  (*callback_waveBufferRefresh)(void *);
+      void *user_data = nullptr;
+      void (*wave_buffer_callback)(AudioChannel &channel);
 
       void trigger_attack()  {
         adsr_frame = 0;

--- a/32blit/audio/mp3-stream.hpp
+++ b/32blit/audio/mp3-stream.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "audio/audio.hpp"
 #include "engine/file.hpp"
 
 namespace blit {
@@ -29,8 +30,8 @@ namespace blit {
 
     void read(int32_t len);
 
-    static void static_callback(void *arg);
-    void callback();
+    static void static_callback(AudioChannel &channel);
+    void callback(AudioChannel &channel);
 
     // file io
     blit::File file;

--- a/examples/audio-wave/audio-wave.cpp
+++ b/examples/audio-wave/audio-wave.cpp
@@ -9,7 +9,7 @@
 
 /*
     Wave example:
-    
+
     An example of an arbitrary waveform being played through the blit speaker.
 
     This example, a runthrough:
@@ -32,14 +32,14 @@
 
 using namespace blit;
 
-void buff_callback(void *);    //Declare our callback here instead of putting the whole thing here.
+void buff_callback(AudioChannel &);    //Declare our callback here instead of putting the whole thing here.
 
 /* setup */
 void init() {
 
   // Setup channel
-  channels[0].waveforms                  = Waveform::WAVE; // Set type to WAVE
-  channels[0].callback_waveBufferRefresh = &buff_callback;  // Set callback address
+  channels[0].waveforms            = Waveform::WAVE; // Set type to WAVE
+  channels[0].wave_buffer_callback = &buff_callback;  // Set callback address
 
   screen.pen = Pen(0, 0, 0, 255);
   screen.clear();
@@ -54,13 +54,13 @@ static const uint8_t *wav_sample;
 
 
 // Called everytime audio buffer ends
-void buff_callback(void *) {
+void buff_callback(AudioChannel &channel) {
 
   // Copy 64 bytes to the channel audio buffer
   for (int x = 0; x < 64; x++) {
     // If current sample position is greater than the sample length, fill the rest of the buffer with zeros.
-    // Note: The sample used here has an offset, so we adjust by 0x7f. 
-    channels[0].wave_buffer[x] = (wav_pos < wav_size) ? wav_sample[wav_pos] - 0x7f : 0;
+    // Note: The sample used here has an offset, so we adjust by 0x7f.
+    channel.wave_buffer[x] = (wav_pos < wav_size) ? (wav_sample[wav_pos] << 8) - 0x7f00 : 0;
 
     // As the engine is 22050Hz, we can timestretch to match by incrementing our sample every other step (every even 'x')
     if (wav_sample_rate == 11025) {
@@ -69,10 +69,10 @@ void buff_callback(void *) {
       wav_pos++;
     }
   }
-  
+
   // For this example, clear the values
   if (wav_pos >= wav_size) {
-    channels[0].off();        // Stop playback of this channel.
+    channel.off();        // Stop playback of this channel.
     //Clear buffer
     wav_sample = nullptr;
     wav_size = 0;
@@ -93,7 +93,7 @@ void render(uint32_t time_ms) {
 
   screen.pen = Pen(64, 64, 64);
 	screen.text("Press A to break screen.", minimal_font, Point(20, 60));
-} 
+}
 
 void update(uint32_t time_ms) {
   bool button_a = blit::buttons & blit::Button::A;
@@ -105,4 +105,4 @@ void update(uint32_t time_ms) {
     channels[0].trigger_attack(); // Start the playback.
   }
 }
-  
+


### PR DESCRIPTION
- Rename the callback for more consistency (#344)
- Pass the channel to the callback, helps if you're using more than one channel... and just makes sense
- Stop doing << 8 on samples. Now you can use 16-bit samples without reducing the volume 256x
- Make the callback optional to allow using a fixed pattern.
- `wave_callback_arg` is now a generic `user_data` pointer.

Changes for users are...

Old:
```c++
channels[0].wave_callback_arg = some_ptr;
channels[0].callback_waveBufferRefresh = &callback;

//...

void callback(void *data) {
  //...
  for(int i = 0; i < 64; i++)
    channels[0].wave_buffer[i] = some_sample;
}
```
New:
```c++
channels[0].user_data = some_ptr;
channels[0].wave_buffer_callback = &callback;

//...

void callback(AudioChannel &channel) {
  auto data = channel->user_data;
  //...
  for(int i = 0; i < 64; i++)
    channel.wave_buffer[i] = some_sample;
}
```

Also, if you're using 8-bit samples you need to multiply them by 256 now. (If you're using 16-bit samples you can stop dividing your volume by 256).

This will also cause API breakage, but will only affect games that use the WAVE waveform (callback arg will be wrong).