### PR TITLE
Added center() function to blit::Rect

### DIFF
--- a/32blit/types/rect.hpp
+++ b/32blit/types/rect.hpp
@@ -118,8 +118,13 @@ namespace blit {
       return Point(x + w, y + h);
     }
 
+    Point center() const {
+      return Point(x + w/2, y + h/2);
+    }
+
   };
 
   inline Rect operator*  (Rect lhs, const float a) { lhs *= a; return lhs; }
 
 }
+


### PR DESCRIPTION
Minor enhancement, after I found myself writing code to get the middle of a Rect for the 42nd time.