### PR TITLE
Warning fixes - -Wextra edition

### DIFF
--- a/32blit/audio/mp3-stream.cpp
+++ b/32blit/audio/mp3-stream.cpp
@@ -182,7 +182,8 @@ namespace blit {
     // swap buffers
     if(current_sample == end_sample) {
       data_size[cur_audio_buf] = 0;
-      cur_audio_buf = ++cur_audio_buf % 2;
+      cur_audio_buf++;
+      cur_audio_buf %= 2;
 
       if(data_size[cur_audio_buf] == -1) // EOF
         current_sample = end_sample = nullptr;

--- a/32blit/graphics/primitive.cpp
+++ b/32blit/graphics/primitive.cpp
@@ -173,7 +173,7 @@ namespace blit {
   int32_t orient2d(Point p1, Point p2, Point p3) {
     return (p2.x - p1.x) * (p3.y - p1.y) - (p2.y - p1.y) * (p3.x - p1.x);
   }
-  
+
   /**
    * TODO: Document this function
    *
@@ -297,7 +297,7 @@ namespace blit {
         }
       }
 
-      for (uint16_t i = 0; i < n; i += 2) {
+      for (i = 0; i < n; i += 2) {
         h_span(Point(nodes[i], p.y), nodes[i + 1] - nodes[i] + 1);
       }
     }

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -575,7 +575,7 @@ namespace blit {
     PixelFormat format = (PixelFormat)image.format;
     Size bounds = Size(image.width, image.height);
 
-    auto needed_size = pixel_format_stride[image.format] * image.width * image.height;
+    size_t needed_size = pixel_format_stride[image.format] * image.width * image.height;
     if(data && needed_size > data_size)
       return nullptr;
 
@@ -635,7 +635,6 @@ namespace blit {
       uint8_t *pdest = (uint8_t *)ret->data;
 
       if(is_rle) {
-        auto bytes = image_data;
         int parse_state = 0;
         uint8_t count = 0;
 
@@ -793,7 +792,6 @@ namespace blit {
         std::swap(ret->palette[i].r, ret->palette[i].b);
     } else {
       // R/B swap
-      auto p = data;
       auto end = data + header.image_size;
       for(auto p = data; p != end; p += ret->pixel_stride)
         std::swap(p[0], p[2]);


### PR DESCRIPTION
Fixes a few warnings that show up with the boilerplate's extra warning flags.

(Mostly clean with https://github.com/Daft-Freak/32blit-boilerplate/commit/26afd314b77ac630b345f4eb3bd24dbf6829b282)