### PR TITLE
More helpful errors for missing libs

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -94,6 +94,14 @@ else()
 		PATH_SUFFIXES bin ${VC_LIB_PATH_SUFFIX}
 	)
 
+	if(NOT SDL2_IMAGE_INCLUDE_DIR OR NOT SDL2_IMAGE_LIBRARY)
+		message(FATAL_ERROR "SDL_image not found!")
+	endif()
+
+	if(NOT SDL2_NET_INCLUDE_DIR OR NOT SDL2_NET_LIBRARY)
+		message(FATAL_ERROR "SDL_net not found!")
+	endif()
+
 	target_include_directories(BlitHalSDL
 		PRIVATE	${SDL2_IMAGE_INCLUDE_DIR} ${SDL2_NET_INCLUDE_DIR}
 	)


### PR DESCRIPTION
From
```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
/home/daftfreak/programs/32blit-beta/32blit-sdl/SDL2_NET_INCLUDE_DIR
   used as include directory in directory /home/daftfreak/programs/32blit-beta/32blit-sdl
SDL2_NET_LIBRARY
    linked by target "BlitHalSDL" in directory /home/daftfreak/programs/32blit-beta/32blit-sdl

-- Configuring incomplete, errors occurred!
```
to
```
CMake Error at 32blit-sdl/CMakeLists.txt:102 (message):
  SDL_net not found!


-- Configuring incomplete, errors occurred!
```

Also, fails a lot faster instead of waiting until the end. 