### PR TITLE
Move flash_end to the right place

### DIFF
--- a/32blit-stm32/STM32H750VBTx.ld
+++ b/32blit-stm32/STM32H750VBTx.ld
@@ -152,11 +152,6 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
   } >DTCMRAM AT> FLASH
 
-  .flash_end :
-  {
-    _flash_end = .;
-  } > FLASH
-
   /* Uninitialized data section */
   . = ALIGN(4);
   .bss :
@@ -193,6 +188,11 @@ SECTIONS
     . = ALIGN(4);
     itcm_text_end = .;
   } >ITCMRAM AT> FLASH
+
+  .flash_end :
+  {
+    _flash_end = .;
+  } > FLASH
 
   .ltdc (NOLOAD):
   {


### PR DESCRIPTION
Doesn't fix anything, but does prevent metadata overwriting ITCM if you attempt to use it. (Making that actually work for games is more work...)