### PR TITLE
Fix metadata absolute path handling

### DIFF
--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -48,7 +48,7 @@ function(blit_executable NAME SOURCES)
 endfunction()
 
 function(blit_metadata TARGET FILE)
-	if(NOT EXISTS ${FILE})
+	if(NOT IS_ABSOLUTE ${FILE})
 		set(FILE ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
 	endif()
 


### PR DESCRIPTION
Only possible to hit this if you're being lazy and doing:
```
cmake -G Ninja -B build -DCMAKE_TOOLCHAIN_FILE=~/repos/32blit-beta/32blit.toolchain
ninja -C build-test
```

Without doing `mkdir/cd`.