### PR TITLE
Add a command line option to set the position of the SDL window

### DIFF
--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -180,6 +180,12 @@ int main(int argc, char *argv[]) {
 		}
 		else if(arg_str == "--listen")
 			mp_mode = Multiplayer::Mode::Listen;
+		else if(arg_str == "--position") {
+			int x, y;
+			if(SDL_sscanf(argv[i+1], "%d,%d", &x, &y) == 2) {
+			    SDL_SetWindowPosition(window, x, y);
+			}
+		}
 	}
 
 	blit_system = new System();


### PR DESCRIPTION
This is useful for testing multiplayer games, as you can run two
copies with arbitrary window positions.