### PR TITLE
CDC stream adjustment/cleanup

### DIFF
--- a/32blit-stm32/Inc/CDCDataStream.h
+++ b/32blit-stm32/Inc/CDCDataStream.h
@@ -13,39 +13,6 @@
 #include <streambuf>
 #include <istream>
 
-class CDCMemBuffer : public std::basic_streambuf<char>
-{
-public:
-	CDCMemBuffer(const uint8_t *pData, size_t uLen)
-	{
-    setg((char*)pData, (char*)pData, (char*)pData + uLen);
-  }
-
-	void SetData(const uint8_t *pData, size_t uLen)
-	{
-    setg((char*)pData, (char*)pData, (char*)pData + uLen);
-  }
-};
-
-class CDCMemoryStream : public std::istream
-{
-public:
-	CDCMemoryStream(const uint8_t *pData = NULL , size_t uLen = 0) : std::istream(&m_buffer), m_buffer(pData, uLen)
-	{
-    rdbuf(&m_buffer);
-  }
-
-	void SetData(const uint8_t *pData, size_t uLen)
-	{
-		clear();
-		m_buffer.SetData(pData, uLen);
-    rdbuf(&m_buffer);
-	}
-private:
-	CDCMemBuffer m_buffer;
-};
-
-
 class CDCDataStream
 {
 public:
@@ -66,41 +33,6 @@ public:
 	uint32_t GetStreamLength(void)
 	{
 		return m_uLen;
-	}
-
-
-	bool GetMemoryStream(CDCMemoryStream &ms)
-	{
-		bool bResult = false;
-
-		uint8_t *pData;
-		uint32_t uLen;
-		if(uLen)
-		{
-			ms.SetData(pData, uLen);
-			bResult = true;
-		}
-
-		return bResult;
-	}
-
-
-	bool GetStreamData(uint8_t **ppData, uint32_t *puLen)
-	{
-		bool bResult = true;
-
-		if(m_uLen)
-		{
-			*ppData = m_pData;
-			*puLen = m_uLen;
-			m_uLen = 0;
-		}
-		else
-		{
-			bResult = false;
-		}
-
-		return bResult;
 	}
 
 	bool GetDataOfLength(void *pData, uint8_t uLen)

--- a/32blit-stm32/Inc/CDCDataStream.h
+++ b/32blit-stm32/Inc/CDCDataStream.h
@@ -23,11 +23,14 @@ public:
 
 	bool AddData(uint8_t *pData, uint32_t uLen)
 	{
-		m_pData = pData;
-		m_uLen  = uLen;
+		if(m_uLen)
+			memmove(buf, m_pData, m_uLen);
+
+		memcpy(buf + m_uLen, pData, uLen);
+		m_pData = buf;
+		m_uLen += uLen;
 
 		return true;
-
 	}
 
 	uint32_t GetStreamLength(void)
@@ -71,6 +74,8 @@ public:
 private:
 	uint8_t		*m_pData;
 	uint32_t 	m_uLen;
+
+	uint8_t buf[64 + 4]; // slightly larger than a FIFO element
 };
 
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -886,6 +886,10 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
             // done
             if(m_uParseIndex == num_relocs + 2)
               break;
+
+            // break out of loop as we need more data
+            if(dataStream.GetStreamLength() < 4)
+              return srContinue;
           }
         }
         break;


### PR DESCRIPTION
A result of trying to figure out why https://github.com/ali1234/32blit-webserial-test didn't work.

One problem was that it would end up stuck in the reloc parsing with 2 bytes in the buffer when it needed 4. This makes it so that you can return from StreamData with a few bytes in the buffer and they will be preserved on the next call.

Also deletes a bunch of stream stuff that we're not using.