### PR TITLE
Install libraries into mac bundle when not using frameworks

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -200,6 +200,17 @@ function(blit_executable NAME SOURCES)
 		install(DIRECTORY ${SDL2_LIBRARIES} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
 		install(DIRECTORY ${SDL2_IMAGE_LIBRARY} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
 		install(DIRECTORY ${SDL2_NET_LIBRARY} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
+	elseif(APPLE)
+		# TODO: this should be run in both cases to handle any other dependencies, but it fails on the SDL frameworks and there currently aren't any other deps...
+
+		file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/fixup.cmake
+			CONTENT "
+				include(BundleUtilities)
+				fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:${NAME}>.app\" \"\" \"\")
+			"
+		)
+
+		install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/fixup.cmake)
 	endif()
 endfunction()
 


### PR DESCRIPTION
This doesn't seem to explode any more and results in boilerplate-based builds including the SDL libs (using brew to install).


`fixup_bundle` could also be used to handle copying all needed dlls for Windows... but that's currently not working for a bunch of other reasons... (Mostly path related *sigh*)