### PR TITLE
Emscripten install improvement and persistent saves

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -176,6 +176,10 @@ function(blit_executable NAME SOURCES)
 			SUFFIX ".html"
 			LINK_FLAGS "-s ENVIRONMENT=web -s SDL2_IMAGE_FORMATS=['jpg']"
 		)
+
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.js ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.wasm
+			DESTINATION bin
+		)
 	endif()
 
 	if(APPLE AND SDL2_LIBRARIES MATCHES "\.framework$")

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -176,9 +176,11 @@ function(blit_executable NAME SOURCES)
 	if(EMSCRIPTEN)
 		set_target_properties(${NAME} PROPERTIES
 			SUFFIX ".html"
-			LINK_FLAGS "-s ENVIRONMENT=web -s SDL2_IMAGE_FORMATS=['jpg'] --shell-file ${EMSCRIPTEN_SHELL}"
+			LINK_FLAGS "-s ENVIRONMENT=web -s SDL2_IMAGE_FORMATS=['jpg'] --shell-file ${EMSCRIPTEN_SHELL} -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"addRunDependency\", \"removeRunDependency\"]'"
 			LINK_DEPENDS ${EMSCRIPTEN_SHELL}
 		)
+
+		target_link_libraries(${NAME} "-lidbfs.js") # include the persistent IndexedDB-based filesystem
 
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.js ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.wasm
 			DESTINATION bin

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -19,6 +19,8 @@ if(EMSCRIPTEN)
 	set(SDL2_LIBRARIES "-s USE_SDL=2")
 	set(SDL2_IMAGE_LIBRARY "-s USE_SDL_IMAGE=2")
 	set(SDL2_NET_LIBRARY "-s USE_SDL_NET=2")
+
+	set(EMSCRIPTEN_SHELL ${CMAKE_CURRENT_SOURCE_DIR}/emscripten-shell.html PARENT_SCOPE)
 else()
 	# attempt to find the framework (find_package won't work as there's no config file)
 	if(APPLE)
@@ -174,7 +176,8 @@ function(blit_executable NAME SOURCES)
 	if(EMSCRIPTEN)
 		set_target_properties(${NAME} PROPERTIES
 			SUFFIX ".html"
-			LINK_FLAGS "-s ENVIRONMENT=web -s SDL2_IMAGE_FORMATS=['jpg']"
+			LINK_FLAGS "-s ENVIRONMENT=web -s SDL2_IMAGE_FORMATS=['jpg'] --shell-file ${EMSCRIPTEN_SHELL}"
+			LINK_DEPENDS ${EMSCRIPTEN_SHELL}
 		)
 
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.js ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.wasm

--- a/32blit-sdl/File.cpp
+++ b/32blit-sdl/File.cpp
@@ -188,6 +188,13 @@ bool remove_file(const std::string &path) {
 static std::string save_path;
 
 const char *get_save_path() {
+#ifdef __EMSCRIPTEN__
+  // The Emscripten backend's GetPrefPath is a little broken (doesn't create the dirs correctly)
+  // Work around it until the fix gets released
+  mkdir("/libsdl", 0700);
+  mkdir((std::string("/libsdl/") + metadata_author).c_str(), 0700);
+#endif
+
   auto tmp = SDL_GetPrefPath(metadata_author, metadata_title);
   save_path = std::string(tmp);
 

--- a/32blit-sdl/emscripten-shell.html
+++ b/32blit-sdl/emscripten-shell.html
@@ -43,8 +43,20 @@
       var progressElement = document.getElementById('progress');
       var spinnerElement = document.getElementById('spinner');
 
+      function mountIDBFS() {
+        // mount a persistant filesystem over the directory used for saves
+        FS.mkdir("/libsdl");
+        FS.mount(IDBFS, {}, '/libsdl');
+
+        // sync before starting game
+        Module['addRunDependency']("SYNC_DATA");
+        FS.syncfs(true, function(err) {
+          Module['removeRunDependency']("SYNC_DATA");
+        });
+      }
+
       var Module = {
-        preRun: [],
+        preRun: [mountIDBFS],
         postRun: [],
         print: (function() {
           return function(text) {

--- a/32blit-sdl/emscripten-shell.html
+++ b/32blit-sdl/emscripten-shell.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>32Blit Game</title>
+    <style>
+      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
+
+      div.emscripten { text-align: center; }
+      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+      canvas.emscripten { border: 0px none; background-color: black; }
+
+      .spinner {
+        height: 50px;
+        width: 50px;
+        margin: 0px auto;
+        animation: rotation 0.8s linear infinite;
+        border-left: 10px solid #000;
+        border-right: 10px solid #000;
+        border-bottom: 10px solid #000;
+        border-top: 10px solid #0f0;
+        border-radius: 100%;
+      }
+      @keyframes rotation {
+        from {transform: rotate(0deg);}
+        to {transform: rotate(360deg);}
+      }
+
+    </style>
+  </head>
+  <body>
+    <figure style="overflow:visible;" id="spinner"><div class="spinner"></div></figure>
+    <div class="emscripten" id="status">Downloading...</div>
+    <div class="emscripten">
+      <progress value="0" max="100" id="progress" hidden=1></progress>
+    </div>
+
+    <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+
+    <script type='text/javascript'>
+      var statusElement = document.getElementById('status');
+      var progressElement = document.getElementById('progress');
+      var spinnerElement = document.getElementById('spinner');
+
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+          return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            console.log(text);
+          };
+        })(),
+        printErr: function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          console.error(text);
+        },
+        canvas: (function() {
+          var canvas = document.getElementById('canvas');
+
+          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+          // application robust, you may want to override this behavior before shipping!
+          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+          return canvas;
+        })(),
+        setStatus: function(text) {
+          if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+          if (text === Module.setStatus.last.text) return;
+          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+          var now = Date.now();
+          if (m && now - Module.setStatus.last.time < 30) return; // if this is a progress update, skip it if too soon
+          Module.setStatus.last.time = now;
+          Module.setStatus.last.text = text;
+          if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+          } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.hidden = true;
+          }
+          statusElement.innerHTML = text;
+        },
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+        }
+      };
+      Module.setStatus('Downloading...');
+      window.onerror = function() {
+        Module.setStatus('Exception thrown, see JavaScript console');
+        spinnerElement.style.display = 'none';
+        Module.setStatus = function(text) {
+          if (text) Module.printErr('[post-exception status] ' + text);
+        };
+      };
+    </script>
+    {{{ SCRIPT }}}
+  </body>
+</html>


### PR DESCRIPTION
Fixes the the install step for Emscripten to install the actual game wasm/js instead of just the shell. Then adds a minimal custom shell and makes saves persist.

Includes a workaround for an old SDL issue I forgot to fix. (I'll probably merge [the fix](https://github.com/emscripten-ports/SDL2/pull/136) soon, but would still need to add a new tag/update Emscripten/wait for an Emscripten release/...)

The sync in the save code feels a bit like the wrong place, but `close_file` doesn't know if the file was used for writing... or if it was written to somewhere that needs syncing.